### PR TITLE
[iOS] Adding new event and fixes some bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## Changelog
 
+### 0.1.11
+- GitHub #5 : [iOS] Application crash when NFC tag is empty.
+- [iOS] Adding event when user cancels NFC reading session.
+- Minor changes.
+
+### 0.1.10
+- GitHub #1 : [ANDROID] Add support nfc tag id (serial number).
+
 ### 0.1.9
 - GitHub #1 : [ANDROID] Add support nfc tag id (serial number).
 

--- a/src/Plugin.NFC.Sample/Plugin.NFC.Sample/MainPage.xaml.cs
+++ b/src/Plugin.NFC.Sample/Plugin.NFC.Sample/MainPage.xaml.cs
@@ -78,7 +78,7 @@ namespace NFCSample
 			// Customized serial number
 			var identifier = tagInfo.Identifier;
 			var serialNumber = NFCUtils.ByteArrayToHexString(identifier, ":");
-			var title = $"Tag [{serialNumber}]";
+			var title = !string.IsNullOrWhiteSpace(serialNumber) ? $"Tag [{serialNumber}]" : "Tag Info";
 
 			if (!tagInfo.IsSupported)
 			{

--- a/src/Plugin.NFC.Sample/Plugin.NFC.Sample/MainPage.xaml.cs
+++ b/src/Plugin.NFC.Sample/Plugin.NFC.Sample/MainPage.xaml.cs
@@ -52,6 +52,9 @@ namespace NFCSample
 			CrossNFC.Current.OnMessageReceived += Current_OnMessageReceived;
 			CrossNFC.Current.OnMessagePublished += Current_OnMessagePublished;
 			CrossNFC.Current.OnTagDiscovered += Current_OnTagDiscovered;
+
+			if (Device.RuntimePlatform == Device.iOS)
+				CrossNFC.Current.OniOSReadingSessionCancelled += Current_OniOSReadingSessionCancelled;
 		}
 
 		void UnsubscribeEvents()
@@ -59,6 +62,9 @@ namespace NFCSample
 			CrossNFC.Current.OnMessageReceived -= Current_OnMessageReceived;
 			CrossNFC.Current.OnMessagePublished -= Current_OnMessagePublished;
 			CrossNFC.Current.OnTagDiscovered -= Current_OnTagDiscovered;
+
+			if (Device.RuntimePlatform == Device.iOS)
+				CrossNFC.Current.OniOSReadingSessionCancelled -= Current_OniOSReadingSessionCancelled;
 		}
 
 		async void Current_OnMessageReceived(ITagInfo tagInfo)
@@ -68,8 +74,6 @@ namespace NFCSample
 				await ShowAlert("No tag found");
 				return;
 			}
-
-			
 
 			// Customized serial number
 			var identifier = tagInfo.Identifier;
@@ -90,6 +94,8 @@ namespace NFCSample
 				await ShowAlert(GetMessage(first), title);
 			}
 		}
+
+		async void Current_OniOSReadingSessionCancelled(object sender, EventArgs e) => await ShowAlert("User has cancelled NFC reading session");
 
 		async void Current_OnMessagePublished(ITagInfo tagInfo)
 		{

--- a/src/Plugin.NFC/Android/NFC.android.cs
+++ b/src/Plugin.NFC/Android/NFC.android.cs
@@ -21,6 +21,7 @@ namespace Plugin.NFC
 		public event NdefMessageReceivedEventHandler OnMessageReceived;
 		public event NdefMessagePublishedEventHandler OnMessagePublished;
 		public event TagDiscoveredEventHandler OnTagDiscovered;
+		public event EventHandler OniOSReadingSessionCancelled;
 
 		readonly NfcAdapter _nfcAdapter;
 

--- a/src/Plugin.NFC/Shared/INFC.shared.cs
+++ b/src/Plugin.NFC/Shared/INFC.shared.cs
@@ -85,5 +85,10 @@ namespace Plugin.NFC
 		/// Event raised when ndef message has been published
 		/// </summary>
 		event NdefMessagePublishedEventHandler OnMessagePublished;
+
+		/// <summary>
+		/// Event raised when iOS NFC reading session is cancelled
+		/// </summary>
+		event EventHandler OniOSReadingSessionCancelled;
 	}
 }

--- a/src/Plugin.NFC/Shared/TagInfo.shared.cs
+++ b/src/Plugin.NFC/Shared/TagInfo.shared.cs
@@ -37,7 +37,7 @@
 		/// </summary>
 		public TagInfo()
 		{
-
+			IsSupported = true;
 		}
 
 		/// <summary>
@@ -45,7 +45,7 @@
 		/// </summary>
 		/// <param name="identifier">Tag Identifier as <see cref="byte[]"/></param>
 		/// <param name="isNdef">Is Ndef tag</param>
-		public TagInfo(byte[] identifier, bool isNdef = false)
+		public TagInfo(byte[] identifier, bool isNdef = true)
 		{
 			Identifier = identifier;
 			SerialNumber = NFCUtils.ByteArrayToHexString(identifier);

--- a/src/Plugin.NFC/UWP/NFC.uwp.cs
+++ b/src/Plugin.NFC/UWP/NFC.uwp.cs
@@ -14,9 +14,10 @@ namespace Plugin.NFC
 		public event NdefMessageReceivedEventHandler OnMessageReceived;
 		public event NdefMessagePublishedEventHandler OnMessagePublished;
 		public event TagDiscoveredEventHandler OnTagDiscovered;
+		public event EventHandler OniOSReadingSessionCancelled;
 
 		readonly ProximityDevice _defaultDevice;
-		long ndefSubscriptionId = -1;
+		long _ndefSubscriptionId = -1;
 
 		/// <summary>
 		/// Checks if NFC Feature is available
@@ -65,7 +66,7 @@ namespace Plugin.NFC
 		{
 			_defaultDevice.DeviceArrived += OnDeviceArrived;
 			_defaultDevice.DeviceDeparted += OnDeviceDeparted;
-			ndefSubscriptionId = _defaultDevice.SubscribeForMessage("NDEF", OnNdefMessageReceived);
+			_ndefSubscriptionId = _defaultDevice.SubscribeForMessage("NDEF", OnNdefMessageReceived);
 		}
 
 		/// <summary>
@@ -76,10 +77,10 @@ namespace Plugin.NFC
 			_defaultDevice.DeviceArrived -= OnDeviceArrived;
 			_defaultDevice.DeviceDeparted -= OnDeviceDeparted;
 
-			if (ndefSubscriptionId != -1)
+			if (_ndefSubscriptionId != -1)
 			{
-				_defaultDevice.StopSubscribingForMessage(ndefSubscriptionId);
-				ndefSubscriptionId = -1;
+				_defaultDevice.StopSubscribingForMessage(_ndefSubscriptionId);
+				_ndefSubscriptionId = -1;
 			}
 		}
 

--- a/src/Plugin.NFC/iOS/NFC.iOS.cs
+++ b/src/Plugin.NFC/iOS/NFC.iOS.cs
@@ -17,8 +17,9 @@ namespace Plugin.NFC
 		public event NdefMessageReceivedEventHandler OnMessageReceived;
 		public event NdefMessagePublishedEventHandler OnMessagePublished;
 		public event TagDiscoveredEventHandler OnTagDiscovered;
+		public event EventHandler OniOSReadingSessionCancelled;
 
-		readonly string writingNotSupportedMessage = "Writing NFC Tag is not supported on iOS";
+		readonly string _writingNotSupportedMessage = "Writing NFC Tag is not supported on iOS";
 
 		NFCNdefReaderSession NfcSession { get; set; }
 
@@ -60,24 +61,24 @@ namespace Plugin.NFC
 		/// Starts tag publishing (writing or formatting)
 		/// </summary>
 		/// <param name="clearMessage">Format tag</param>
-		public void StartPublishing(bool clearMessage = false) => throw new NotSupportedException(writingNotSupportedMessage);
+		public void StartPublishing(bool clearMessage = false) => throw new NotSupportedException(_writingNotSupportedMessage);
 
 		/// <summary>
 		/// Stops tag publishing
 		/// </summary>
-		public void StopPublishing() => throw new NotSupportedException(writingNotSupportedMessage);
+		public void StopPublishing() => throw new NotSupportedException(_writingNotSupportedMessage);
 
 		/// <summary>
 		/// Publish or write a message on a tag
 		/// </summary>
 		/// <param name="tagInfo">see <see cref="ITagInfo"/></param>
-		public void PublishMessage(ITagInfo tagInfo) => throw new NotSupportedException(writingNotSupportedMessage);
+		public void PublishMessage(ITagInfo tagInfo) => throw new NotSupportedException(_writingNotSupportedMessage);
 
 		/// <summary>
 		/// Format tag
 		/// </summary>
 		/// <param name="tagInfo">see <see cref="ITagInfo"/></param>
-		public void ClearMessage(ITagInfo tagInfo) => throw new NotSupportedException(writingNotSupportedMessage);
+		public void ClearMessage(ITagInfo tagInfo) => throw new NotSupportedException(_writingNotSupportedMessage);
 
 		/// <summary>
 		/// Event raised when tag is detected
@@ -119,6 +120,8 @@ namespace Plugin.NFC
 					GetCurrentController().PresentViewController(alertController, true, null);
 				});
 			}
+			else if (readerError == NFCReaderError.ReaderSessionInvalidationErrorUserCanceled)
+				OniOSReadingSessionCancelled.Invoke(null, EventArgs.Empty);
 		}
 
 		#region Private

--- a/src/Plugin.NFC/iOS/NFC.iOS.cs
+++ b/src/Plugin.NFC/iOS/NFC.iOS.cs
@@ -176,7 +176,7 @@ namespace Plugin.NFC
 		public static byte[] ToByteArray(this NSData data)
 		{
 			var bytes = new byte[data.Length];
-			System.Runtime.InteropServices.Marshal.Copy(data.Bytes, bytes, 0, Convert.ToInt32(data.Length));
+			if (data.Length > 0) System.Runtime.InteropServices.Marshal.Copy(data.Bytes, bytes, 0, Convert.ToInt32(data.Length));
 			return bytes;
 		}
 


### PR DESCRIPTION
### Description of Change ###

- [iOS] Adding event when user cancels NFC reading session.

### Bugs Fixed ###

- Related to issue #1 (iOS and UWP)
- Fixes #5 

### API Changes ###

Added: 
 
- `Event OniOSReadingSessionCancelled;`

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [ ] Updated documentation