### PR TITLE
[Android] Add event listener for NFC States changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+### 0.1.15
+- [Android] Add event listener for NFC status.
+
 ### 0.1.14 
 - [iOS] Fixed OniOSReadingSessionCancelled calls.
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@ CrossNFC.Current.OnMessagePublished += Current_OnMessagePublished;
 // Event raised when a tag is discovered. Used for publishing.
 CrossNFC.Current.OnTagDiscovered += Current_OnTagDiscovered;
 
+// Android Only:
+// Event raised when NFC state has changed.
+CrossNFC.Current.OnNfcStatusChanged += Current_OnNfcStatusChanged;
+
 // iOS Only: 
 // Event raised when a user cancelled NFC session.
 CrossNFC.Current.OniOSReadingSessionCancelled += Current_OniOSReadingSessionCancelled;

--- a/src/Plugin.NFC.Full.sln
+++ b/src/Plugin.NFC.Full.sln
@@ -19,6 +19,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		..\.editorconfig = ..\.editorconfig
 		..\.gitignore = ..\.gitignore
+		..\CHANGELOG.md = ..\CHANGELOG.md
+		..\README.md = ..\README.md
 	EndProjectSection
 EndProject
 Global

--- a/src/Plugin.NFC.Sample/Plugin.NFC.Sample/MainPage.xaml
+++ b/src/Plugin.NFC.Sample/Plugin.NFC.Sample/MainPage.xaml
@@ -1,36 +1,80 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
-<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+<ContentPage x:Class="NFCSample.MainPage"
+             xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:local="clr-namespace:NFCSample"
-             x:Class="NFCSample.MainPage">
+             x:Name="thisPage"
+             BindingContext="{x:Reference thisPage}">
 
-	<ContentPage.Resources>
-		<ResourceDictionary>
-			<Style TargetType="Button">
-				<Setter Property="BorderColor" Value="Gray" />
-				<Setter Property="BorderWidth" Value="1" />
-				<Setter Property="BackgroundColor" Value="WhiteSmoke" />
-			</Style>
-		</ResourceDictionary>
-	</ContentPage.Resources>
-	
-	<ScrollView>
-		<StackLayout HorizontalOptions="CenterAndExpand" VerticalOptions="CenterAndExpand">
-			<Label Text="Plugin NFC Sample" FontSize="Large" HorizontalOptions="CenterAndExpand" />
-			<Button Text="Read Tag" Clicked="Button_Clicked_StartListening"/>
-			<Frame BorderColor="Gray" HasShadow="False">
-				<StackLayout>
-					<StackLayout Orientation="Horizontal" HorizontalOptions="CenterAndExpand" Spacing="0" Padding="0">
-						<CheckBox x:Name="ChkReadOnly" IsChecked="False" VerticalOptions="Center" Color="Red"/>
-						<Label Text="Make Tag Read-Only" VerticalOptions="Center" TextColor="Red" FontAttributes="Bold"/>
-					</StackLayout>
-					<Button Text="Write Tag (Text)" Clicked="Button_Clicked_StartWriting" />
-					<Button Text="Write Tag (Uri)" Clicked="Button_Clicked_StartWriting_Uri" />
-					<Button Text="Write Tag (Custom)" Clicked="Button_Clicked_StartWriting_Custom" />
-				</StackLayout>
-			</Frame>
-			<Button Text="Clear Tag" Clicked="Button_Clicked_FormatTag" />
+    <ContentPage.Resources>
+        <ResourceDictionary>
+            <Style TargetType="Button">
+                <Setter Property="BorderColor" Value="Gray" />
+                <Setter Property="BorderWidth" Value="1" />
+                <Setter Property="BackgroundColor" Value="WhiteSmoke" />
+            </Style>
+        </ResourceDictionary>
+    </ContentPage.Resources>
+
+    <ScrollView>
+        <StackLayout HorizontalOptions="CenterAndExpand" VerticalOptions="CenterAndExpand">
+            <Label FontSize="Large"
+                   HorizontalOptions="CenterAndExpand"
+                   Text="Plugin NFC Sample" />
+
+            <Button Clicked="Button_Clicked_StartListening"
+                    IsEnabled="{Binding NfcIsEnabled}"
+                    Text="Read Tag" />
+			
+            <Frame BorderColor="Gray" HasShadow="False">
+                <StackLayout>
+					
+                    <StackLayout Padding="0"
+                                 HorizontalOptions="CenterAndExpand"
+                                 Orientation="Horizontal"
+                                 Spacing="0">
+						
+                        <CheckBox x:Name="ChkReadOnly"
+                                  IsChecked="False"
+                                  IsEnabled="{Binding NfcIsEnabled}"
+                                  VerticalOptions="Center"
+                                  Color="Red" />
+						
+                        <Label FontAttributes="Bold"
+                               Text="Make Tag Read-Only"
+                               TextColor="Red"
+                               VerticalOptions="Center" />
+                    </StackLayout>
+					
+                    <Button Clicked="Button_Clicked_StartWriting"
+                            IsEnabled="{Binding NfcIsEnabled}"
+                            Text="Write Tag (Text)" />
+					
+                    <Button Clicked="Button_Clicked_StartWriting_Uri"
+                            IsEnabled="{Binding NfcIsEnabled}"
+                            Text="Write Tag (Uri)" />
+					
+                    <Button Clicked="Button_Clicked_StartWriting_Custom"
+                            IsEnabled="{Binding NfcIsEnabled}"
+                            Text="Write Tag (Custom)" />
+					
+                </StackLayout>
+            </Frame>
+			
+            <Button Clicked="Button_Clicked_FormatTag"
+                    IsEnabled="{Binding NfcIsEnabled}"
+                    Text="Clear Tag" />
+
+			<Label Margin="0,6,0,0"
+				   Padding="12,6"
+                   HorizontalOptions="CenterAndExpand"
+                   IsVisible="{Binding NfcIsDisabled}"
+                   Text="NFC IS DISABLED"
+				   FontAttributes="Bold"
+                   TextColor="White"
+				   BackgroundColor="Red"/>
+
 		</StackLayout>
-	</ScrollView>
+    </ScrollView>
 
 </ContentPage>

--- a/src/Plugin.NFC/Shared/INFC.shared.cs
+++ b/src/Plugin.NFC/Shared/INFC.shared.cs
@@ -6,6 +6,7 @@ namespace Plugin.NFC
 	public delegate void NdefMessageReceivedEventHandler(ITagInfo tagInfo);
 	public delegate void NdefMessagePublishedEventHandler(ITagInfo tagInfo);
 	public delegate void TagDiscoveredEventHandler(ITagInfo tagInfo, bool format);
+	public delegate void OnNfcStatusChangedEventHandler(bool isEnabled);
 	#endregion
 
 	/// <summary>
@@ -91,6 +92,11 @@ namespace Plugin.NFC
 		/// Event raised when iOS NFC reading session is cancelled
 		/// </summary>
 		event EventHandler OniOSReadingSessionCancelled;
+
+		/// <summary>
+		/// 
+		/// </summary>
+		event OnNfcStatusChangedEventHandler OnNfcStatusChanged;
 	}
 
 	/// <summary>

--- a/src/Plugin.NFC/UWP/NFC.uwp.cs
+++ b/src/Plugin.NFC/UWP/NFC.uwp.cs
@@ -15,6 +15,7 @@ namespace Plugin.NFC
 		public event NdefMessagePublishedEventHandler OnMessagePublished;
 		public event TagDiscoveredEventHandler OnTagDiscovered;
 		public event EventHandler OniOSReadingSessionCancelled;
+		public event OnNfcStatusChangedEventHandler OnNfcStatusChanged;
 
 		readonly ProximityDevice _defaultDevice;
 		long _ndefSubscriptionId = -1;

--- a/src/Plugin.NFC/iOS/NFC.iOS.cs
+++ b/src/Plugin.NFC/iOS/NFC.iOS.cs
@@ -21,6 +21,7 @@ namespace Plugin.NFC
 		public event NdefMessagePublishedEventHandler OnMessagePublished;
 		public event TagDiscoveredEventHandler OnTagDiscovered;
 		public event EventHandler OniOSReadingSessionCancelled;
+		public event OnNfcStatusChangedEventHandler OnNfcStatusChanged;
 
 		bool _isWriting;
 		bool _isFormatting;
@@ -546,6 +547,7 @@ namespace Plugin.NFC
 		public event NdefMessagePublishedEventHandler OnMessagePublished;
 		public event TagDiscoveredEventHandler OnTagDiscovered;
 		public event EventHandler OniOSReadingSessionCancelled;
+		public event OnNfcStatusChangedEventHandler OnNfcStatusChanged;
 
 		NFCNdefReaderSession NfcSession { get; set; }
 


### PR DESCRIPTION
### Description of Change ###

Add an event listener in order to detect NFC states changes in **Android only**.

### API Changes ###

Added: 
 
- `event OnNfcStatusChangedEventHandler OnNfcStatusChanged;`

```csharp
// Register NFC status event listener
CrossNFC.Current.OnNfcStatusChanged += Current_OnNfcStatusChanged;
```

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [X] Has samples (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard
- [X] Updated documentation