### PR TITLE
Add NfcConfiguration to let user define UI messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Next release
 - Update Plugin.NFC.csproj
 - Add [sourcelink](https://github.com/dotnet/sourcelink) support
+- GitHub #28 : [iOS] Change default UI messages
 
 ### 0.1.16
 - GitHub #29 : [ANDROID] App sample - Write functionality needs fixing (PR #30)

--- a/README.md
+++ b/README.md
@@ -134,6 +134,33 @@ In this case, we will receive tags supporting NDEF mapped to a specified MIME Ty
 
 For more examples, see sample application in the repository.
 
+### Customizing UI messages
+* Set a new `NfcConfiguration` object to `CrossNFC.Current` with `SetConfiguration(NfcConfiguration cfg)` method like below
+
+```Csharp
+// Custom NFC configuration (ex. UI messages in French)
+CrossNFC.Current.SetConfiguration(new NfcConfiguration
+{
+    Messages = new UserDefinedMessages
+    {
+        NFCWritingNotSupported = "L'écriture des TAGs NFC n'est pas supporté sur cet appareil",
+        NFCDialogAlertMessage = "Approchez votre appareil du tag NFC",
+        NFCErrorRead = "Erreur de lecture. Veuillez rééssayer",
+        NFCErrorEmptyTag = "Ce tag est vide",
+        NFCErrorReadOnlyTag = "Ce tag n'est pas accessible en écriture",
+        NFCErrorCapacityTag = "La capacité de ce TAG est trop basse",
+        NFCErrorMissingTag = "Aucun tag trouvé",
+        NFCErrorMissingTagInfo = "Aucune information à écrire sur le tag",
+        NFCErrorNotSupportedTag = "Ce tag n'est pas supporté",
+        NFCErrorNotCompliantTag = "Ce tag n'est pas compatible NDEF",
+        NFCErrorWrite = "Aucune information à écrire sur le tag",
+        NFCSuccessRead = "Lecture réussie",
+        NFCSuccessWrite = "Ecriture réussie",
+        NFCSuccessClear = "Effaçage réussi"
+    }
+});
+```
+
 ## Contributing
 Feel free to contribute. PRs are accepted and welcomed.
 

--- a/src/Plugin.NFC.Sample/Plugin.NFC.Sample.Android/Resources/Resource.designer.cs
+++ b/src/Plugin.NFC.Sample/Plugin.NFC.Sample.Android/Resources/Resource.designer.cs
@@ -15,7 +15,7 @@ namespace NFCSample.Droid
 {
 	
 	
-	[System.CodeDom.Compiler.GeneratedCodeAttribute("Xamarin.Android.Build.Tasks", "1.0.0.0")]
+	[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Xamarin.Android.Build.Tasks", "1.0.0.0")]
 	public partial class Resource
 	{
 		

--- a/src/Plugin.NFC.Sample/Plugin.NFC.Sample/MainPage.xaml
+++ b/src/Plugin.NFC.Sample/Plugin.NFC.Sample/MainPage.xaml
@@ -4,6 +4,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:local="clr-namespace:NFCSample"
              x:Name="thisPage"
+             Title="Plugin NFC Sample"
              BindingContext="{x:Reference thisPage}">
 
     <ContentPage.Resources>
@@ -25,56 +26,56 @@
             <Button Clicked="Button_Clicked_StartListening"
                     IsEnabled="{Binding NfcIsEnabled}"
                     Text="Read Tag" />
-			
+
             <Frame BorderColor="Gray" HasShadow="False">
                 <StackLayout>
-					
+
                     <StackLayout Padding="0"
                                  HorizontalOptions="CenterAndExpand"
                                  Orientation="Horizontal"
                                  Spacing="0">
-						
+
                         <CheckBox x:Name="ChkReadOnly"
                                   IsChecked="False"
                                   IsEnabled="{Binding NfcIsEnabled}"
                                   VerticalOptions="Center"
                                   Color="Red" />
-						
+
                         <Label FontAttributes="Bold"
                                Text="Make Tag Read-Only"
                                TextColor="Red"
                                VerticalOptions="Center" />
                     </StackLayout>
-					
+
                     <Button Clicked="Button_Clicked_StartWriting"
                             IsEnabled="{Binding NfcIsEnabled}"
                             Text="Write Tag (Text)" />
-					
+
                     <Button Clicked="Button_Clicked_StartWriting_Uri"
                             IsEnabled="{Binding NfcIsEnabled}"
                             Text="Write Tag (Uri)" />
-					
+
                     <Button Clicked="Button_Clicked_StartWriting_Custom"
                             IsEnabled="{Binding NfcIsEnabled}"
                             Text="Write Tag (Custom)" />
-					
+
                 </StackLayout>
             </Frame>
-			
+
             <Button Clicked="Button_Clicked_FormatTag"
                     IsEnabled="{Binding NfcIsEnabled}"
                     Text="Clear Tag" />
 
-			<Label Margin="0,6,0,0"
-				   Padding="12,6"
+            <Label Margin="0,6,0,0"
+                   Padding="12,6"
+                   BackgroundColor="Red"
+                   FontAttributes="Bold"
                    HorizontalOptions="CenterAndExpand"
                    IsVisible="{Binding NfcIsDisabled}"
                    Text="NFC IS DISABLED"
-				   FontAttributes="Bold"
-                   TextColor="White"
-				   BackgroundColor="Red"/>
+                   TextColor="White" />
 
-		</StackLayout>
+        </StackLayout>
     </ScrollView>
 
 </ContentPage>

--- a/src/Plugin.NFC.Sample/Plugin.NFC.Sample/MainPage.xaml.cs
+++ b/src/Plugin.NFC.Sample/Plugin.NFC.Sample/MainPage.xaml.cs
@@ -14,6 +14,7 @@ namespace NFCSample
 
 		NFCNdefTypeFormat _type;
 		bool _makeReadOnly = false;
+		bool _eventsAlreadySubscribed = false;
 
 		private bool _nfcIsEnabled;
 		public bool NfcIsEnabled {
@@ -46,6 +47,28 @@ namespace NFCSample
 				if (!NfcIsEnabled)
 					await ShowAlert("NFC is disabled");
 
+				//// Custom NFC configuration (ex. UI messages in French)
+				//CrossNFC.Current.SetConfiguration(new NfcConfiguration
+				//{
+				//	Messages = new UserDefinedMessages
+				//	{
+				//		NFCWritingNotSupported = "L'écriture des TAGs NFC n'est pas supporté sur cet appareil",
+				//		NFCDialogAlertMessage = "Approchez votre appareil du tag NFC",
+				//		NFCErrorRead = "Erreur de lecture. Veuillez rééssayer",
+				//		NFCErrorEmptyTag = "Ce tag est vide",
+				//		NFCErrorReadOnlyTag = "Ce tag n'est pas accessible en écriture",
+				//		NFCErrorCapacityTag = "La capacité de ce TAG est trop basse",
+				//		NFCErrorMissingTag = "Aucun tag trouvé",
+				//		NFCErrorMissingTagInfo = "Aucune information à écrire sur le tag",
+				//		NFCErrorNotSupportedTag = "Ce tag n'est pas supporté",
+				//		NFCErrorNotCompliantTag = "Ce tag n'est pas compatible NDEF",
+				//		NFCErrorWrite = "Aucune information à écrire sur le tag",
+				//		NFCSuccessRead = "Lecture réussie",
+				//		NFCSuccessWrite = "Ecriture réussie",
+				//		NFCSuccessClear = "Effaçage réussi"
+				//	}
+				//});
+
 				SubscribeEvents();
 
 				await StartListeningIfNotiOS();
@@ -64,6 +87,11 @@ namespace NFCSample
 		/// </summary>
 		void SubscribeEvents()
 		{
+			if (_eventsAlreadySubscribed)
+				return;
+
+			_eventsAlreadySubscribed = true;
+
 			CrossNFC.Current.OnMessageReceived += Current_OnMessageReceived;
 			CrossNFC.Current.OnMessagePublished += Current_OnMessagePublished;
 			CrossNFC.Current.OnTagDiscovered += Current_OnTagDiscovered;
@@ -151,7 +179,7 @@ namespace NFCSample
 				else
 					await ShowAlert("Writing tag operation successful");
 			}
-			catch (System.Exception ex)
+			catch (Exception ex)
 			{
 				await ShowAlert(ex.Message);
 			}
@@ -214,7 +242,7 @@ namespace NFCSample
 					CrossNFC.Current.PublishMessage(tagInfo, _makeReadOnly);
 				}
 			}
-			catch (System.Exception ex)
+			catch (Exception ex)
 			{
 				await ShowAlert(ex.Message);
 			}
@@ -280,7 +308,7 @@ namespace NFCSample
 				if (type.HasValue) _type = type.Value;
 				CrossNFC.Current.StartPublishing(!type.HasValue);
 			}
-			catch (System.Exception ex)
+			catch (Exception ex)
 			{
 				await ShowAlert(ex.Message);
 			}

--- a/src/Plugin.NFC/Android/NFC.android.cs
+++ b/src/Plugin.NFC/Android/NFC.android.cs
@@ -64,13 +64,26 @@ namespace Plugin.NFC
 		public bool IsWritingTagSupported => NFCUtils.IsWritingSupported();
 
 		/// <summary>
+		/// NFC configuration
+		/// </summary>
+		public NfcConfiguration Configuration { get; private set; }
+
+		/// <summary>
 		/// Default constructor
 		/// </summary>
 		public NFCImplementation()
 		{
 			_nfcAdapter = NfcAdapter.GetDefaultAdapter(CurrentContext);
 			IsEnabled = IsAvailable && _nfcAdapter.IsEnabled;
+
+			Configuration = NfcConfiguration.GetDefaultConfiguration();
 		}
+
+		/// <summary>
+		/// Update NFC configuration
+		/// </summary>
+		/// <param name="configuration"><see cref="NfcConfiguration"/></param>
+		public void SetConfiguration(NfcConfiguration configuration) => Configuration.Update(configuration);
 
 		/// <summary>
 		/// Starts tags detection
@@ -146,10 +159,10 @@ namespace Plugin.NFC
 			try
 			{
 				if (_currentTag == null)
-					throw new Exception(UIMessages.NFCErrorMissingTag);
+					throw new Exception(Configuration.Messages.NFCErrorMissingTag);
 
 				if (tagInfo == null)
-					throw new Exception(UIMessages.NFCErrorMissingTagInfo);
+					throw new Exception(Configuration.Messages.NFCErrorMissingTagInfo);
 
 				var ndef = Ndef.Get(_currentTag);
 				if (ndef != null)
@@ -157,10 +170,10 @@ namespace Plugin.NFC
 					try
 					{
 						if (!ndef.IsWritable)
-							throw new Exception(UIMessages.NFCErrorReadOnlyTag);
+							throw new Exception(Configuration.Messages.NFCErrorReadOnlyTag);
 
 						if (ndef.MaxSize < NFCUtils.GetSize(tagInfo.Records))
-							throw new Exception(UIMessages.NFCErrorCapacityTag);
+							throw new Exception(Configuration.Messages.NFCErrorCapacityTag);
 
 						ndef.Connect();
 						OnTagConnected?.Invoke(null, EventArgs.Empty);
@@ -198,7 +211,7 @@ namespace Plugin.NFC
 							OnMessagePublished?.Invoke(nTag);
 						}
 						else
-							throw new Exception(UIMessages.NFCErrorWrite);
+							throw new Exception(Configuration.Messages.NFCErrorWrite);
 					}
 					catch (Android.Nfc.TagLostException tlex)
 					{
@@ -226,7 +239,7 @@ namespace Plugin.NFC
 					}
 				}
 				else
-					throw new Exception(UIMessages.NFCErrorNotCompliantTag);
+					throw new Exception(Configuration.Messages.NFCErrorNotCompliantTag);
 			} 
 			catch (Exception ex)
 			{
@@ -398,6 +411,7 @@ namespace Plugin.NFC
 
 		/// <summary>
 		/// Make a tag read-only
+		/// WARNING: This operation is permanent
 		/// </summary>
 		/// <param name="ndef"><see cref="Ndef"/></param>
 		/// <returns>boolean</returns>
@@ -534,5 +548,6 @@ namespace Plugin.NFC
 		}
 
 		#endregion
+
 	}
 }

--- a/src/Plugin.NFC/Plugin.NFC.csproj
+++ b/src/Plugin.NFC/Plugin.NFC.csproj
@@ -67,7 +67,7 @@
   </PropertyGroup>
 
 	<ItemGroup Condition=" '$(Configuration)'=='Release' ">
-		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
+		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
 	</ItemGroup>
 	
   <ItemGroup>

--- a/src/Plugin.NFC/Shared/INFC.shared.cs
+++ b/src/Plugin.NFC/Shared/INFC.shared.cs
@@ -30,6 +30,17 @@ namespace Plugin.NFC
 		bool IsWritingTagSupported { get; }
 
 		/// <summary>
+		/// NFC Configuration
+		/// </summary>
+		NfcConfiguration Configuration { get; }
+
+		/// <summary>
+		/// Set Nfc configuration
+		/// </summary>
+		/// <param name="configuration"><see cref="NfcConfiguration"/></param>
+		void SetConfiguration(NfcConfiguration configuration);
+
+		/// <summary>
 		/// Starts tags detection
 		/// </summary>
 		void StartListening();
@@ -94,31 +105,8 @@ namespace Plugin.NFC
 		event EventHandler OniOSReadingSessionCancelled;
 
 		/// <summary>
-		/// 
+		/// Event raised when NFC status changes
 		/// </summary>
 		event OnNfcStatusChangedEventHandler OnNfcStatusChanged;
-	}
-
-	/// <summary>
-	/// UI Messages
-	/// </summary>
-	internal static class UIMessages
-	{
-		public const string NFCWritingNotSupported = "Writing NFC Tag is not supported on this device";
-		public const string NFCDialogAlertMessage = "Please hold your phone near a NFC tag";
-
-		public const string NFCErrorRead = "Read error. Please try again";
-		public const string NFCErrorEmptyTag = "Tag is empty";
-		public const string NFCErrorReadOnlyTag = "Tag is not writable";
-		public const string NFCErrorCapacityTag = "Tag's capacity is too low";
-		public const string NFCErrorMissingTag = "Tag is missing";
-		public const string NFCErrorMissingTagInfo = "No Tag Informations: nothing to write";
-		public const string NFCErrorNotSupportedTag = "Tag is not supported";
-		public const string NFCErrorNotCompliantTag = "Tag is not NDEF compliant";
-		public const string NFCErrorWrite = "Nothing to write";
-
-		public const string NFCSuccessRead = "Tag Read Success";
-		public const string NFCSuccessWrite = "Tag Write Success";
-		public const string NFCSuccessClear = "Tag Clear Success";
 	}
 }

--- a/src/Plugin.NFC/Shared/NFCUtils.shared.cs
+++ b/src/Plugin.NFC/Shared/NFCUtils.shared.cs
@@ -1,5 +1,5 @@
-﻿using System.Text;
-using System.Linq;
+﻿using System.Linq;
+using System.Text;
 #if XAMARIN_IOS
 using UIKit;
 #endif

--- a/src/Plugin.NFC/Shared/NfcConfiguration.shared.cs
+++ b/src/Plugin.NFC/Shared/NfcConfiguration.shared.cs
@@ -1,0 +1,234 @@
+﻿namespace Plugin.NFC
+{
+	/// <summary>
+	/// NFC Configuration class
+	/// </summary>
+	public class NfcConfiguration
+	{
+		/// <summary>
+		/// List of user defined messages
+		/// </summary>
+		public UserDefinedMessages Messages { get; set; }
+
+		/// <summary>
+		/// Update Nfc Configuration with a new configuration object
+		/// </summary>
+		/// <param name="newCfg"><see cref="NfcConfiguration"/></param>
+		public void Update(NfcConfiguration newCfg)
+		{
+			if (newCfg == null || newCfg.Messages == null)
+				return;
+			Messages = newCfg.Messages;
+		}
+
+		/// <summary>
+		/// Get the default Nfc configuration
+		/// </summary>
+		/// <returns>Default <see cref="NfcConfiguration"/></returns>
+		public static NfcConfiguration GetDefaultConfiguration()
+			=> new NfcConfiguration { Messages = new UserDefinedMessages() };
+	}
+
+	/// <summary>
+	/// User defined UI messages
+	/// </summary>
+	public class UserDefinedMessages
+	{
+		string _nfcWritingNotSupported = "Writing NFC Tag is not supported on this device";
+		string _nfcDialogAlertMessage = "Please hold your phone near a NFC tag";
+		string _nfcErrorRead = "Read error. Please try again";
+		string _nfcErrorEmptyTag = "Tag is empty";
+		string _nfcErrorReadOnlyTag = "Tag is not writable";
+		string _nfcErrorCapacityTag = "Tag's capacity is too low";
+		string _nfcErrorMissingTag = "Tag is missing";
+		string _nfcErrorMissingTagInfo = "No Tag Informations: nothing to write";
+		string _nfcErrorNotSupportedTag = "Tag is not supported";
+		string _nfcErrorNotCompliantTag = "Tag is not NDEF compliant";
+		string _nfcErrorWrite = "Nothing to write";
+		string _nfcSuccessRead = "Tag Read Success";
+		string _nfcSuccessWrite = "Tag Write Success";
+		string _nfcSuccessClear = "Tag Clear Success";
+
+		/// <summary>
+		/// Writing feature not supported
+		/// </summary>
+		public string NFCWritingNotSupported
+		{
+			get => _nfcWritingNotSupported;
+			set
+			{
+				if (!string.IsNullOrWhiteSpace(value))
+					_nfcWritingNotSupported = value;
+			}
+		}
+
+		/// <summary>
+		/// [iOS] NFC Scan dialog alert message
+		/// </summary>
+		public string NFCDialogAlertMessage
+		{
+			get => _nfcDialogAlertMessage;
+			set
+			{
+				if (!string.IsNullOrWhiteSpace(value))
+					_nfcDialogAlertMessage = value;
+			}
+		}
+
+		/// <summary>
+		/// Read operation error
+		/// </summary>
+		public string NFCErrorRead
+		{
+			get => _nfcErrorRead;
+			set
+			{
+				if (!string.IsNullOrWhiteSpace(value))
+					_nfcErrorRead = value;
+			}
+		}
+
+		/// <summary>
+		/// Write operation error
+		/// </summary>
+		public string NFCErrorWrite
+		{
+			get => _nfcErrorWrite;
+			set
+			{
+				if (!string.IsNullOrWhiteSpace(value))
+					_nfcErrorWrite = value;
+			}
+		}
+
+		/// <summary>
+		/// Empty tag error
+		/// </summary>
+		public string NFCErrorEmptyTag
+		{
+			get => _nfcErrorEmptyTag;
+			set
+			{
+				if (!string.IsNullOrWhiteSpace(value))
+					_nfcErrorEmptyTag = value;
+			}
+		}
+
+		/// <summary>
+		/// Read-only tag error
+		/// </summary>
+		public string NFCErrorReadOnlyTag
+		{
+			get => _nfcErrorReadOnlyTag;
+			set
+			{
+				if (!string.IsNullOrWhiteSpace(value))
+					_nfcErrorReadOnlyTag = value;
+			}
+		}
+
+		/// <summary>
+		/// Tag capacity error
+		/// </summary>
+		public string NFCErrorCapacityTag
+		{
+			get => _nfcErrorCapacityTag;
+			set
+			{
+				if (!string.IsNullOrWhiteSpace(value))
+					_nfcErrorCapacityTag = value;
+			}
+		}
+
+		/// <summary>
+		/// Missing tag error
+		/// </summary>
+		public string NFCErrorMissingTag
+		{
+			get => _nfcErrorMissingTag;
+			set
+			{
+				if (!string.IsNullOrWhiteSpace(value))
+					_nfcErrorMissingTag = value;
+			}
+		}
+
+		/// <summary>
+		/// Missing tag info error
+		/// </summary>
+		public string NFCErrorMissingTagInfo
+		{
+			get => _nfcErrorMissingTagInfo;
+			set
+			{
+				if (!string.IsNullOrWhiteSpace(value))
+					_nfcErrorMissingTagInfo = value;
+			}
+		}
+
+		/// <summary>
+		/// Not supported tag error
+		/// </summary>
+		public string NFCErrorNotSupportedTag
+		{
+			get => _nfcErrorNotSupportedTag;
+			set
+			{
+				if (!string.IsNullOrWhiteSpace(value))
+					_nfcErrorNotSupportedTag = value;
+			}
+		}
+
+		/// <summary>
+		/// Not NDEF compliant tag error
+		/// </summary>
+		public string NFCErrorNotCompliantTag
+		{
+			get => _nfcErrorNotCompliantTag;
+			set
+			{
+				if (!string.IsNullOrWhiteSpace(value))
+					_nfcErrorNotCompliantTag = value;
+			}
+		}
+
+		/// <summary>
+		/// [iOS] Successful read operation message 
+		/// </summary>
+		public string NFCSuccessRead
+		{
+			get => _nfcSuccessRead;
+			set
+			{
+				if (!string.IsNullOrWhiteSpace(value))
+					_nfcSuccessRead = value;
+			}
+		}
+
+		/// <summary>
+		/// [iOS] Successful write operation message
+		/// </summary>
+		public string NFCSuccessWrite
+		{
+			get => _nfcSuccessWrite;
+			set
+			{
+				if (!string.IsNullOrWhiteSpace(value))
+					_nfcSuccessWrite = value;
+			}
+		}
+
+		/// <summary>
+		/// [iOS] Successful clear operation message
+		/// </summary>
+		public string NFCSuccessClear
+		{
+			get => _nfcSuccessClear;
+			set
+			{
+				if (!string.IsNullOrWhiteSpace(value))
+					_nfcSuccessClear = value;
+			}
+		}
+	}
+}

--- a/src/Plugin.NFC/UWP/NFC.uwp.cs
+++ b/src/Plugin.NFC/UWP/NFC.uwp.cs
@@ -53,12 +53,24 @@ namespace Plugin.NFC
 		public bool IsWritingTagSupported => true;
 
 		/// <summary>
+		/// NFC configuration
+		/// </summary>
+		public NfcConfiguration Configuration { get; private set; }
+
+		/// <summary>
 		/// Default constructor
 		/// </summary>
 		public NFCImplementation()
 		{
 			_defaultDevice = ProximityDevice.GetDefault();
+			Configuration = NfcConfiguration.GetDefaultConfiguration();
 		}
+
+		/// <summary>
+		/// Update NFC configuration
+		/// </summary>
+		/// <param name="configuration"><see cref="NfcConfiguration"/></param>
+		public void SetConfiguration(NfcConfiguration configuration) => Configuration.Update(configuration);
 
 		/// <summary>
 		/// Starts tags detection


### PR DESCRIPTION
### Description of Change ###

Add a NfcConfiguration object to let users define UI messages.

### Bugs Fixed ###

- Related to issue #28

### API Changes ###
Added a new method in `INFC` interface: 
 
- `void INFC.SetConfiguration(NfcConfiguration configuration);`

Added new classes:

```csharp
public class NfcConfiguration {
    public UserDefinedMessages Messages { get; set; }
    public void Update(NfcConfiguration newCfg);
    public static NfcConfiguration GetDefaultConfiguration();
}

public class UserDefinedMessages
{
    public string NFCDialogAlertMessage { get; set; } = "Please hold your phone near a NFC tag";
    public string NFCErrorRead { get; set; } = "Read error. Please try again";
    public string NFCErrorEmptyTag { get; set; } = "Tag is empty";
    public string NFCErrorReadOnlyTag { get; set; } = "Tag is not writable";
    public string NFCErrorCapacityTag { get; set; } = "Tag's capacity is too low";
    public string NFCErrorMissingTag { get; set; } = "Tag is missing";
    public string NFCErrorMissingTagInfo { get; set; } = "No Tag Informations: nothing to write";
    public string NFCErrorNotSupportedTag { get; set; } = "Tag is not supported";
    public string NFCErrorNotCompliantTag { get; set; } = "Tag is not NDEF compliant";
    public string NFCErrorWrite { get; set; } = "Nothing to write";
    public string NFCSuccessRead { get; set; } = "Tag Read Success";
    public string NFCSuccessWrite { get; set; } = "Tag Write Success";
    public string NFCSuccessClear { get; set; } = "Tag Clear Success";
}
```

### Behavioral Changes ###

New method is called like this:

```csharp
// Custom NFC configuration (ex. UI messages in French)
CrossNFC.Current.SetConfiguration(new NfcConfiguration
{
    Messages = new UserDefinedMessages
    {
        NFCWritingNotSupported = "L'écriture des TAGs NFC n'est pas supporté sur cet appareil",
        NFCDialogAlertMessage = "Approchez votre appareil du tag NFC",
        NFCErrorRead = "Erreur de lecture. Veuillez rééssayer",
        NFCErrorEmptyTag = "Ce tag est vide",
        NFCErrorReadOnlyTag = "Ce tag n'est pas accessible en écriture",
        NFCErrorCapacityTag = "La capacité de ce TAG est trop basse",
        NFCErrorMissingTag = "Aucun tag trouvé",
        NFCErrorMissingTagInfo = "Aucune information à écrire sur le tag",
        NFCErrorNotSupportedTag = "Ce tag n'est pas supporté",
        NFCErrorNotCompliantTag = "Ce tag n'est pas compatible NDEF",
        NFCErrorWrite = "Aucune information à écrire sur le tag",
        NFCSuccessRead = "Lecture réussie",
        NFCSuccessWrite = "Ecriture réussie",
        NFCSuccessClear = "Effaçage réussi"
    }
});
```

### PR Checklist ###

- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of vnext at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation