### PR TITLE
enhancements/Droid-IndicateListeningInProgress (#1)

### DIFF
--- a/src/Plugin.NFC.Sample/Plugin.NFC.Sample/MainPage.xaml
+++ b/src/Plugin.NFC.Sample/Plugin.NFC.Sample/MainPage.xaml
@@ -68,6 +68,14 @@
 			<Label Margin="0,6,0,0"
 				   Padding="12,6"
                    HorizontalOptions="CenterAndExpand"
+                   IsVisible="{Binding DeviceIsListening}"
+                   Text="Listening for NFC Tag..."
+				   FontAttributes="Bold"
+                   TextColor="Blue"/>
+
+			<Label Margin="0,6,0,0"
+				   Padding="12,6"
+                   HorizontalOptions="CenterAndExpand"
                    IsVisible="{Binding NfcIsDisabled}"
                    Text="NFC IS DISABLED"
 				   FontAttributes="Bold"

--- a/src/Plugin.NFC/Shared/INFC.shared.cs
+++ b/src/Plugin.NFC/Shared/INFC.shared.cs
@@ -104,21 +104,20 @@ namespace Plugin.NFC
 	/// </summary>
 	internal static class UIMessages
 	{
-		public const string NFCWritingNotSupported = "Writing NFC Tag is not supported on this device";
-		public const string NFCDialogAlertMessage = "Please hold your phone near a NFC tag";
-
+		public const string NFCWritingNotSupported = "Writing NFC Tag opration is not supported on this device";
+		public const string NFCDialogAlertMessage = "Please hold your phone near an NFC tag";
 		public const string NFCErrorRead = "Read error. Please try again";
 		public const string NFCErrorEmptyTag = "Tag is empty";
 		public const string NFCErrorReadOnlyTag = "Tag is not writable";
 		public const string NFCErrorCapacityTag = "Tag's capacity is too low";
 		public const string NFCErrorMissingTag = "Tag is missing";
-		public const string NFCErrorMissingTagInfo = "No Tag Informations: nothing to write";
+		public const string NFCErrorMissingTagInfo = "No Tag Information. Nothing to write";
 		public const string NFCErrorNotSupportedTag = "Tag is not supported";
 		public const string NFCErrorNotCompliantTag = "Tag is not NDEF compliant";
 		public const string NFCErrorWrite = "Nothing to write";
 
-		public const string NFCSuccessRead = "Tag Read Success";
-		public const string NFCSuccessWrite = "Tag Write Success";
-		public const string NFCSuccessClear = "Tag Clear Success";
+		public const string NFCSuccessRead = "Tag Read Operation Successful";
+		public const string NFCSuccessWrite = "Tag Write Operation Successful";
+		public const string NFCSuccessClear = "Tag Clear Operation Successful";
 	}
 }


### PR DESCRIPTION
### Description of Change ###

* Added a "Listening for NFC tag..." label at the bottom of the Clear button to display when the device is listening for an NFC Tag
* On iOS, if the device is listening, there's a popup box indicating the listening action. However on Android there was no indication before
* Created a Property DeviceIsListening that determines visibility of the "Listening.." label for Android and appropriately set it to true or false depending on each situation
* DeviceIsListening is not needed for iOS since the user sees the prompt anyway, and cannot be used for iOS because of the DidInvalidate() in Plugin.NFC/iOS/NFC.iOS.cs not being accessible from the Xaml.cs file

**Testing**
----------
* Tested on iOS & Android and it worked fine.
* Tested the different possible failure cases:
  * When the user presses cancel or the NFC prompt times out, the Listening text goes away
  * It indicated how Android keeps listening without a timeout, unlike iOS that times out
  * Tested on iOS & Android devices with and without NFC technology to make sure it works

### Behavioral Changes ###
Earlier on android, in the sample there was no indication that the app was listening for an nfc tag when a button is pressed, now the sample shows a “Listening for NFC Tag...” label when the app is looking for a tag. iOS is unchanged since it already showed a dialog when listening for device.  

### PR Checklist ###
- [n/a] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard
- [n/a] Updated documentation