### PR TITLE
[ANDROID] Add support nfc tag id (serial number)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -55,13 +55,13 @@ dotnet_naming_rule.methods_and_properties_must_be_pascal_case.symbols = method_a
 dotnet_naming_rule.methods_and_properties_must_be_pascal_case.style = pascal_case_style
 
 # Non-public members must be lower-case
-dotnet_naming_symbols.non_public_symbols.applicable_kinds = property,method,event,delegate
-dotnet_naming_symbols.non_public_symbols.applicable_accessibilities = private
-dotnet_naming_style.all_lower_case_style.capitalization = camel_case
+#dotnet_naming_symbols.non_public_symbols.applicable_kinds = property,event,delegate
+#dotnet_naming_symbols.non_public_symbols.applicable_accessibilities = private
+#dotnet_naming_style.all_lower_case_style.capitalization = camel_case
 
-dotnet_naming_rule.non_public_members_must_be_lower_case.severity = warning
-dotnet_naming_rule.non_public_members_must_be_lower_case.symbols = non_public_symbols
-dotnet_naming_rule.non_public_members_must_be_lower_case.style = all_lower_case_style
+#dotnet_naming_rule.non_public_members_must_be_lower_case.severity = warning
+#dotnet_naming_rule.non_public_members_must_be_lower_case.symbols = non_public_symbols
+#dotnet_naming_rule.non_public_members_must_be_lower_case.style = all_lower_case_style
 
 # Private fields must start with an underscore
 dotnet_naming_symbols.private_fields.applicable_kinds = field

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 ## Changelog
+
+### 0.1.9
+- GitHub #1 : [ANDROID] Add support nfc tag id (serial number).
+
+### 0.1.8
+- First public release.
+
 ### 0.1.0
 - Add read/write support for Android.
 - Add shared interfaces and classes.

--- a/src/Plugin.NFC.Sample/Plugin.NFC.Sample/MainPage.xaml.cs
+++ b/src/Plugin.NFC.Sample/Plugin.NFC.Sample/MainPage.xaml.cs
@@ -73,10 +73,17 @@ namespace NFCSample
 			}
 			else
 			{
+				// Customized serial number
+				var identifier = tagInfo.Identifier;
+				var serialNumber = NFCUtils.ByteArrayToHexString(identifier, ":");
+
+				// Basic serial number
+				//var serialNumber = tagInfo.SerialNumber;
+
 				var first = tagInfo.Records[0];
 				var type = first.TypeFormat.ToString();
 				var raw = Encoding.UTF8.GetString(first.Payload);
-				await ShowAlert($"{type} => {first.Message} [{raw}] ({first.MimeType})");
+				await ShowAlert($"{type} [SN: {serialNumber}] => {first.Message} [{raw}] ({first.MimeType})");
 			}
 		}
 

--- a/src/Plugin.NFC/Android/CrossNFC.android.cs
+++ b/src/Plugin.NFC/Android/CrossNFC.android.cs
@@ -63,14 +63,14 @@ namespace Plugin.NFC
 	/// </summary>
 	class ActivityLifecycleContextListener : Java.Lang.Object, Application.IActivityLifecycleCallbacks
 	{
-		WeakReference<Activity> currentActivity = new WeakReference<Activity>(null);
+		WeakReference<Activity> _currentActivity = new WeakReference<Activity>(null);
 
 		internal Context Context => Activity ?? Application.Context;
 
 		internal Activity Activity
 		{
-			get => currentActivity.TryGetTarget(out var a) ? a : null;
-			set => currentActivity.SetTarget(value);
+			get => _currentActivity.TryGetTarget(out var a) ? a : null;
+			set => _currentActivity.SetTarget(value);
 		}
 
 		void Application.IActivityLifecycleCallbacks.OnActivityCreated(Activity activity, Bundle savedInstanceState) => Activity = activity;

--- a/src/Plugin.NFC/Android/NFC.android.cs
+++ b/src/Plugin.NFC/Android/NFC.android.cs
@@ -289,14 +289,13 @@ namespace Plugin.NFC
 				return null;
 
 			var ndef = Ndef.Get(tag);
-
 			if (ndef == null)
 				return null;
 
 			if (ndefMessage == null)
 				ndefMessage = ndef.CachedNdefMessage;
 
-			var nTag = new TagInfo()
+			var nTag = new TagInfo(tag.GetId())
 			{
 				IsWritable = ndef.IsWritable
 			};

--- a/src/Plugin.NFC/Plugin.NFC.csproj
+++ b/src/Plugin.NFC/Plugin.NFC.csproj
@@ -33,7 +33,7 @@
     <PackageProjectUrl>https://github.com/franckbour/Plugin.NFC</PackageProjectUrl>
     <RepositoryUrl>https://github.com/franckbour/Plugin.NFC</RepositoryUrl>
     <PackageReleaseNotes>https://github.com/franckbour/Plugin.NFC/blob/master/CHANGELOG.md</PackageReleaseNotes>
-    <PackageIconUrl>https://github.com/franckbour/Test/raw/master/art/nfc128.png</PackageIconUrl>
+    <PackageIconUrl>https://github.com/franckbour/Plugin.NFC/raw/master/art/nfc128.png</PackageIconUrl>
     <PackageTags>xamarin, windows, ios, android, xamarin.forms, plugin, NFC</PackageTags>
     
     <Title>NFC Plugin for Xamarin and Windows</Title>

--- a/src/Plugin.NFC/Shared/ITagInfo.shared.cs
+++ b/src/Plugin.NFC/Shared/ITagInfo.shared.cs
@@ -6,6 +6,16 @@
 	public interface ITagInfo
 	{
 		/// <summary>
+		/// Tag Raw Identifier
+		/// </summary>
+		byte[] Identifier { get; }
+
+		/// <summary>
+		/// Tag Serial Number
+		/// </summary>
+		string SerialNumber { get; }
+		
+		/// <summary>
 		/// Writable tag
 		/// </summary>
 		bool IsWritable { get; set; }

--- a/src/Plugin.NFC/Shared/NFCUtils.shared.cs
+++ b/src/Plugin.NFC/Shared/NFCUtils.shared.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text;
+using System.Linq;
 
 namespace Plugin.NFC
 {
@@ -72,5 +73,16 @@ namespace Plugin.NFC
 				return string.Empty;
 			return GetMessage(record.TypeFormat, record.Payload, record.Uri);
 		}
+
+        /// <summary>
+        /// Convert bytes array into hexadecimal string
+        /// </summary>
+        /// <param name="bytes">Bytes Array</param>
+        /// <param name="separator">Separator</param>
+        /// <returns>Hexadecimal string</returns>
+        public static string ByteArrayToHexString(byte[] bytes, string separator = null)
+        {
+            return bytes == null ? string.Empty : string.Join(separator ?? string.Empty, bytes.Select(b => b.ToString("X2")));
+        }
 	}
 }

--- a/src/Plugin.NFC/Shared/TagInfo.shared.cs
+++ b/src/Plugin.NFC/Shared/TagInfo.shared.cs
@@ -5,6 +5,13 @@
 	/// </summary>
 	public class TagInfo : ITagInfo
 	{
+		public byte[] Identifier { get; }
+
+		/// <summary>
+		/// Tag Serial Number
+		/// </summary>
+		public string SerialNumber { get;  }
+
 		/// <summary>
 		/// Writable tag
 		/// </summary>
@@ -19,5 +26,23 @@
 		/// Empty tag
 		/// </summary>
 		public bool IsEmpty => Records == null || Records.Length == 0 || Records[0].TypeFormat == NFCNdefTypeFormat.Empty;
+
+		/// <summary>
+		/// Default constructor
+		/// </summary>
+		public TagInfo()
+		{
+
+		}
+
+		/// <summary>
+		/// Custom contructor
+		/// </summary>
+		/// <param name="identifier">Tag Identifier as <see cref="byte[]"/></param>
+		public TagInfo(byte[] identifier)
+		{
+			Identifier = identifier;
+			SerialNumber = NFCUtils.ByteArrayToHexString(identifier);
+		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

Adding NFC Tag identifier and string serial number on Android.

### Bugs Fixed ###

- Related to issue #1 

### API Changes ###

List all API changes here (or just put None), example:

Added: 
 
- `byte[] ITagInfo.Identifier { get; }`
- `string ITagInfo.SerialNumber { get; }`

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [ ] Updated documentation