### PR TITLE
Accessing tag identifer even if tag doesn't support Ndef and adding m…

### DIFF
--- a/src/Plugin.NFC.Sample/Plugin.NFC.Sample/MainPage.xaml
+++ b/src/Plugin.NFC.Sample/Plugin.NFC.Sample/MainPage.xaml
@@ -4,11 +4,15 @@
              xmlns:local="clr-namespace:NFCSample"
              x:Class="NFCSample.MainPage">
 
-    <StackLayout HorizontalOptions="CenterAndExpand" VerticalOptions="CenterAndExpand">
-        <Label Text="Plugin NFC Sample" FontSize="Large" HorizontalOptions="CenterAndExpand" />
-		<Button Text="Read Tag" Clicked="Button_Clicked_StartListening"/>
-		<Button Text="Write Tag" Clicked="Button_Clicked_StartWriting" />
-        <Button Text="Clear Tag" Clicked="Button_Clicked_FormatTag" />
-    </StackLayout>
+	<ScrollView>
+		<StackLayout HorizontalOptions="CenterAndExpand" VerticalOptions="CenterAndExpand">
+			<Label Text="Plugin NFC Sample" FontSize="Large" HorizontalOptions="CenterAndExpand" />
+			<Button Text="Read Tag" Clicked="Button_Clicked_StartListening"/>
+			<Button Text="Write Tag (Text)" Clicked="Button_Clicked_StartWriting" />
+			<Button Text="Write Tag (Uri)" Clicked="Button_Clicked_StartWriting_Uri" />
+			<Button Text="Write Tag (Custom)" Clicked="Button_Clicked_StartWriting_Custom" />
+			<Button Text="Clear Tag" Clicked="Button_Clicked_FormatTag" />
+		</StackLayout>
+	</ScrollView>
 
 </ContentPage>

--- a/src/Plugin.NFC/Android/NFC.android.cs
+++ b/src/Plugin.NFC/Android/NFC.android.cs
@@ -289,21 +289,20 @@ namespace Plugin.NFC
 				return null;
 
 			var ndef = Ndef.Get(tag);
-			if (ndef == null)
-				return null;
+			var nTag = new TagInfo(tag.GetId(), ndef != null);
 
-			if (ndefMessage == null)
-				ndefMessage = ndef.CachedNdefMessage;
-
-			var nTag = new TagInfo(tag.GetId())
+			if (ndef != null)
 			{
-				IsWritable = ndef.IsWritable
-			};
+				nTag.IsWritable = ndef.IsWritable;
 
-			if (ndefMessage != null)
-			{
-				var records = ndefMessage.GetRecords();
-				nTag.Records = GetRecords(records);
+				if (ndefMessage == null)
+					ndefMessage = ndef.CachedNdefMessage;
+
+				if (ndefMessage != null)
+				{
+					var records = ndefMessage.GetRecords();
+					nTag.Records = GetRecords(records);
+				}
 			}
 
 			return nTag;

--- a/src/Plugin.NFC/Plugin.NFC.csproj
+++ b/src/Plugin.NFC/Plugin.NFC.csproj
@@ -1,10 +1,10 @@
-﻿<Project Sdk="MSBuild.Sdk.Extras/2.0.29">
+﻿<Project Sdk="MSBuild.Sdk.Extras/2.0.31">
 
   <PropertyGroup>
     <!--Work around so the conditions work below-->
     <TargetFrameworks></TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">netstandard1.0;netstandard2.0;Xamarin.iOS10;MonoAndroid81;uap10.0.16299</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.0;netstandard2.0;Xamarin.iOS10;MonoAndroid81</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">netstandard1.0;netstandard2.0;Xamarin.iOS10;MonoAndroid81;MonoAndroid90;uap10.0.16299</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.0;netstandard2.0;Xamarin.iOS10;MonoAndroid81;MonoAndroid90</TargetFrameworks>
     <!--Feel free to add as many targets as you need below
     netstandard1.0;netstandard2.0;MonoAndroid81;Xamarin.iOS10;uap10.0.16299;Xamarin.TVOS10;Xamarin.WatchOS10;Xamarin.Mac20;Tizen40
     For UWP update the version number with a version number you have installed.
@@ -111,4 +111,12 @@
     <Compile Include="**\*.dotnet.cs" />
   </ItemGroup>
   -->
+
+	<!--https://github.com/onovotny/MSBuildSdkExtras/issues/174-->
+	<Target Name="_RemoveNonExistingResgenFile" BeforeTargets="CoreCompile" Condition="'$(_SdkSetAndroidResgenFile)' == 'true' And '$(AndroidResgenFile)' != '' And !Exists('$(AndroidResgenFile)')">
+		<ItemGroup>
+			<Compile Remove="$(AndroidResgenFile)"/>
+		</ItemGroup>
+	</Target>
+
 </Project>

--- a/src/Plugin.NFC/Shared/ITagInfo.shared.cs
+++ b/src/Plugin.NFC/Shared/ITagInfo.shared.cs
@@ -26,6 +26,11 @@
 		bool IsEmpty { get; }
 
 		/// <summary>
+		/// Supported tag
+		/// </summary>
+		bool IsSupported { get; }
+
+		/// <summary>
 		/// Array of <see cref="NFCNdefRecord"/> of tag
 		/// </summary>
 		NFCNdefRecord[] Records { get; set; }

--- a/src/Plugin.NFC/Shared/NFCUtils.shared.cs
+++ b/src/Plugin.NFC/Shared/NFCUtils.shared.cs
@@ -19,7 +19,10 @@ namespace Plugin.NFC
 			if (records != null && records.Length > 0)
 			{
 				for (var i = 0; i < records.Length; i++)
-					size += records[i].Payload.Length;
+				{
+					if (records[i] != null)
+						size += records[i].Payload.Length;
+				}
 			}
 			return size;
 		}
@@ -33,8 +36,7 @@ namespace Plugin.NFC
 		/// <returns>String formatted payload</returns>
 		internal static string GetMessage(NFCNdefTypeFormat type, byte[] payload, string uri)
 		{
-			var message = string.Empty;
-
+			string message;
 			if (!string.IsNullOrWhiteSpace(uri))
 				message = uri;
 			else
@@ -42,8 +44,13 @@ namespace Plugin.NFC
 				if (type == NFCNdefTypeFormat.WellKnown)
 				{
 					// NDEF_WELLKNOWN Text record
-					var languageCodeLength = payload[0] & 0x63;
-					message = Encoding.UTF8.GetString(payload, languageCodeLength + 1, payload.Length - languageCodeLength - 1);
+					var status = payload[0];
+					var enc = status & 0x80;
+					var languageCodeLength = status & 0x3F;
+					if (enc == 0)
+						message = Encoding.UTF8.GetString(payload, languageCodeLength + 1, payload.Length - languageCodeLength - 1);
+					else
+						message = Encoding.Unicode.GetString(payload, languageCodeLength + 1, payload.Length - languageCodeLength - 1);
 				}
 				else
 				{
@@ -51,7 +58,6 @@ namespace Plugin.NFC
 					message = Encoding.UTF8.GetString(payload, 0, payload.Length);
 				}
 			}
-
 			return message;
 		}
 

--- a/src/Plugin.NFC/Shared/TagInfo.shared.cs
+++ b/src/Plugin.NFC/Shared/TagInfo.shared.cs
@@ -25,7 +25,12 @@
 		/// <summary>
 		/// Empty tag
 		/// </summary>
-		public bool IsEmpty => Records == null || Records.Length == 0 || Records[0].TypeFormat == NFCNdefTypeFormat.Empty;
+		public bool IsEmpty => Records == null || Records.Length == 0 || Records[0] == null ||Records[0].TypeFormat == NFCNdefTypeFormat.Empty;
+
+		/// <summary>
+		/// 
+		/// </summary>
+		public bool IsSupported { get; private set; }
 
 		/// <summary>
 		/// Default constructor
@@ -39,10 +44,12 @@
 		/// Custom contructor
 		/// </summary>
 		/// <param name="identifier">Tag Identifier as <see cref="byte[]"/></param>
-		public TagInfo(byte[] identifier)
+		/// <param name="isNdef">Is Ndef tag</param>
+		public TagInfo(byte[] identifier, bool isNdef = false)
 		{
 			Identifier = identifier;
 			SerialNumber = NFCUtils.ByteArrayToHexString(identifier);
+			IsSupported = isNdef;
 		}
 	}
 }


### PR DESCRIPTION
…inor changes

### Description of Change ###

You can now access tag identifier even if tag isn't supported (non Ndef) and/or if tag records are empty.

### Bugs Fixed ###

- Related to issue #1

### API Changes ###
Added: 
 
- `ITagInfo.IsSupported { get; }`

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [ ] Updated documentation