### PR TITLE
expose the capacity of the ndef tag

### DIFF
--- a/src/Plugin.NFC/Android/NFC.android.cs
+++ b/src/Plugin.NFC/Android/NFC.android.cs
@@ -331,7 +331,10 @@ namespace Plugin.NFC
 				return null;
 
 			var ndef = Ndef.Get(tag);
-			var nTag = new TagInfo(tag.GetId(), ndef != null);
+			var nTag = new TagInfo(tag.GetId(), ndef != null)
+			{
+				Capacity = ndef.MaxSize
+			};
 
 			if (ndef != null)
 			{

--- a/src/Plugin.NFC/Shared/ITagInfo.shared.cs
+++ b/src/Plugin.NFC/Shared/ITagInfo.shared.cs
@@ -31,6 +31,11 @@
 		bool IsSupported { get; }
 
 		/// <summary>
+		/// Capacity of tag in bytes
+		/// </summary>
+		int Capacity { get; set; }
+
+		/// <summary>
 		/// Array of <see cref="NFCNdefRecord"/> of tag
 		/// </summary>
 		NFCNdefRecord[] Records { get; set; }

--- a/src/Plugin.NFC/Shared/TagInfo.shared.cs
+++ b/src/Plugin.NFC/Shared/TagInfo.shared.cs
@@ -18,6 +18,11 @@
 		public bool IsWritable { get; set; }
 
 		/// <summary>
+		/// Capacity of tag in bytes
+		/// </summary>
+		public int Capacity { get; set; }
+
+		/// <summary>
 		/// Array of <see cref="NFCNdefRecord"/> of tag
 		/// </summary>
 		public NFCNdefRecord[] Records { get; set; }
@@ -52,9 +57,6 @@
 			IsSupported = isNdef;
 		}
 
-		public override string ToString()
-		{
-			return $"TagInfo: identifier: {Identifier}, SerialNumber:{SerialNumber}, IsSupported:{IsSupported}, IsEmpty:{IsEmpty}, IsWritable:{IsWritable}";
-		}
+		public override string ToString() => $"TagInfo: identifier: {Identifier}, SerialNumber:{SerialNumber}, Capacity:{Capacity} bytes, IsSupported:{IsSupported}, IsEmpty:{IsEmpty}, IsWritable:{IsWritable}";
 	}
 }

--- a/src/Plugin.NFC/iOS/NFC.iOS.cs
+++ b/src/Plugin.NFC/iOS/NFC.iOS.cs
@@ -174,7 +174,8 @@ namespace Plugin.NFC
 					var identifier = GetTagIdentifier(ndefTag);
 					var nTag = new TagInfo(identifier)
 					{
-						IsWritable = status == NFCNdefStatus.ReadWrite
+						IsWritable = status == NFCNdefStatus.ReadWrite,
+						Capacity = Convert.ToInt32(capacity)
 					};
 
 					if (_isWriting)


### PR DESCRIPTION
### Description of Change ###
This allows a user to get the capacity, in bytes, of a tag.

### Bugs Fixed ###

- Related to issue #45

### API Changes ###

List all API changes here (or just put None), example:

Added: 
 
- `int ITagInfo.Capacity { get; set; }`


