### PR TITLE
NFC listener/Reader for Android 10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Changelog
 
+### Vnext
+- [Android] Fixing some issues with NFC listener on Android 10 (PR #49)
+- GitHub #40 : [iOS] NFC Tag not reading on iOS unless I have a message on the tag (PR #48)
+- GitHub #45 : [ANDROID, iOS] Expose the capacity of the ndef tag (PR #46)
+
 ### 0.1.17
 - Update Plugin.NFC.csproj
 - Add [sourcelink](https://github.com/dotnet/sourcelink) support

--- a/README.md
+++ b/README.md
@@ -41,6 +41,16 @@ protected override void OnCreate(Bundle savedInstanceState)
     LoadApplication(new App());
 }
 ```
+* Add the line `CrossNFC.OnResume()` in your `OnResume()`
+```csharp
+protected override void OnResume()
+{
+    base.OnResume();
+
+    // Plugin NFC: Restart NFC listening on resume (needed for Android 10+) 
+    CrossNFC.OnResume();
+}
+```
 
 * Add the line `CrossNFC.OnNewIntent(intent)` in your `OnNewIntent()`
 ```csharp
@@ -95,6 +105,8 @@ CrossNFC.Current.OnMessageReceived += Current_OnMessageReceived;
 CrossNFC.Current.OnMessagePublished += Current_OnMessagePublished;
 // Event raised when a tag is discovered. Used for publishing.
 CrossNFC.Current.OnTagDiscovered += Current_OnTagDiscovered;
+// Event raised when NFC listener status changed
+CrossNFC.Current.OnTagListeningStatusChanged += Current_OnTagListeningStatusChanged;
 
 // Android Only:
 // Event raised when NFC state has changed.

--- a/src/Plugin.NFC.Sample/Plugin.NFC.Sample.Android/MainActivity.cs
+++ b/src/Plugin.NFC.Sample/Plugin.NFC.Sample.Android/MainActivity.cs
@@ -23,6 +23,12 @@ namespace NFCSample.Droid
 			LoadApplication(new App());
 		}
 
+		protected override void OnResume()
+		{
+			base.OnResume();
+			CrossNFC.OnResume();
+		}
+
 		protected override void OnNewIntent(Intent intent)
 		{
 			base.OnNewIntent(intent);

--- a/src/Plugin.NFC.Sample/Plugin.NFC.Sample.Android/Plugin.NFC.Sample.Android.csproj
+++ b/src/Plugin.NFC.Sample/Plugin.NFC.Sample.Android/Plugin.NFC.Sample.Android.csproj
@@ -16,7 +16,7 @@
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
     <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
-    <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v10.0</TargetFrameworkVersion>
     <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>

--- a/src/Plugin.NFC.Sample/Plugin.NFC.Sample.Android/Properties/AndroidManifest.xml
+++ b/src/Plugin.NFC.Sample/Plugin.NFC.Sample.Android/Properties/AndroidManifest.xml
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.companyname.NFCSample" android:installLocation="auto">
-	<uses-sdk android:minSdkVersion="21" android:targetSdkVersion="27" />
+	<uses-sdk android:minSdkVersion="21" android:targetSdkVersion="29" />
 	<uses-permission android:name="android.permission.NFC" />
+	<uses-feature android:name="android.hardware.nfc" android:required="true" />
 	<application android:label="NFCSample.Android"></application>
 </manifest>

--- a/src/Plugin.NFC.Sample/Plugin.NFC.Sample.Android/Resources/Resource.designer.cs
+++ b/src/Plugin.NFC.Sample/Plugin.NFC.Sample.Android/Resources/Resource.designer.cs
@@ -35,6 +35,8 @@ namespace NFCSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Animation.abc_slide_in_top = global::NFCSample.Droid.Resource.Animation.abc_slide_in_top;
 			global::Xamarin.Forms.Platform.Android.Resource.Animation.abc_slide_out_bottom = global::NFCSample.Droid.Resource.Animation.abc_slide_out_bottom;
 			global::Xamarin.Forms.Platform.Android.Resource.Animation.abc_slide_out_top = global::NFCSample.Droid.Resource.Animation.abc_slide_out_top;
+			global::Xamarin.Forms.Platform.Android.Resource.Animation.abc_tooltip_enter = global::NFCSample.Droid.Resource.Animation.abc_tooltip_enter;
+			global::Xamarin.Forms.Platform.Android.Resource.Animation.abc_tooltip_exit = global::NFCSample.Droid.Resource.Animation.abc_tooltip_exit;
 			global::Xamarin.Forms.Platform.Android.Resource.Animation.design_bottom_sheet_slide_in = global::NFCSample.Droid.Resource.Animation.design_bottom_sheet_slide_in;
 			global::Xamarin.Forms.Platform.Android.Resource.Animation.design_bottom_sheet_slide_out = global::NFCSample.Droid.Resource.Animation.design_bottom_sheet_slide_out;
 			global::Xamarin.Forms.Platform.Android.Resource.Animation.design_snackbar_in = global::NFCSample.Droid.Resource.Animation.design_snackbar_in;
@@ -43,9 +45,16 @@ namespace NFCSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Animation.EnterFromRight = global::NFCSample.Droid.Resource.Animation.EnterFromRight;
 			global::Xamarin.Forms.Platform.Android.Resource.Animation.ExitToLeft = global::NFCSample.Droid.Resource.Animation.ExitToLeft;
 			global::Xamarin.Forms.Platform.Android.Resource.Animation.ExitToRight = global::NFCSample.Droid.Resource.Animation.ExitToRight;
-			global::Xamarin.Forms.Platform.Android.Resource.Animation.tooltip_enter = global::NFCSample.Droid.Resource.Animation.tooltip_enter;
-			global::Xamarin.Forms.Platform.Android.Resource.Animation.tooltip_exit = global::NFCSample.Droid.Resource.Animation.tooltip_exit;
 			global::Xamarin.Forms.Platform.Android.Resource.Animator.design_appbar_state_list_animator = global::NFCSample.Droid.Resource.Animator.design_appbar_state_list_animator;
+			global::Xamarin.Forms.Platform.Android.Resource.Animator.design_fab_hide_motion_spec = global::NFCSample.Droid.Resource.Animator.design_fab_hide_motion_spec;
+			global::Xamarin.Forms.Platform.Android.Resource.Animator.design_fab_show_motion_spec = global::NFCSample.Droid.Resource.Animator.design_fab_show_motion_spec;
+			global::Xamarin.Forms.Platform.Android.Resource.Animator.mtrl_btn_state_list_anim = global::NFCSample.Droid.Resource.Animator.mtrl_btn_state_list_anim;
+			global::Xamarin.Forms.Platform.Android.Resource.Animator.mtrl_btn_unelevated_state_list_anim = global::NFCSample.Droid.Resource.Animator.mtrl_btn_unelevated_state_list_anim;
+			global::Xamarin.Forms.Platform.Android.Resource.Animator.mtrl_chip_state_list_anim = global::NFCSample.Droid.Resource.Animator.mtrl_chip_state_list_anim;
+			global::Xamarin.Forms.Platform.Android.Resource.Animator.mtrl_fab_hide_motion_spec = global::NFCSample.Droid.Resource.Animator.mtrl_fab_hide_motion_spec;
+			global::Xamarin.Forms.Platform.Android.Resource.Animator.mtrl_fab_show_motion_spec = global::NFCSample.Droid.Resource.Animator.mtrl_fab_show_motion_spec;
+			global::Xamarin.Forms.Platform.Android.Resource.Animator.mtrl_fab_transformation_sheet_collapse_spec = global::NFCSample.Droid.Resource.Animator.mtrl_fab_transformation_sheet_collapse_spec;
+			global::Xamarin.Forms.Platform.Android.Resource.Animator.mtrl_fab_transformation_sheet_expand_spec = global::NFCSample.Droid.Resource.Animator.mtrl_fab_transformation_sheet_expand_spec;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.actionBarDivider = global::NFCSample.Droid.Resource.Attribute.actionBarDivider;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.actionBarItemBackground = global::NFCSample.Droid.Resource.Attribute.actionBarItemBackground;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.actionBarPopupTheme = global::NFCSample.Droid.Resource.Attribute.actionBarPopupTheme;
@@ -102,20 +111,33 @@ namespace NFCSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.backgroundTintMode = global::NFCSample.Droid.Resource.Attribute.backgroundTintMode;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.barLength = global::NFCSample.Droid.Resource.Attribute.barLength;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.behavior_autoHide = global::NFCSample.Droid.Resource.Attribute.behavior_autoHide;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.behavior_fitToContents = global::NFCSample.Droid.Resource.Attribute.behavior_fitToContents;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.behavior_hideable = global::NFCSample.Droid.Resource.Attribute.behavior_hideable;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.behavior_overlapTop = global::NFCSample.Droid.Resource.Attribute.behavior_overlapTop;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.behavior_peekHeight = global::NFCSample.Droid.Resource.Attribute.behavior_peekHeight;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.behavior_skipCollapsed = global::NFCSample.Droid.Resource.Attribute.behavior_skipCollapsed;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.borderWidth = global::NFCSample.Droid.Resource.Attribute.borderWidth;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.borderlessButtonStyle = global::NFCSample.Droid.Resource.Attribute.borderlessButtonStyle;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.bottomAppBarStyle = global::NFCSample.Droid.Resource.Attribute.bottomAppBarStyle;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.bottomNavigationStyle = global::NFCSample.Droid.Resource.Attribute.bottomNavigationStyle;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.bottomSheetDialogTheme = global::NFCSample.Droid.Resource.Attribute.bottomSheetDialogTheme;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.bottomSheetStyle = global::NFCSample.Droid.Resource.Attribute.bottomSheetStyle;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.boxBackgroundColor = global::NFCSample.Droid.Resource.Attribute.boxBackgroundColor;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.boxBackgroundMode = global::NFCSample.Droid.Resource.Attribute.boxBackgroundMode;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.boxCollapsedPaddingTop = global::NFCSample.Droid.Resource.Attribute.boxCollapsedPaddingTop;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.boxCornerRadiusBottomEnd = global::NFCSample.Droid.Resource.Attribute.boxCornerRadiusBottomEnd;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.boxCornerRadiusBottomStart = global::NFCSample.Droid.Resource.Attribute.boxCornerRadiusBottomStart;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.boxCornerRadiusTopEnd = global::NFCSample.Droid.Resource.Attribute.boxCornerRadiusTopEnd;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.boxCornerRadiusTopStart = global::NFCSample.Droid.Resource.Attribute.boxCornerRadiusTopStart;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.boxStrokeColor = global::NFCSample.Droid.Resource.Attribute.boxStrokeColor;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.boxStrokeWidth = global::NFCSample.Droid.Resource.Attribute.boxStrokeWidth;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.buttonBarButtonStyle = global::NFCSample.Droid.Resource.Attribute.buttonBarButtonStyle;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.buttonBarNegativeButtonStyle = global::NFCSample.Droid.Resource.Attribute.buttonBarNegativeButtonStyle;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.buttonBarNeutralButtonStyle = global::NFCSample.Droid.Resource.Attribute.buttonBarNeutralButtonStyle;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.buttonBarPositiveButtonStyle = global::NFCSample.Droid.Resource.Attribute.buttonBarPositiveButtonStyle;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.buttonBarStyle = global::NFCSample.Droid.Resource.Attribute.buttonBarStyle;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.buttonGravity = global::NFCSample.Droid.Resource.Attribute.buttonGravity;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.buttonIconDimen = global::NFCSample.Droid.Resource.Attribute.buttonIconDimen;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.buttonPanelSideLayout = global::NFCSample.Droid.Resource.Attribute.buttonPanelSideLayout;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.buttonStyle = global::NFCSample.Droid.Resource.Attribute.buttonStyle;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.buttonStyleSmall = global::NFCSample.Droid.Resource.Attribute.buttonStyleSmall;
@@ -127,9 +149,38 @@ namespace NFCSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.cardMaxElevation = global::NFCSample.Droid.Resource.Attribute.cardMaxElevation;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.cardPreventCornerOverlap = global::NFCSample.Droid.Resource.Attribute.cardPreventCornerOverlap;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.cardUseCompatPadding = global::NFCSample.Droid.Resource.Attribute.cardUseCompatPadding;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.cardViewStyle = global::NFCSample.Droid.Resource.Attribute.cardViewStyle;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.checkboxStyle = global::NFCSample.Droid.Resource.Attribute.checkboxStyle;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.checkedChip = global::NFCSample.Droid.Resource.Attribute.checkedChip;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.checkedIcon = global::NFCSample.Droid.Resource.Attribute.checkedIcon;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.checkedIconEnabled = global::NFCSample.Droid.Resource.Attribute.checkedIconEnabled;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.checkedIconVisible = global::NFCSample.Droid.Resource.Attribute.checkedIconVisible;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.checkedTextViewStyle = global::NFCSample.Droid.Resource.Attribute.checkedTextViewStyle;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.chipBackgroundColor = global::NFCSample.Droid.Resource.Attribute.chipBackgroundColor;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.chipCornerRadius = global::NFCSample.Droid.Resource.Attribute.chipCornerRadius;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.chipEndPadding = global::NFCSample.Droid.Resource.Attribute.chipEndPadding;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.chipGroupStyle = global::NFCSample.Droid.Resource.Attribute.chipGroupStyle;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.chipIcon = global::NFCSample.Droid.Resource.Attribute.chipIcon;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.chipIconEnabled = global::NFCSample.Droid.Resource.Attribute.chipIconEnabled;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.chipIconSize = global::NFCSample.Droid.Resource.Attribute.chipIconSize;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.chipIconTint = global::NFCSample.Droid.Resource.Attribute.chipIconTint;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.chipIconVisible = global::NFCSample.Droid.Resource.Attribute.chipIconVisible;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.chipMinHeight = global::NFCSample.Droid.Resource.Attribute.chipMinHeight;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.chipSpacing = global::NFCSample.Droid.Resource.Attribute.chipSpacing;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.chipSpacingHorizontal = global::NFCSample.Droid.Resource.Attribute.chipSpacingHorizontal;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.chipSpacingVertical = global::NFCSample.Droid.Resource.Attribute.chipSpacingVertical;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.chipStandaloneStyle = global::NFCSample.Droid.Resource.Attribute.chipStandaloneStyle;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.chipStartPadding = global::NFCSample.Droid.Resource.Attribute.chipStartPadding;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.chipStrokeColor = global::NFCSample.Droid.Resource.Attribute.chipStrokeColor;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.chipStrokeWidth = global::NFCSample.Droid.Resource.Attribute.chipStrokeWidth;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.chipStyle = global::NFCSample.Droid.Resource.Attribute.chipStyle;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.closeIcon = global::NFCSample.Droid.Resource.Attribute.closeIcon;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.closeIconEnabled = global::NFCSample.Droid.Resource.Attribute.closeIconEnabled;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.closeIconEndPadding = global::NFCSample.Droid.Resource.Attribute.closeIconEndPadding;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.closeIconSize = global::NFCSample.Droid.Resource.Attribute.closeIconSize;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.closeIconStartPadding = global::NFCSample.Droid.Resource.Attribute.closeIconStartPadding;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.closeIconTint = global::NFCSample.Droid.Resource.Attribute.closeIconTint;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.closeIconVisible = global::NFCSample.Droid.Resource.Attribute.closeIconVisible;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.closeItemLayout = global::NFCSample.Droid.Resource.Attribute.closeItemLayout;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.collapseContentDescription = global::NFCSample.Droid.Resource.Attribute.collapseContentDescription;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.collapseIcon = global::NFCSample.Droid.Resource.Attribute.collapseIcon;
@@ -145,6 +196,7 @@ namespace NFCSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.colorError = global::NFCSample.Droid.Resource.Attribute.colorError;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.colorPrimary = global::NFCSample.Droid.Resource.Attribute.colorPrimary;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.colorPrimaryDark = global::NFCSample.Droid.Resource.Attribute.colorPrimaryDark;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.colorSecondary = global::NFCSample.Droid.Resource.Attribute.colorSecondary;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.colorSwitchThumbNormal = global::NFCSample.Droid.Resource.Attribute.colorSwitchThumbNormal;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.commitIcon = global::NFCSample.Droid.Resource.Attribute.commitIcon;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.contentDescription = global::NFCSample.Droid.Resource.Attribute.contentDescription;
@@ -161,12 +213,15 @@ namespace NFCSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.contentPaddingTop = global::NFCSample.Droid.Resource.Attribute.contentPaddingTop;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.contentScrim = global::NFCSample.Droid.Resource.Attribute.contentScrim;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.controlBackground = global::NFCSample.Droid.Resource.Attribute.controlBackground;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.coordinatorLayoutStyle = global::NFCSample.Droid.Resource.Attribute.coordinatorLayoutStyle;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.cornerRadius = global::NFCSample.Droid.Resource.Attribute.cornerRadius;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.counterEnabled = global::NFCSample.Droid.Resource.Attribute.counterEnabled;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.counterMaxLength = global::NFCSample.Droid.Resource.Attribute.counterMaxLength;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.counterOverflowTextAppearance = global::NFCSample.Droid.Resource.Attribute.counterOverflowTextAppearance;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.counterTextAppearance = global::NFCSample.Droid.Resource.Attribute.counterTextAppearance;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.customNavigationLayout = global::NFCSample.Droid.Resource.Attribute.customNavigationLayout;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.defaultQueryHint = global::NFCSample.Droid.Resource.Attribute.defaultQueryHint;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.dialogCornerRadius = global::NFCSample.Droid.Resource.Attribute.dialogCornerRadius;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.dialogPreferredPadding = global::NFCSample.Droid.Resource.Attribute.dialogPreferredPadding;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.dialogTheme = global::NFCSample.Droid.Resource.Attribute.dialogTheme;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.displayOptions = global::NFCSample.Droid.Resource.Attribute.displayOptions;
@@ -182,6 +237,8 @@ namespace NFCSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.editTextColor = global::NFCSample.Droid.Resource.Attribute.editTextColor;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.editTextStyle = global::NFCSample.Droid.Resource.Attribute.editTextStyle;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.elevation = global::NFCSample.Droid.Resource.Attribute.elevation;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.enforceMaterialTheme = global::NFCSample.Droid.Resource.Attribute.enforceMaterialTheme;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.enforceTextAppearance = global::NFCSample.Droid.Resource.Attribute.enforceTextAppearance;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.errorEnabled = global::NFCSample.Droid.Resource.Attribute.errorEnabled;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.errorTextAppearance = global::NFCSample.Droid.Resource.Attribute.errorTextAppearance;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.expandActivityOverflowButtonDrawable = global::NFCSample.Droid.Resource.Attribute.expandActivityOverflowButtonDrawable;
@@ -193,12 +250,19 @@ namespace NFCSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.expandedTitleMarginStart = global::NFCSample.Droid.Resource.Attribute.expandedTitleMarginStart;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.expandedTitleMarginTop = global::NFCSample.Droid.Resource.Attribute.expandedTitleMarginTop;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.expandedTitleTextAppearance = global::NFCSample.Droid.Resource.Attribute.expandedTitleTextAppearance;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.fabAlignmentMode = global::NFCSample.Droid.Resource.Attribute.fabAlignmentMode;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.fabCradleMargin = global::NFCSample.Droid.Resource.Attribute.fabCradleMargin;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.fabCradleRoundedCornerRadius = global::NFCSample.Droid.Resource.Attribute.fabCradleRoundedCornerRadius;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.fabCradleVerticalOffset = global::NFCSample.Droid.Resource.Attribute.fabCradleVerticalOffset;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.fabCustomSize = global::NFCSample.Droid.Resource.Attribute.fabCustomSize;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.fabSize = global::NFCSample.Droid.Resource.Attribute.fabSize;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.fastScrollEnabled = global::NFCSample.Droid.Resource.Attribute.fastScrollEnabled;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.fastScrollHorizontalThumbDrawable = global::NFCSample.Droid.Resource.Attribute.fastScrollHorizontalThumbDrawable;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.fastScrollHorizontalTrackDrawable = global::NFCSample.Droid.Resource.Attribute.fastScrollHorizontalTrackDrawable;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.fastScrollVerticalThumbDrawable = global::NFCSample.Droid.Resource.Attribute.fastScrollVerticalThumbDrawable;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.fastScrollVerticalTrackDrawable = global::NFCSample.Droid.Resource.Attribute.fastScrollVerticalTrackDrawable;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.firstBaselineToTopHeight = global::NFCSample.Droid.Resource.Attribute.firstBaselineToTopHeight;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.floatingActionButtonStyle = global::NFCSample.Droid.Resource.Attribute.floatingActionButtonStyle;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.font = global::NFCSample.Droid.Resource.Attribute.font;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.fontFamily = global::NFCSample.Droid.Resource.Attribute.fontFamily;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.fontProviderAuthority = global::NFCSample.Droid.Resource.Attribute.fontProviderAuthority;
@@ -208,19 +272,31 @@ namespace NFCSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.fontProviderPackage = global::NFCSample.Droid.Resource.Attribute.fontProviderPackage;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.fontProviderQuery = global::NFCSample.Droid.Resource.Attribute.fontProviderQuery;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.fontStyle = global::NFCSample.Droid.Resource.Attribute.fontStyle;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.fontVariationSettings = global::NFCSample.Droid.Resource.Attribute.fontVariationSettings;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.fontWeight = global::NFCSample.Droid.Resource.Attribute.fontWeight;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.foregroundInsidePadding = global::NFCSample.Droid.Resource.Attribute.foregroundInsidePadding;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.gapBetweenBars = global::NFCSample.Droid.Resource.Attribute.gapBetweenBars;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.goIcon = global::NFCSample.Droid.Resource.Attribute.goIcon;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.headerLayout = global::NFCSample.Droid.Resource.Attribute.headerLayout;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.height = global::NFCSample.Droid.Resource.Attribute.height;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.helperText = global::NFCSample.Droid.Resource.Attribute.helperText;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.helperTextEnabled = global::NFCSample.Droid.Resource.Attribute.helperTextEnabled;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.helperTextTextAppearance = global::NFCSample.Droid.Resource.Attribute.helperTextTextAppearance;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.hideMotionSpec = global::NFCSample.Droid.Resource.Attribute.hideMotionSpec;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.hideOnContentScroll = global::NFCSample.Droid.Resource.Attribute.hideOnContentScroll;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.hideOnScroll = global::NFCSample.Droid.Resource.Attribute.hideOnScroll;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.hintAnimationEnabled = global::NFCSample.Droid.Resource.Attribute.hintAnimationEnabled;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.hintEnabled = global::NFCSample.Droid.Resource.Attribute.hintEnabled;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.hintTextAppearance = global::NFCSample.Droid.Resource.Attribute.hintTextAppearance;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.homeAsUpIndicator = global::NFCSample.Droid.Resource.Attribute.homeAsUpIndicator;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.homeLayout = global::NFCSample.Droid.Resource.Attribute.homeLayout;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.hoveredFocusedTranslationZ = global::NFCSample.Droid.Resource.Attribute.hoveredFocusedTranslationZ;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.icon = global::NFCSample.Droid.Resource.Attribute.icon;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.iconEndPadding = global::NFCSample.Droid.Resource.Attribute.iconEndPadding;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.iconGravity = global::NFCSample.Droid.Resource.Attribute.iconGravity;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.iconPadding = global::NFCSample.Droid.Resource.Attribute.iconPadding;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.iconSize = global::NFCSample.Droid.Resource.Attribute.iconSize;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.iconStartPadding = global::NFCSample.Droid.Resource.Attribute.iconStartPadding;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.iconTint = global::NFCSample.Droid.Resource.Attribute.iconTint;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.iconTintMode = global::NFCSample.Droid.Resource.Attribute.iconTintMode;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.iconifiedByDefault = global::NFCSample.Droid.Resource.Attribute.iconifiedByDefault;
@@ -230,11 +306,20 @@ namespace NFCSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.insetForeground = global::NFCSample.Droid.Resource.Attribute.insetForeground;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.isLightTheme = global::NFCSample.Droid.Resource.Attribute.isLightTheme;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.itemBackground = global::NFCSample.Droid.Resource.Attribute.itemBackground;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.itemHorizontalPadding = global::NFCSample.Droid.Resource.Attribute.itemHorizontalPadding;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.itemHorizontalTranslationEnabled = global::NFCSample.Droid.Resource.Attribute.itemHorizontalTranslationEnabled;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.itemIconPadding = global::NFCSample.Droid.Resource.Attribute.itemIconPadding;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.itemIconSize = global::NFCSample.Droid.Resource.Attribute.itemIconSize;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.itemIconTint = global::NFCSample.Droid.Resource.Attribute.itemIconTint;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.itemPadding = global::NFCSample.Droid.Resource.Attribute.itemPadding;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.itemSpacing = global::NFCSample.Droid.Resource.Attribute.itemSpacing;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.itemTextAppearance = global::NFCSample.Droid.Resource.Attribute.itemTextAppearance;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.itemTextAppearanceActive = global::NFCSample.Droid.Resource.Attribute.itemTextAppearanceActive;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.itemTextAppearanceInactive = global::NFCSample.Droid.Resource.Attribute.itemTextAppearanceInactive;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.itemTextColor = global::NFCSample.Droid.Resource.Attribute.itemTextColor;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.keylines = global::NFCSample.Droid.Resource.Attribute.keylines;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.labelVisibilityMode = global::NFCSample.Droid.Resource.Attribute.labelVisibilityMode;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.lastBaselineToBottomHeight = global::NFCSample.Droid.Resource.Attribute.lastBaselineToBottomHeight;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.layout = global::NFCSample.Droid.Resource.Attribute.layout;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.layoutManager = global::NFCSample.Droid.Resource.Attribute.layoutManager;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.layout_anchor = global::NFCSample.Droid.Resource.Attribute.layout_anchor;
@@ -247,6 +332,9 @@ namespace NFCSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.layout_keyline = global::NFCSample.Droid.Resource.Attribute.layout_keyline;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.layout_scrollFlags = global::NFCSample.Droid.Resource.Attribute.layout_scrollFlags;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.layout_scrollInterpolator = global::NFCSample.Droid.Resource.Attribute.layout_scrollInterpolator;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.liftOnScroll = global::NFCSample.Droid.Resource.Attribute.liftOnScroll;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.lineHeight = global::NFCSample.Droid.Resource.Attribute.lineHeight;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.lineSpacing = global::NFCSample.Droid.Resource.Attribute.lineSpacing;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.listChoiceBackgroundIndicator = global::NFCSample.Droid.Resource.Attribute.listChoiceBackgroundIndicator;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.listDividerAlertDialog = global::NFCSample.Droid.Resource.Attribute.listDividerAlertDialog;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.listItemLayout = global::NFCSample.Droid.Resource.Attribute.listItemLayout;
@@ -260,14 +348,18 @@ namespace NFCSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.listPreferredItemPaddingRight = global::NFCSample.Droid.Resource.Attribute.listPreferredItemPaddingRight;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.logo = global::NFCSample.Droid.Resource.Attribute.logo;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.logoDescription = global::NFCSample.Droid.Resource.Attribute.logoDescription;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.materialButtonStyle = global::NFCSample.Droid.Resource.Attribute.materialButtonStyle;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.materialCardViewStyle = global::NFCSample.Droid.Resource.Attribute.materialCardViewStyle;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.maxActionInlineWidth = global::NFCSample.Droid.Resource.Attribute.maxActionInlineWidth;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.maxButtonHeight = global::NFCSample.Droid.Resource.Attribute.maxButtonHeight;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.maxImageSize = global::NFCSample.Droid.Resource.Attribute.maxImageSize;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.measureWithLargestChild = global::NFCSample.Droid.Resource.Attribute.measureWithLargestChild;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.menu = global::NFCSample.Droid.Resource.Attribute.menu;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.multiChoiceItemLayout = global::NFCSample.Droid.Resource.Attribute.multiChoiceItemLayout;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.navigationContentDescription = global::NFCSample.Droid.Resource.Attribute.navigationContentDescription;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.navigationIcon = global::NFCSample.Droid.Resource.Attribute.navigationIcon;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.navigationMode = global::NFCSample.Droid.Resource.Attribute.navigationMode;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.navigationViewStyle = global::NFCSample.Droid.Resource.Attribute.navigationViewStyle;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.numericModifiers = global::NFCSample.Droid.Resource.Attribute.numericModifiers;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.overlapAnchor = global::NFCSample.Droid.Resource.Attribute.overlapAnchor;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.paddingBottomNoButtons = global::NFCSample.Droid.Resource.Attribute.paddingBottomNoButtons;
@@ -298,6 +390,7 @@ namespace NFCSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.reverseLayout = global::NFCSample.Droid.Resource.Attribute.reverseLayout;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.rippleColor = global::NFCSample.Droid.Resource.Attribute.rippleColor;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.scrimAnimationDuration = global::NFCSample.Droid.Resource.Attribute.scrimAnimationDuration;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.scrimBackground = global::NFCSample.Droid.Resource.Attribute.scrimBackground;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.scrimVisibleHeightTrigger = global::NFCSample.Droid.Resource.Attribute.scrimVisibleHeightTrigger;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.searchHintIcon = global::NFCSample.Droid.Resource.Attribute.searchHintIcon;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.searchIcon = global::NFCSample.Droid.Resource.Attribute.searchIcon;
@@ -307,9 +400,14 @@ namespace NFCSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.selectableItemBackgroundBorderless = global::NFCSample.Droid.Resource.Attribute.selectableItemBackgroundBorderless;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.showAsAction = global::NFCSample.Droid.Resource.Attribute.showAsAction;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.showDividers = global::NFCSample.Droid.Resource.Attribute.showDividers;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.showMotionSpec = global::NFCSample.Droid.Resource.Attribute.showMotionSpec;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.showText = global::NFCSample.Droid.Resource.Attribute.showText;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.showTitle = global::NFCSample.Droid.Resource.Attribute.showTitle;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.singleChoiceItemLayout = global::NFCSample.Droid.Resource.Attribute.singleChoiceItemLayout;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.singleLine = global::NFCSample.Droid.Resource.Attribute.singleLine;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.singleSelection = global::NFCSample.Droid.Resource.Attribute.singleSelection;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.snackbarButtonStyle = global::NFCSample.Droid.Resource.Attribute.snackbarButtonStyle;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.snackbarStyle = global::NFCSample.Droid.Resource.Attribute.snackbarStyle;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.spanCount = global::NFCSample.Droid.Resource.Attribute.spanCount;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.spinBars = global::NFCSample.Droid.Resource.Attribute.spinBars;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.spinnerDropDownItemStyle = global::NFCSample.Droid.Resource.Attribute.spinnerDropDownItemStyle;
@@ -320,8 +418,12 @@ namespace NFCSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.state_above_anchor = global::NFCSample.Droid.Resource.Attribute.state_above_anchor;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.state_collapsed = global::NFCSample.Droid.Resource.Attribute.state_collapsed;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.state_collapsible = global::NFCSample.Droid.Resource.Attribute.state_collapsible;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.state_liftable = global::NFCSample.Droid.Resource.Attribute.state_liftable;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.state_lifted = global::NFCSample.Droid.Resource.Attribute.state_lifted;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.statusBarBackground = global::NFCSample.Droid.Resource.Attribute.statusBarBackground;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.statusBarScrim = global::NFCSample.Droid.Resource.Attribute.statusBarScrim;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.strokeColor = global::NFCSample.Droid.Resource.Attribute.strokeColor;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.strokeWidth = global::NFCSample.Droid.Resource.Attribute.strokeWidth;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.subMenuArrow = global::NFCSample.Droid.Resource.Attribute.subMenuArrow;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.submitBackground = global::NFCSample.Droid.Resource.Attribute.submitBackground;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.subtitle = global::NFCSample.Droid.Resource.Attribute.subtitle;
@@ -336,8 +438,15 @@ namespace NFCSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.tabBackground = global::NFCSample.Droid.Resource.Attribute.tabBackground;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.tabContentStart = global::NFCSample.Droid.Resource.Attribute.tabContentStart;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.tabGravity = global::NFCSample.Droid.Resource.Attribute.tabGravity;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.tabIconTint = global::NFCSample.Droid.Resource.Attribute.tabIconTint;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.tabIconTintMode = global::NFCSample.Droid.Resource.Attribute.tabIconTintMode;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.tabIndicator = global::NFCSample.Droid.Resource.Attribute.tabIndicator;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.tabIndicatorAnimationDuration = global::NFCSample.Droid.Resource.Attribute.tabIndicatorAnimationDuration;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.tabIndicatorColor = global::NFCSample.Droid.Resource.Attribute.tabIndicatorColor;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.tabIndicatorFullWidth = global::NFCSample.Droid.Resource.Attribute.tabIndicatorFullWidth;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.tabIndicatorGravity = global::NFCSample.Droid.Resource.Attribute.tabIndicatorGravity;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.tabIndicatorHeight = global::NFCSample.Droid.Resource.Attribute.tabIndicatorHeight;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.tabInlineLabel = global::NFCSample.Droid.Resource.Attribute.tabInlineLabel;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.tabMaxWidth = global::NFCSample.Droid.Resource.Attribute.tabMaxWidth;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.tabMinWidth = global::NFCSample.Droid.Resource.Attribute.tabMinWidth;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.tabMode = global::NFCSample.Droid.Resource.Attribute.tabMode;
@@ -346,21 +455,39 @@ namespace NFCSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.tabPaddingEnd = global::NFCSample.Droid.Resource.Attribute.tabPaddingEnd;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.tabPaddingStart = global::NFCSample.Droid.Resource.Attribute.tabPaddingStart;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.tabPaddingTop = global::NFCSample.Droid.Resource.Attribute.tabPaddingTop;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.tabRippleColor = global::NFCSample.Droid.Resource.Attribute.tabRippleColor;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.tabSelectedTextColor = global::NFCSample.Droid.Resource.Attribute.tabSelectedTextColor;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.tabStyle = global::NFCSample.Droid.Resource.Attribute.tabStyle;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.tabTextAppearance = global::NFCSample.Droid.Resource.Attribute.tabTextAppearance;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.tabTextColor = global::NFCSample.Droid.Resource.Attribute.tabTextColor;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.tabUnboundedRipple = global::NFCSample.Droid.Resource.Attribute.tabUnboundedRipple;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.textAllCaps = global::NFCSample.Droid.Resource.Attribute.textAllCaps;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.textAppearanceBody1 = global::NFCSample.Droid.Resource.Attribute.textAppearanceBody1;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.textAppearanceBody2 = global::NFCSample.Droid.Resource.Attribute.textAppearanceBody2;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.textAppearanceButton = global::NFCSample.Droid.Resource.Attribute.textAppearanceButton;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.textAppearanceCaption = global::NFCSample.Droid.Resource.Attribute.textAppearanceCaption;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.textAppearanceHeadline1 = global::NFCSample.Droid.Resource.Attribute.textAppearanceHeadline1;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.textAppearanceHeadline2 = global::NFCSample.Droid.Resource.Attribute.textAppearanceHeadline2;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.textAppearanceHeadline3 = global::NFCSample.Droid.Resource.Attribute.textAppearanceHeadline3;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.textAppearanceHeadline4 = global::NFCSample.Droid.Resource.Attribute.textAppearanceHeadline4;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.textAppearanceHeadline5 = global::NFCSample.Droid.Resource.Attribute.textAppearanceHeadline5;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.textAppearanceHeadline6 = global::NFCSample.Droid.Resource.Attribute.textAppearanceHeadline6;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.textAppearanceLargePopupMenu = global::NFCSample.Droid.Resource.Attribute.textAppearanceLargePopupMenu;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.textAppearanceListItem = global::NFCSample.Droid.Resource.Attribute.textAppearanceListItem;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.textAppearanceListItemSecondary = global::NFCSample.Droid.Resource.Attribute.textAppearanceListItemSecondary;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.textAppearanceListItemSmall = global::NFCSample.Droid.Resource.Attribute.textAppearanceListItemSmall;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.textAppearanceOverline = global::NFCSample.Droid.Resource.Attribute.textAppearanceOverline;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.textAppearancePopupMenuHeader = global::NFCSample.Droid.Resource.Attribute.textAppearancePopupMenuHeader;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.textAppearanceSearchResultSubtitle = global::NFCSample.Droid.Resource.Attribute.textAppearanceSearchResultSubtitle;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.textAppearanceSearchResultTitle = global::NFCSample.Droid.Resource.Attribute.textAppearanceSearchResultTitle;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.textAppearanceSmallPopupMenu = global::NFCSample.Droid.Resource.Attribute.textAppearanceSmallPopupMenu;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.textAppearanceSubtitle1 = global::NFCSample.Droid.Resource.Attribute.textAppearanceSubtitle1;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.textAppearanceSubtitle2 = global::NFCSample.Droid.Resource.Attribute.textAppearanceSubtitle2;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.textColorAlertDialogListItem = global::NFCSample.Droid.Resource.Attribute.textColorAlertDialogListItem;
-			global::Xamarin.Forms.Platform.Android.Resource.Attribute.textColorError = global::NFCSample.Droid.Resource.Attribute.textColorError;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.textColorSearchUrl = global::NFCSample.Droid.Resource.Attribute.textColorSearchUrl;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.textEndPadding = global::NFCSample.Droid.Resource.Attribute.textEndPadding;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.textInputStyle = global::NFCSample.Droid.Resource.Attribute.textInputStyle;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.textStartPadding = global::NFCSample.Droid.Resource.Attribute.textStartPadding;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.theme = global::NFCSample.Droid.Resource.Attribute.theme;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.thickness = global::NFCSample.Droid.Resource.Attribute.thickness;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.thumbTextPadding = global::NFCSample.Droid.Resource.Attribute.thumbTextPadding;
@@ -391,7 +518,9 @@ namespace NFCSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.track = global::NFCSample.Droid.Resource.Attribute.track;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.trackTint = global::NFCSample.Droid.Resource.Attribute.trackTint;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.trackTintMode = global::NFCSample.Droid.Resource.Attribute.trackTintMode;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.ttcIndex = global::NFCSample.Droid.Resource.Attribute.ttcIndex;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.useCompatPadding = global::NFCSample.Droid.Resource.Attribute.useCompatPadding;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.viewInflaterClass = global::NFCSample.Droid.Resource.Attribute.viewInflaterClass;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.voiceIcon = global::NFCSample.Droid.Resource.Attribute.voiceIcon;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.windowActionBar = global::NFCSample.Droid.Resource.Attribute.windowActionBar;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.windowActionBarOverlay = global::NFCSample.Droid.Resource.Attribute.windowActionBarOverlay;
@@ -406,8 +535,7 @@ namespace NFCSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Boolean.abc_action_bar_embed_tabs = global::NFCSample.Droid.Resource.Boolean.abc_action_bar_embed_tabs;
 			global::Xamarin.Forms.Platform.Android.Resource.Boolean.abc_allow_stacked_button_bar = global::NFCSample.Droid.Resource.Boolean.abc_allow_stacked_button_bar;
 			global::Xamarin.Forms.Platform.Android.Resource.Boolean.abc_config_actionMenuItemAllCaps = global::NFCSample.Droid.Resource.Boolean.abc_config_actionMenuItemAllCaps;
-			global::Xamarin.Forms.Platform.Android.Resource.Boolean.abc_config_closeDialogWhenTouchOutside = global::NFCSample.Droid.Resource.Boolean.abc_config_closeDialogWhenTouchOutside;
-			global::Xamarin.Forms.Platform.Android.Resource.Boolean.abc_config_showMenuShortcutsWhenKeyboardPresent = global::NFCSample.Droid.Resource.Boolean.abc_config_showMenuShortcutsWhenKeyboardPresent;
+			global::Xamarin.Forms.Platform.Android.Resource.Boolean.mtrl_btn_textappearance_all_caps = global::NFCSample.Droid.Resource.Boolean.mtrl_btn_textappearance_all_caps;
 			global::Xamarin.Forms.Platform.Android.Resource.Color.abc_background_cache_hint_selector_material_dark = global::NFCSample.Droid.Resource.Color.abc_background_cache_hint_selector_material_dark;
 			global::Xamarin.Forms.Platform.Android.Resource.Color.abc_background_cache_hint_selector_material_light = global::NFCSample.Droid.Resource.Color.abc_background_cache_hint_selector_material_light;
 			global::Xamarin.Forms.Platform.Android.Resource.Color.abc_btn_colored_borderless_text_material = global::NFCSample.Droid.Resource.Color.abc_btn_colored_borderless_text_material;
@@ -451,6 +579,8 @@ namespace NFCSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Color.cardview_shadow_end_color = global::NFCSample.Droid.Resource.Color.cardview_shadow_end_color;
 			global::Xamarin.Forms.Platform.Android.Resource.Color.cardview_shadow_start_color = global::NFCSample.Droid.Resource.Color.cardview_shadow_start_color;
 			global::Xamarin.Forms.Platform.Android.Resource.Color.design_bottom_navigation_shadow_color = global::NFCSample.Droid.Resource.Color.design_bottom_navigation_shadow_color;
+			global::Xamarin.Forms.Platform.Android.Resource.Color.design_default_color_primary = global::NFCSample.Droid.Resource.Color.design_default_color_primary;
+			global::Xamarin.Forms.Platform.Android.Resource.Color.design_default_color_primary_dark = global::NFCSample.Droid.Resource.Color.design_default_color_primary_dark;
 			global::Xamarin.Forms.Platform.Android.Resource.Color.design_error = global::NFCSample.Droid.Resource.Color.design_error;
 			global::Xamarin.Forms.Platform.Android.Resource.Color.design_fab_shadow_end_color = global::NFCSample.Droid.Resource.Color.design_fab_shadow_end_color;
 			global::Xamarin.Forms.Platform.Android.Resource.Color.design_fab_shadow_mid_color = global::NFCSample.Droid.Resource.Color.design_fab_shadow_mid_color;
@@ -465,7 +595,8 @@ namespace NFCSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Color.dim_foreground_disabled_material_light = global::NFCSample.Droid.Resource.Color.dim_foreground_disabled_material_light;
 			global::Xamarin.Forms.Platform.Android.Resource.Color.dim_foreground_material_dark = global::NFCSample.Droid.Resource.Color.dim_foreground_material_dark;
 			global::Xamarin.Forms.Platform.Android.Resource.Color.dim_foreground_material_light = global::NFCSample.Droid.Resource.Color.dim_foreground_material_light;
-			global::Xamarin.Forms.Platform.Android.Resource.Color.error_color_material = global::NFCSample.Droid.Resource.Color.error_color_material;
+			global::Xamarin.Forms.Platform.Android.Resource.Color.error_color_material_dark = global::NFCSample.Droid.Resource.Color.error_color_material_dark;
+			global::Xamarin.Forms.Platform.Android.Resource.Color.error_color_material_light = global::NFCSample.Droid.Resource.Color.error_color_material_light;
 			global::Xamarin.Forms.Platform.Android.Resource.Color.foreground_material_dark = global::NFCSample.Droid.Resource.Color.foreground_material_dark;
 			global::Xamarin.Forms.Platform.Android.Resource.Color.foreground_material_light = global::NFCSample.Droid.Resource.Color.foreground_material_light;
 			global::Xamarin.Forms.Platform.Android.Resource.Color.highlighted_text_material_dark = global::NFCSample.Droid.Resource.Color.highlighted_text_material_dark;
@@ -482,6 +613,32 @@ namespace NFCSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Color.material_grey_800 = global::NFCSample.Droid.Resource.Color.material_grey_800;
 			global::Xamarin.Forms.Platform.Android.Resource.Color.material_grey_850 = global::NFCSample.Droid.Resource.Color.material_grey_850;
 			global::Xamarin.Forms.Platform.Android.Resource.Color.material_grey_900 = global::NFCSample.Droid.Resource.Color.material_grey_900;
+			global::Xamarin.Forms.Platform.Android.Resource.Color.mtrl_bottom_nav_colored_item_tint = global::NFCSample.Droid.Resource.Color.mtrl_bottom_nav_colored_item_tint;
+			global::Xamarin.Forms.Platform.Android.Resource.Color.mtrl_bottom_nav_item_tint = global::NFCSample.Droid.Resource.Color.mtrl_bottom_nav_item_tint;
+			global::Xamarin.Forms.Platform.Android.Resource.Color.mtrl_btn_bg_color_disabled = global::NFCSample.Droid.Resource.Color.mtrl_btn_bg_color_disabled;
+			global::Xamarin.Forms.Platform.Android.Resource.Color.mtrl_btn_bg_color_selector = global::NFCSample.Droid.Resource.Color.mtrl_btn_bg_color_selector;
+			global::Xamarin.Forms.Platform.Android.Resource.Color.mtrl_btn_ripple_color = global::NFCSample.Droid.Resource.Color.mtrl_btn_ripple_color;
+			global::Xamarin.Forms.Platform.Android.Resource.Color.mtrl_btn_stroke_color_selector = global::NFCSample.Droid.Resource.Color.mtrl_btn_stroke_color_selector;
+			global::Xamarin.Forms.Platform.Android.Resource.Color.mtrl_btn_text_btn_ripple_color = global::NFCSample.Droid.Resource.Color.mtrl_btn_text_btn_ripple_color;
+			global::Xamarin.Forms.Platform.Android.Resource.Color.mtrl_btn_text_color_disabled = global::NFCSample.Droid.Resource.Color.mtrl_btn_text_color_disabled;
+			global::Xamarin.Forms.Platform.Android.Resource.Color.mtrl_btn_text_color_selector = global::NFCSample.Droid.Resource.Color.mtrl_btn_text_color_selector;
+			global::Xamarin.Forms.Platform.Android.Resource.Color.mtrl_btn_transparent_bg_color = global::NFCSample.Droid.Resource.Color.mtrl_btn_transparent_bg_color;
+			global::Xamarin.Forms.Platform.Android.Resource.Color.mtrl_chip_background_color = global::NFCSample.Droid.Resource.Color.mtrl_chip_background_color;
+			global::Xamarin.Forms.Platform.Android.Resource.Color.mtrl_chip_close_icon_tint = global::NFCSample.Droid.Resource.Color.mtrl_chip_close_icon_tint;
+			global::Xamarin.Forms.Platform.Android.Resource.Color.mtrl_chip_ripple_color = global::NFCSample.Droid.Resource.Color.mtrl_chip_ripple_color;
+			global::Xamarin.Forms.Platform.Android.Resource.Color.mtrl_chip_text_color = global::NFCSample.Droid.Resource.Color.mtrl_chip_text_color;
+			global::Xamarin.Forms.Platform.Android.Resource.Color.mtrl_fab_ripple_color = global::NFCSample.Droid.Resource.Color.mtrl_fab_ripple_color;
+			global::Xamarin.Forms.Platform.Android.Resource.Color.mtrl_scrim_color = global::NFCSample.Droid.Resource.Color.mtrl_scrim_color;
+			global::Xamarin.Forms.Platform.Android.Resource.Color.mtrl_tabs_colored_ripple_color = global::NFCSample.Droid.Resource.Color.mtrl_tabs_colored_ripple_color;
+			global::Xamarin.Forms.Platform.Android.Resource.Color.mtrl_tabs_icon_color_selector = global::NFCSample.Droid.Resource.Color.mtrl_tabs_icon_color_selector;
+			global::Xamarin.Forms.Platform.Android.Resource.Color.mtrl_tabs_icon_color_selector_colored = global::NFCSample.Droid.Resource.Color.mtrl_tabs_icon_color_selector_colored;
+			global::Xamarin.Forms.Platform.Android.Resource.Color.mtrl_tabs_legacy_text_color_selector = global::NFCSample.Droid.Resource.Color.mtrl_tabs_legacy_text_color_selector;
+			global::Xamarin.Forms.Platform.Android.Resource.Color.mtrl_tabs_ripple_color = global::NFCSample.Droid.Resource.Color.mtrl_tabs_ripple_color;
+			global::Xamarin.Forms.Platform.Android.Resource.Color.mtrl_text_btn_text_color_selector = global::NFCSample.Droid.Resource.Color.mtrl_text_btn_text_color_selector;
+			global::Xamarin.Forms.Platform.Android.Resource.Color.mtrl_textinput_default_box_stroke_color = global::NFCSample.Droid.Resource.Color.mtrl_textinput_default_box_stroke_color;
+			global::Xamarin.Forms.Platform.Android.Resource.Color.mtrl_textinput_disabled_color = global::NFCSample.Droid.Resource.Color.mtrl_textinput_disabled_color;
+			global::Xamarin.Forms.Platform.Android.Resource.Color.mtrl_textinput_filled_box_default_background_color = global::NFCSample.Droid.Resource.Color.mtrl_textinput_filled_box_default_background_color;
+			global::Xamarin.Forms.Platform.Android.Resource.Color.mtrl_textinput_hovered_box_stroke_color = global::NFCSample.Droid.Resource.Color.mtrl_textinput_hovered_box_stroke_color;
 			global::Xamarin.Forms.Platform.Android.Resource.Color.notification_action_color_filter = global::NFCSample.Droid.Resource.Color.notification_action_color_filter;
 			global::Xamarin.Forms.Platform.Android.Resource.Color.notification_icon_bg_color = global::NFCSample.Droid.Resource.Color.notification_icon_bg_color;
 			global::Xamarin.Forms.Platform.Android.Resource.Color.notification_material_background_media_default_color = global::NFCSample.Droid.Resource.Color.notification_material_background_media_default_color;
@@ -516,7 +673,6 @@ namespace NFCSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.abc_action_bar_icon_vertical_padding_material = global::NFCSample.Droid.Resource.Dimension.abc_action_bar_icon_vertical_padding_material;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.abc_action_bar_overflow_padding_end_material = global::NFCSample.Droid.Resource.Dimension.abc_action_bar_overflow_padding_end_material;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.abc_action_bar_overflow_padding_start_material = global::NFCSample.Droid.Resource.Dimension.abc_action_bar_overflow_padding_start_material;
-			global::Xamarin.Forms.Platform.Android.Resource.Dimension.abc_action_bar_progress_bar_size = global::NFCSample.Droid.Resource.Dimension.abc_action_bar_progress_bar_size;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.abc_action_bar_stacked_max_height = global::NFCSample.Droid.Resource.Dimension.abc_action_bar_stacked_max_height;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.abc_action_bar_stacked_tab_max_width = global::NFCSample.Droid.Resource.Dimension.abc_action_bar_stacked_tab_max_width;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.abc_action_bar_subtitle_bottom_margin_material = global::NFCSample.Droid.Resource.Dimension.abc_action_bar_subtitle_bottom_margin_material;
@@ -525,6 +681,7 @@ namespace NFCSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.abc_action_button_min_width_material = global::NFCSample.Droid.Resource.Dimension.abc_action_button_min_width_material;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.abc_action_button_min_width_overflow_material = global::NFCSample.Droid.Resource.Dimension.abc_action_button_min_width_overflow_material;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.abc_alert_dialog_button_bar_height = global::NFCSample.Droid.Resource.Dimension.abc_alert_dialog_button_bar_height;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.abc_alert_dialog_button_dimen = global::NFCSample.Droid.Resource.Dimension.abc_alert_dialog_button_dimen;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.abc_button_inset_horizontal_material = global::NFCSample.Droid.Resource.Dimension.abc_button_inset_horizontal_material;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.abc_button_inset_vertical_material = global::NFCSample.Droid.Resource.Dimension.abc_button_inset_vertical_material;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.abc_button_padding_horizontal_material = global::NFCSample.Droid.Resource.Dimension.abc_button_padding_horizontal_material;
@@ -534,6 +691,7 @@ namespace NFCSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.abc_control_corner_material = global::NFCSample.Droid.Resource.Dimension.abc_control_corner_material;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.abc_control_inset_material = global::NFCSample.Droid.Resource.Dimension.abc_control_inset_material;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.abc_control_padding_material = global::NFCSample.Droid.Resource.Dimension.abc_control_padding_material;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.abc_dialog_corner_radius_material = global::NFCSample.Droid.Resource.Dimension.abc_dialog_corner_radius_material;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.abc_dialog_fixed_height_major = global::NFCSample.Droid.Resource.Dimension.abc_dialog_fixed_height_major;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.abc_dialog_fixed_height_minor = global::NFCSample.Droid.Resource.Dimension.abc_dialog_fixed_height_minor;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.abc_dialog_fixed_width_major = global::NFCSample.Droid.Resource.Dimension.abc_dialog_fixed_width_major;
@@ -589,11 +747,15 @@ namespace NFCSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.compat_button_padding_horizontal_material = global::NFCSample.Droid.Resource.Dimension.compat_button_padding_horizontal_material;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.compat_button_padding_vertical_material = global::NFCSample.Droid.Resource.Dimension.compat_button_padding_vertical_material;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.compat_control_corner_material = global::NFCSample.Droid.Resource.Dimension.compat_control_corner_material;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.compat_notification_large_icon_max_height = global::NFCSample.Droid.Resource.Dimension.compat_notification_large_icon_max_height;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.compat_notification_large_icon_max_width = global::NFCSample.Droid.Resource.Dimension.compat_notification_large_icon_max_width;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.design_appbar_elevation = global::NFCSample.Droid.Resource.Dimension.design_appbar_elevation;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.design_bottom_navigation_active_item_max_width = global::NFCSample.Droid.Resource.Dimension.design_bottom_navigation_active_item_max_width;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.design_bottom_navigation_active_item_min_width = global::NFCSample.Droid.Resource.Dimension.design_bottom_navigation_active_item_min_width;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.design_bottom_navigation_active_text_size = global::NFCSample.Droid.Resource.Dimension.design_bottom_navigation_active_text_size;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.design_bottom_navigation_elevation = global::NFCSample.Droid.Resource.Dimension.design_bottom_navigation_elevation;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.design_bottom_navigation_height = global::NFCSample.Droid.Resource.Dimension.design_bottom_navigation_height;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.design_bottom_navigation_icon_size = global::NFCSample.Droid.Resource.Dimension.design_bottom_navigation_icon_size;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.design_bottom_navigation_item_max_width = global::NFCSample.Droid.Resource.Dimension.design_bottom_navigation_item_max_width;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.design_bottom_navigation_item_min_width = global::NFCSample.Droid.Resource.Dimension.design_bottom_navigation_item_min_width;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.design_bottom_navigation_margin = global::NFCSample.Droid.Resource.Dimension.design_bottom_navigation_margin;
@@ -606,10 +768,13 @@ namespace NFCSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.design_fab_image_size = global::NFCSample.Droid.Resource.Dimension.design_fab_image_size;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.design_fab_size_mini = global::NFCSample.Droid.Resource.Dimension.design_fab_size_mini;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.design_fab_size_normal = global::NFCSample.Droid.Resource.Dimension.design_fab_size_normal;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.design_fab_translation_z_hovered_focused = global::NFCSample.Droid.Resource.Dimension.design_fab_translation_z_hovered_focused;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.design_fab_translation_z_pressed = global::NFCSample.Droid.Resource.Dimension.design_fab_translation_z_pressed;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.design_navigation_elevation = global::NFCSample.Droid.Resource.Dimension.design_navigation_elevation;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.design_navigation_icon_padding = global::NFCSample.Droid.Resource.Dimension.design_navigation_icon_padding;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.design_navigation_icon_size = global::NFCSample.Droid.Resource.Dimension.design_navigation_icon_size;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.design_navigation_item_horizontal_padding = global::NFCSample.Droid.Resource.Dimension.design_navigation_item_horizontal_padding;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.design_navigation_item_icon_padding = global::NFCSample.Droid.Resource.Dimension.design_navigation_item_icon_padding;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.design_navigation_max_width = global::NFCSample.Droid.Resource.Dimension.design_navigation_max_width;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.design_navigation_padding_bottom = global::NFCSample.Droid.Resource.Dimension.design_navigation_padding_bottom;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.design_navigation_separator_vertical_padding = global::NFCSample.Droid.Resource.Dimension.design_navigation_separator_vertical_padding;
@@ -627,6 +792,7 @@ namespace NFCSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.design_tab_scrollable_min_width = global::NFCSample.Droid.Resource.Dimension.design_tab_scrollable_min_width;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.design_tab_text_size = global::NFCSample.Droid.Resource.Dimension.design_tab_text_size;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.design_tab_text_size_2line = global::NFCSample.Droid.Resource.Dimension.design_tab_text_size_2line;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.design_textinput_caption_translate_y = global::NFCSample.Droid.Resource.Dimension.design_textinput_caption_translate_y;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.disabled_alpha_material_dark = global::NFCSample.Droid.Resource.Dimension.disabled_alpha_material_dark;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.disabled_alpha_material_light = global::NFCSample.Droid.Resource.Dimension.disabled_alpha_material_light;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.fastscroll_default_thickness = global::NFCSample.Droid.Resource.Dimension.fastscroll_default_thickness;
@@ -642,6 +808,54 @@ namespace NFCSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.item_touch_helper_max_drag_scroll_per_frame = global::NFCSample.Droid.Resource.Dimension.item_touch_helper_max_drag_scroll_per_frame;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.item_touch_helper_swipe_escape_max_velocity = global::NFCSample.Droid.Resource.Dimension.item_touch_helper_swipe_escape_max_velocity;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.item_touch_helper_swipe_escape_velocity = global::NFCSample.Droid.Resource.Dimension.item_touch_helper_swipe_escape_velocity;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_bottomappbar_fabOffsetEndMode = global::NFCSample.Droid.Resource.Dimension.mtrl_bottomappbar_fabOffsetEndMode;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_bottomappbar_fab_cradle_margin = global::NFCSample.Droid.Resource.Dimension.mtrl_bottomappbar_fab_cradle_margin;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_bottomappbar_fab_cradle_rounded_corner_radius = global::NFCSample.Droid.Resource.Dimension.mtrl_bottomappbar_fab_cradle_rounded_corner_radius;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_bottomappbar_fab_cradle_vertical_offset = global::NFCSample.Droid.Resource.Dimension.mtrl_bottomappbar_fab_cradle_vertical_offset;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_bottomappbar_height = global::NFCSample.Droid.Resource.Dimension.mtrl_bottomappbar_height;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_btn_corner_radius = global::NFCSample.Droid.Resource.Dimension.mtrl_btn_corner_radius;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_btn_dialog_btn_min_width = global::NFCSample.Droid.Resource.Dimension.mtrl_btn_dialog_btn_min_width;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_btn_disabled_elevation = global::NFCSample.Droid.Resource.Dimension.mtrl_btn_disabled_elevation;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_btn_disabled_z = global::NFCSample.Droid.Resource.Dimension.mtrl_btn_disabled_z;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_btn_elevation = global::NFCSample.Droid.Resource.Dimension.mtrl_btn_elevation;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_btn_focused_z = global::NFCSample.Droid.Resource.Dimension.mtrl_btn_focused_z;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_btn_hovered_z = global::NFCSample.Droid.Resource.Dimension.mtrl_btn_hovered_z;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_btn_icon_btn_padding_left = global::NFCSample.Droid.Resource.Dimension.mtrl_btn_icon_btn_padding_left;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_btn_icon_padding = global::NFCSample.Droid.Resource.Dimension.mtrl_btn_icon_padding;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_btn_inset = global::NFCSample.Droid.Resource.Dimension.mtrl_btn_inset;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_btn_letter_spacing = global::NFCSample.Droid.Resource.Dimension.mtrl_btn_letter_spacing;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_btn_padding_bottom = global::NFCSample.Droid.Resource.Dimension.mtrl_btn_padding_bottom;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_btn_padding_left = global::NFCSample.Droid.Resource.Dimension.mtrl_btn_padding_left;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_btn_padding_right = global::NFCSample.Droid.Resource.Dimension.mtrl_btn_padding_right;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_btn_padding_top = global::NFCSample.Droid.Resource.Dimension.mtrl_btn_padding_top;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_btn_pressed_z = global::NFCSample.Droid.Resource.Dimension.mtrl_btn_pressed_z;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_btn_stroke_size = global::NFCSample.Droid.Resource.Dimension.mtrl_btn_stroke_size;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_btn_text_btn_icon_padding = global::NFCSample.Droid.Resource.Dimension.mtrl_btn_text_btn_icon_padding;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_btn_text_btn_padding_left = global::NFCSample.Droid.Resource.Dimension.mtrl_btn_text_btn_padding_left;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_btn_text_btn_padding_right = global::NFCSample.Droid.Resource.Dimension.mtrl_btn_text_btn_padding_right;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_btn_text_size = global::NFCSample.Droid.Resource.Dimension.mtrl_btn_text_size;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_btn_z = global::NFCSample.Droid.Resource.Dimension.mtrl_btn_z;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_card_elevation = global::NFCSample.Droid.Resource.Dimension.mtrl_card_elevation;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_card_spacing = global::NFCSample.Droid.Resource.Dimension.mtrl_card_spacing;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_chip_pressed_translation_z = global::NFCSample.Droid.Resource.Dimension.mtrl_chip_pressed_translation_z;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_chip_text_size = global::NFCSample.Droid.Resource.Dimension.mtrl_chip_text_size;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_fab_elevation = global::NFCSample.Droid.Resource.Dimension.mtrl_fab_elevation;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_fab_translation_z_hovered_focused = global::NFCSample.Droid.Resource.Dimension.mtrl_fab_translation_z_hovered_focused;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_fab_translation_z_pressed = global::NFCSample.Droid.Resource.Dimension.mtrl_fab_translation_z_pressed;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_navigation_elevation = global::NFCSample.Droid.Resource.Dimension.mtrl_navigation_elevation;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_navigation_item_horizontal_padding = global::NFCSample.Droid.Resource.Dimension.mtrl_navigation_item_horizontal_padding;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_navigation_item_icon_padding = global::NFCSample.Droid.Resource.Dimension.mtrl_navigation_item_icon_padding;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_snackbar_background_corner_radius = global::NFCSample.Droid.Resource.Dimension.mtrl_snackbar_background_corner_radius;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_snackbar_margin = global::NFCSample.Droid.Resource.Dimension.mtrl_snackbar_margin;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_textinput_box_bottom_offset = global::NFCSample.Droid.Resource.Dimension.mtrl_textinput_box_bottom_offset;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_textinput_box_corner_radius_medium = global::NFCSample.Droid.Resource.Dimension.mtrl_textinput_box_corner_radius_medium;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_textinput_box_corner_radius_small = global::NFCSample.Droid.Resource.Dimension.mtrl_textinput_box_corner_radius_small;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_textinput_box_label_cutout_padding = global::NFCSample.Droid.Resource.Dimension.mtrl_textinput_box_label_cutout_padding;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_textinput_box_padding_end = global::NFCSample.Droid.Resource.Dimension.mtrl_textinput_box_padding_end;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_textinput_box_stroke_width_default = global::NFCSample.Droid.Resource.Dimension.mtrl_textinput_box_stroke_width_default;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_textinput_box_stroke_width_focused = global::NFCSample.Droid.Resource.Dimension.mtrl_textinput_box_stroke_width_focused;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_textinput_outline_box_expanded_padding = global::NFCSample.Droid.Resource.Dimension.mtrl_textinput_outline_box_expanded_padding;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_toolbar_default_height = global::NFCSample.Droid.Resource.Dimension.mtrl_toolbar_default_height;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.notification_action_icon_size = global::NFCSample.Droid.Resource.Dimension.notification_action_icon_size;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.notification_action_text_size = global::NFCSample.Droid.Resource.Dimension.notification_action_text_size;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.notification_big_circle_margin = global::NFCSample.Droid.Resource.Dimension.notification_big_circle_margin;
@@ -657,6 +871,10 @@ namespace NFCSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.notification_subtext_size = global::NFCSample.Droid.Resource.Dimension.notification_subtext_size;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.notification_top_pad = global::NFCSample.Droid.Resource.Dimension.notification_top_pad;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.notification_top_pad_large_text = global::NFCSample.Droid.Resource.Dimension.notification_top_pad_large_text;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.subtitle_corner_radius = global::NFCSample.Droid.Resource.Dimension.subtitle_corner_radius;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.subtitle_outline_width = global::NFCSample.Droid.Resource.Dimension.subtitle_outline_width;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.subtitle_shadow_offset = global::NFCSample.Droid.Resource.Dimension.subtitle_shadow_offset;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.subtitle_shadow_radius = global::NFCSample.Droid.Resource.Dimension.subtitle_shadow_radius;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.tooltip_corner_radius = global::NFCSample.Droid.Resource.Dimension.tooltip_corner_radius;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.tooltip_horizontal_padding = global::NFCSample.Droid.Resource.Dimension.tooltip_horizontal_padding;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.tooltip_margin = global::NFCSample.Droid.Resource.Dimension.tooltip_margin;
@@ -705,6 +923,7 @@ namespace NFCSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Drawable.abc_ic_voice_search_api_material = global::NFCSample.Droid.Resource.Drawable.abc_ic_voice_search_api_material;
 			global::Xamarin.Forms.Platform.Android.Resource.Drawable.abc_item_background_holo_dark = global::NFCSample.Droid.Resource.Drawable.abc_item_background_holo_dark;
 			global::Xamarin.Forms.Platform.Android.Resource.Drawable.abc_item_background_holo_light = global::NFCSample.Droid.Resource.Drawable.abc_item_background_holo_light;
+			global::Xamarin.Forms.Platform.Android.Resource.Drawable.abc_list_divider_material = global::NFCSample.Droid.Resource.Drawable.abc_list_divider_material;
 			global::Xamarin.Forms.Platform.Android.Resource.Drawable.abc_list_divider_mtrl_alpha = global::NFCSample.Droid.Resource.Drawable.abc_list_divider_mtrl_alpha;
 			global::Xamarin.Forms.Platform.Android.Resource.Drawable.abc_list_focused_holo = global::NFCSample.Droid.Resource.Drawable.abc_list_focused_holo;
 			global::Xamarin.Forms.Platform.Android.Resource.Drawable.abc_list_longpressed_holo = global::NFCSample.Droid.Resource.Drawable.abc_list_longpressed_holo;
@@ -756,6 +975,11 @@ namespace NFCSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Drawable.design_ic_visibility_off = global::NFCSample.Droid.Resource.Drawable.design_ic_visibility_off;
 			global::Xamarin.Forms.Platform.Android.Resource.Drawable.design_password_eye = global::NFCSample.Droid.Resource.Drawable.design_password_eye;
 			global::Xamarin.Forms.Platform.Android.Resource.Drawable.design_snackbar_background = global::NFCSample.Droid.Resource.Drawable.design_snackbar_background;
+			global::Xamarin.Forms.Platform.Android.Resource.Drawable.ic_mtrl_chip_checked_black = global::NFCSample.Droid.Resource.Drawable.ic_mtrl_chip_checked_black;
+			global::Xamarin.Forms.Platform.Android.Resource.Drawable.ic_mtrl_chip_checked_circle = global::NFCSample.Droid.Resource.Drawable.ic_mtrl_chip_checked_circle;
+			global::Xamarin.Forms.Platform.Android.Resource.Drawable.ic_mtrl_chip_close_circle = global::NFCSample.Droid.Resource.Drawable.ic_mtrl_chip_close_circle;
+			global::Xamarin.Forms.Platform.Android.Resource.Drawable.mtrl_snackbar_background = global::NFCSample.Droid.Resource.Drawable.mtrl_snackbar_background;
+			global::Xamarin.Forms.Platform.Android.Resource.Drawable.mtrl_tabs_default_indicator = global::NFCSample.Droid.Resource.Drawable.mtrl_tabs_default_indicator;
 			global::Xamarin.Forms.Platform.Android.Resource.Drawable.navigation_empty_icon = global::NFCSample.Droid.Resource.Drawable.navigation_empty_icon;
 			global::Xamarin.Forms.Platform.Android.Resource.Drawable.notification_action_background = global::NFCSample.Droid.Resource.Drawable.notification_action_background;
 			global::Xamarin.Forms.Platform.Android.Resource.Drawable.notification_bg = global::NFCSample.Droid.Resource.Drawable.notification_bg;
@@ -819,6 +1043,7 @@ namespace NFCSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Id.clip_vertical = global::NFCSample.Droid.Resource.Id.clip_vertical;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.collapseActionView = global::NFCSample.Droid.Resource.Id.collapseActionView;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.container = global::NFCSample.Droid.Resource.Id.container;
+			global::Xamarin.Forms.Platform.Android.Resource.Id.content = global::NFCSample.Droid.Resource.Id.content;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.contentPanel = global::NFCSample.Droid.Resource.Id.contentPanel;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.coordinator = global::NFCSample.Droid.Resource.Id.coordinator;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.custom = global::NFCSample.Droid.Resource.Id.custom;
@@ -842,11 +1067,13 @@ namespace NFCSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Id.fill = global::NFCSample.Droid.Resource.Id.fill;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.fill_horizontal = global::NFCSample.Droid.Resource.Id.fill_horizontal;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.fill_vertical = global::NFCSample.Droid.Resource.Id.fill_vertical;
+			global::Xamarin.Forms.Platform.Android.Resource.Id.filled = global::NFCSample.Droid.Resource.Id.filled;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.@fixed = global::NFCSample.Droid.Resource.Id.@fixed;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.flyoutcontent_appbar = global::NFCSample.Droid.Resource.Id.flyoutcontent_appbar;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.flyoutcontent_recycler = global::NFCSample.Droid.Resource.Id.flyoutcontent_recycler;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.forever = global::NFCSample.Droid.Resource.Id.forever;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.ghost_view = global::NFCSample.Droid.Resource.Id.ghost_view;
+			global::Xamarin.Forms.Platform.Android.Resource.Id.group_divider = global::NFCSample.Droid.Resource.Id.group_divider;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.home = global::NFCSample.Droid.Resource.Id.home;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.homeAsUp = global::NFCSample.Droid.Resource.Id.homeAsUp;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.icon = global::NFCSample.Droid.Resource.Id.icon;
@@ -856,6 +1083,7 @@ namespace NFCSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Id.info = global::NFCSample.Droid.Resource.Id.info;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.italic = global::NFCSample.Droid.Resource.Id.italic;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.item_touch_helper_previous_elevation = global::NFCSample.Droid.Resource.Id.item_touch_helper_previous_elevation;
+			global::Xamarin.Forms.Platform.Android.Resource.Id.labeled = global::NFCSample.Droid.Resource.Id.labeled;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.largeLabel = global::NFCSample.Droid.Resource.Id.largeLabel;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.left = global::NFCSample.Droid.Resource.Id.left;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.line1 = global::NFCSample.Droid.Resource.Id.line1;
@@ -871,6 +1099,8 @@ namespace NFCSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Id.message = global::NFCSample.Droid.Resource.Id.message;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.middle = global::NFCSample.Droid.Resource.Id.middle;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.mini = global::NFCSample.Droid.Resource.Id.mini;
+			global::Xamarin.Forms.Platform.Android.Resource.Id.mtrl_child_content_container = global::NFCSample.Droid.Resource.Id.mtrl_child_content_container;
+			global::Xamarin.Forms.Platform.Android.Resource.Id.mtrl_internal_children_alpha_tag = global::NFCSample.Droid.Resource.Id.mtrl_internal_children_alpha_tag;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.multiply = global::NFCSample.Droid.Resource.Id.multiply;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.navigation_header_container = global::NFCSample.Droid.Resource.Id.navigation_header_container;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.never = global::NFCSample.Droid.Resource.Id.never;
@@ -879,6 +1109,7 @@ namespace NFCSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Id.notification_background = global::NFCSample.Droid.Resource.Id.notification_background;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.notification_main_column = global::NFCSample.Droid.Resource.Id.notification_main_column;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.notification_main_column_container = global::NFCSample.Droid.Resource.Id.notification_main_column_container;
+			global::Xamarin.Forms.Platform.Android.Resource.Id.outline = global::NFCSample.Droid.Resource.Id.outline;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.parallax = global::NFCSample.Droid.Resource.Id.parallax;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.parentPanel = global::NFCSample.Droid.Resource.Id.parentPanel;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.parent_matrix = global::NFCSample.Droid.Resource.Id.parent_matrix;
@@ -909,6 +1140,7 @@ namespace NFCSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Id.search_src_text = global::NFCSample.Droid.Resource.Id.search_src_text;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.search_voice_btn = global::NFCSample.Droid.Resource.Id.search_voice_btn;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.select_dialog_listview = global::NFCSample.Droid.Resource.Id.select_dialog_listview;
+			global::Xamarin.Forms.Platform.Android.Resource.Id.selected = global::NFCSample.Droid.Resource.Id.selected;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.shellcontent_appbar = global::NFCSample.Droid.Resource.Id.shellcontent_appbar;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.shellcontent_toolbar = global::NFCSample.Droid.Resource.Id.shellcontent_toolbar;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.shortcut = global::NFCSample.Droid.Resource.Id.shortcut;
@@ -919,6 +1151,7 @@ namespace NFCSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Id.snackbar_action = global::NFCSample.Droid.Resource.Id.snackbar_action;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.snackbar_text = global::NFCSample.Droid.Resource.Id.snackbar_text;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.snap = global::NFCSample.Droid.Resource.Id.snap;
+			global::Xamarin.Forms.Platform.Android.Resource.Id.snapMargins = global::NFCSample.Droid.Resource.Id.snapMargins;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.spacer = global::NFCSample.Droid.Resource.Id.spacer;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.split_action_bar = global::NFCSample.Droid.Resource.Id.split_action_bar;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.src_atop = global::NFCSample.Droid.Resource.Id.src_atop;
@@ -926,17 +1159,22 @@ namespace NFCSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Id.src_over = global::NFCSample.Droid.Resource.Id.src_over;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.start = global::NFCSample.Droid.Resource.Id.start;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.status_bar_latest_event_content = global::NFCSample.Droid.Resource.Id.status_bar_latest_event_content;
+			global::Xamarin.Forms.Platform.Android.Resource.Id.stretch = global::NFCSample.Droid.Resource.Id.stretch;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.submenuarrow = global::NFCSample.Droid.Resource.Id.submenuarrow;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.submit_area = global::NFCSample.Droid.Resource.Id.submit_area;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.tabMode = global::NFCSample.Droid.Resource.Id.tabMode;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.tag_transition_group = global::NFCSample.Droid.Resource.Id.tag_transition_group;
+			global::Xamarin.Forms.Platform.Android.Resource.Id.tag_unhandled_key_event_manager = global::NFCSample.Droid.Resource.Id.tag_unhandled_key_event_manager;
+			global::Xamarin.Forms.Platform.Android.Resource.Id.tag_unhandled_key_listeners = global::NFCSample.Droid.Resource.Id.tag_unhandled_key_listeners;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.text = global::NFCSample.Droid.Resource.Id.text;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.text2 = global::NFCSample.Droid.Resource.Id.text2;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.textSpacerNoButtons = global::NFCSample.Droid.Resource.Id.textSpacerNoButtons;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.textSpacerNoTitle = global::NFCSample.Droid.Resource.Id.textSpacerNoTitle;
+			global::Xamarin.Forms.Platform.Android.Resource.Id.textStart = global::NFCSample.Droid.Resource.Id.textStart;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.text_input_password_toggle = global::NFCSample.Droid.Resource.Id.text_input_password_toggle;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.textinput_counter = global::NFCSample.Droid.Resource.Id.textinput_counter;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.textinput_error = global::NFCSample.Droid.Resource.Id.textinput_error;
+			global::Xamarin.Forms.Platform.Android.Resource.Id.textinput_helper_text = global::NFCSample.Droid.Resource.Id.textinput_helper_text;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.time = global::NFCSample.Droid.Resource.Id.time;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.title = global::NFCSample.Droid.Resource.Id.title;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.titleDividerNoCustom = global::NFCSample.Droid.Resource.Id.titleDividerNoCustom;
@@ -950,6 +1188,7 @@ namespace NFCSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Id.transition_scene_layoutid_cache = global::NFCSample.Droid.Resource.Id.transition_scene_layoutid_cache;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.transition_transform = global::NFCSample.Droid.Resource.Id.transition_transform;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.uniform = global::NFCSample.Droid.Resource.Id.uniform;
+			global::Xamarin.Forms.Platform.Android.Resource.Id.unlabeled = global::NFCSample.Droid.Resource.Id.unlabeled;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.up = global::NFCSample.Droid.Resource.Id.up;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.useLogo = global::NFCSample.Droid.Resource.Id.useLogo;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.view_offset_helper = global::NFCSample.Droid.Resource.Id.view_offset_helper;
@@ -963,9 +1202,18 @@ namespace NFCSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Integer.cancel_button_image_alpha = global::NFCSample.Droid.Resource.Integer.cancel_button_image_alpha;
 			global::Xamarin.Forms.Platform.Android.Resource.Integer.config_tooltipAnimTime = global::NFCSample.Droid.Resource.Integer.config_tooltipAnimTime;
 			global::Xamarin.Forms.Platform.Android.Resource.Integer.design_snackbar_text_max_lines = global::NFCSample.Droid.Resource.Integer.design_snackbar_text_max_lines;
+			global::Xamarin.Forms.Platform.Android.Resource.Integer.design_tab_indicator_anim_duration_ms = global::NFCSample.Droid.Resource.Integer.design_tab_indicator_anim_duration_ms;
 			global::Xamarin.Forms.Platform.Android.Resource.Integer.hide_password_duration = global::NFCSample.Droid.Resource.Integer.hide_password_duration;
+			global::Xamarin.Forms.Platform.Android.Resource.Integer.mtrl_btn_anim_delay_ms = global::NFCSample.Droid.Resource.Integer.mtrl_btn_anim_delay_ms;
+			global::Xamarin.Forms.Platform.Android.Resource.Integer.mtrl_btn_anim_duration_ms = global::NFCSample.Droid.Resource.Integer.mtrl_btn_anim_duration_ms;
+			global::Xamarin.Forms.Platform.Android.Resource.Integer.mtrl_chip_anim_duration = global::NFCSample.Droid.Resource.Integer.mtrl_chip_anim_duration;
+			global::Xamarin.Forms.Platform.Android.Resource.Integer.mtrl_tab_indicator_anim_duration_ms = global::NFCSample.Droid.Resource.Integer.mtrl_tab_indicator_anim_duration_ms;
 			global::Xamarin.Forms.Platform.Android.Resource.Integer.show_password_duration = global::NFCSample.Droid.Resource.Integer.show_password_duration;
 			global::Xamarin.Forms.Platform.Android.Resource.Integer.status_bar_notification_info_maxnum = global::NFCSample.Droid.Resource.Integer.status_bar_notification_info_maxnum;
+			global::Xamarin.Forms.Platform.Android.Resource.Interpolator.mtrl_fast_out_linear_in = global::NFCSample.Droid.Resource.Interpolator.mtrl_fast_out_linear_in;
+			global::Xamarin.Forms.Platform.Android.Resource.Interpolator.mtrl_fast_out_slow_in = global::NFCSample.Droid.Resource.Interpolator.mtrl_fast_out_slow_in;
+			global::Xamarin.Forms.Platform.Android.Resource.Interpolator.mtrl_linear = global::NFCSample.Droid.Resource.Interpolator.mtrl_linear;
+			global::Xamarin.Forms.Platform.Android.Resource.Interpolator.mtrl_linear_out_slow_in = global::NFCSample.Droid.Resource.Interpolator.mtrl_linear_out_slow_in;
 			global::Xamarin.Forms.Platform.Android.Resource.Layout.abc_action_bar_title_item = global::NFCSample.Droid.Resource.Layout.abc_action_bar_title_item;
 			global::Xamarin.Forms.Platform.Android.Resource.Layout.abc_action_bar_up_container = global::NFCSample.Droid.Resource.Layout.abc_action_bar_up_container;
 			global::Xamarin.Forms.Platform.Android.Resource.Layout.abc_action_menu_item_layout = global::NFCSample.Droid.Resource.Layout.abc_action_menu_item_layout;
@@ -977,6 +1225,7 @@ namespace NFCSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Layout.abc_alert_dialog_button_bar_material = global::NFCSample.Droid.Resource.Layout.abc_alert_dialog_button_bar_material;
 			global::Xamarin.Forms.Platform.Android.Resource.Layout.abc_alert_dialog_material = global::NFCSample.Droid.Resource.Layout.abc_alert_dialog_material;
 			global::Xamarin.Forms.Platform.Android.Resource.Layout.abc_alert_dialog_title_material = global::NFCSample.Droid.Resource.Layout.abc_alert_dialog_title_material;
+			global::Xamarin.Forms.Platform.Android.Resource.Layout.abc_cascading_menu_item_layout = global::NFCSample.Droid.Resource.Layout.abc_cascading_menu_item_layout;
 			global::Xamarin.Forms.Platform.Android.Resource.Layout.abc_dialog_title_material = global::NFCSample.Droid.Resource.Layout.abc_dialog_title_material;
 			global::Xamarin.Forms.Platform.Android.Resource.Layout.abc_expanded_menu_layout = global::NFCSample.Droid.Resource.Layout.abc_expanded_menu_layout;
 			global::Xamarin.Forms.Platform.Android.Resource.Layout.abc_list_menu_item_checkbox = global::NFCSample.Droid.Resource.Layout.abc_list_menu_item_checkbox;
@@ -992,6 +1241,7 @@ namespace NFCSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Layout.abc_search_dropdown_item_icons_2line = global::NFCSample.Droid.Resource.Layout.abc_search_dropdown_item_icons_2line;
 			global::Xamarin.Forms.Platform.Android.Resource.Layout.abc_search_view = global::NFCSample.Droid.Resource.Layout.abc_search_view;
 			global::Xamarin.Forms.Platform.Android.Resource.Layout.abc_select_dialog_material = global::NFCSample.Droid.Resource.Layout.abc_select_dialog_material;
+			global::Xamarin.Forms.Platform.Android.Resource.Layout.abc_tooltip = global::NFCSample.Droid.Resource.Layout.abc_tooltip;
 			global::Xamarin.Forms.Platform.Android.Resource.Layout.BottomTabLayout = global::NFCSample.Droid.Resource.Layout.BottomTabLayout;
 			global::Xamarin.Forms.Platform.Android.Resource.Layout.design_bottom_navigation_item = global::NFCSample.Droid.Resource.Layout.design_bottom_navigation_item;
 			global::Xamarin.Forms.Platform.Android.Resource.Layout.design_bottom_sheet_dialog = global::NFCSample.Droid.Resource.Layout.design_bottom_sheet_dialog;
@@ -1008,6 +1258,8 @@ namespace NFCSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Layout.design_navigation_menu_item = global::NFCSample.Droid.Resource.Layout.design_navigation_menu_item;
 			global::Xamarin.Forms.Platform.Android.Resource.Layout.design_text_input_password_icon = global::NFCSample.Droid.Resource.Layout.design_text_input_password_icon;
 			global::Xamarin.Forms.Platform.Android.Resource.Layout.FlyoutContent = global::NFCSample.Droid.Resource.Layout.FlyoutContent;
+			global::Xamarin.Forms.Platform.Android.Resource.Layout.mtrl_layout_snackbar = global::NFCSample.Droid.Resource.Layout.mtrl_layout_snackbar;
+			global::Xamarin.Forms.Platform.Android.Resource.Layout.mtrl_layout_snackbar_include = global::NFCSample.Droid.Resource.Layout.mtrl_layout_snackbar_include;
 			global::Xamarin.Forms.Platform.Android.Resource.Layout.notification_action = global::NFCSample.Droid.Resource.Layout.notification_action;
 			global::Xamarin.Forms.Platform.Android.Resource.Layout.notification_action_tombstone = global::NFCSample.Droid.Resource.Layout.notification_action_tombstone;
 			global::Xamarin.Forms.Platform.Android.Resource.Layout.notification_media_action = global::NFCSample.Droid.Resource.Layout.notification_media_action;
@@ -1029,7 +1281,6 @@ namespace NFCSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Layout.select_dialog_singlechoice_material = global::NFCSample.Droid.Resource.Layout.select_dialog_singlechoice_material;
 			global::Xamarin.Forms.Platform.Android.Resource.Layout.ShellContent = global::NFCSample.Droid.Resource.Layout.ShellContent;
 			global::Xamarin.Forms.Platform.Android.Resource.Layout.support_simple_spinner_dropdown_item = global::NFCSample.Droid.Resource.Layout.support_simple_spinner_dropdown_item;
-			global::Xamarin.Forms.Platform.Android.Resource.Layout.tooltip = global::NFCSample.Droid.Resource.Layout.tooltip;
 			global::Xamarin.Forms.Platform.Android.Resource.String.abc_action_bar_home_description = global::NFCSample.Droid.Resource.String.abc_action_bar_home_description;
 			global::Xamarin.Forms.Platform.Android.Resource.String.abc_action_bar_up_description = global::NFCSample.Droid.Resource.String.abc_action_bar_up_description;
 			global::Xamarin.Forms.Platform.Android.Resource.String.abc_action_menu_overflow_description = global::NFCSample.Droid.Resource.String.abc_action_menu_overflow_description;
@@ -1050,6 +1301,16 @@ namespace NFCSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.String.abc_font_family_menu_material = global::NFCSample.Droid.Resource.String.abc_font_family_menu_material;
 			global::Xamarin.Forms.Platform.Android.Resource.String.abc_font_family_subhead_material = global::NFCSample.Droid.Resource.String.abc_font_family_subhead_material;
 			global::Xamarin.Forms.Platform.Android.Resource.String.abc_font_family_title_material = global::NFCSample.Droid.Resource.String.abc_font_family_title_material;
+			global::Xamarin.Forms.Platform.Android.Resource.String.abc_menu_alt_shortcut_label = global::NFCSample.Droid.Resource.String.abc_menu_alt_shortcut_label;
+			global::Xamarin.Forms.Platform.Android.Resource.String.abc_menu_ctrl_shortcut_label = global::NFCSample.Droid.Resource.String.abc_menu_ctrl_shortcut_label;
+			global::Xamarin.Forms.Platform.Android.Resource.String.abc_menu_delete_shortcut_label = global::NFCSample.Droid.Resource.String.abc_menu_delete_shortcut_label;
+			global::Xamarin.Forms.Platform.Android.Resource.String.abc_menu_enter_shortcut_label = global::NFCSample.Droid.Resource.String.abc_menu_enter_shortcut_label;
+			global::Xamarin.Forms.Platform.Android.Resource.String.abc_menu_function_shortcut_label = global::NFCSample.Droid.Resource.String.abc_menu_function_shortcut_label;
+			global::Xamarin.Forms.Platform.Android.Resource.String.abc_menu_meta_shortcut_label = global::NFCSample.Droid.Resource.String.abc_menu_meta_shortcut_label;
+			global::Xamarin.Forms.Platform.Android.Resource.String.abc_menu_shift_shortcut_label = global::NFCSample.Droid.Resource.String.abc_menu_shift_shortcut_label;
+			global::Xamarin.Forms.Platform.Android.Resource.String.abc_menu_space_shortcut_label = global::NFCSample.Droid.Resource.String.abc_menu_space_shortcut_label;
+			global::Xamarin.Forms.Platform.Android.Resource.String.abc_menu_sym_shortcut_label = global::NFCSample.Droid.Resource.String.abc_menu_sym_shortcut_label;
+			global::Xamarin.Forms.Platform.Android.Resource.String.abc_prepend_shortcut_label = global::NFCSample.Droid.Resource.String.abc_prepend_shortcut_label;
 			global::Xamarin.Forms.Platform.Android.Resource.String.abc_search_hint = global::NFCSample.Droid.Resource.String.abc_search_hint;
 			global::Xamarin.Forms.Platform.Android.Resource.String.abc_searchview_description_clear = global::NFCSample.Droid.Resource.String.abc_searchview_description_clear;
 			global::Xamarin.Forms.Platform.Android.Resource.String.abc_searchview_description_query = global::NFCSample.Droid.Resource.String.abc_searchview_description_query;
@@ -1061,7 +1322,12 @@ namespace NFCSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.String.abc_toolbar_collapse_description = global::NFCSample.Droid.Resource.String.abc_toolbar_collapse_description;
 			global::Xamarin.Forms.Platform.Android.Resource.String.appbar_scrolling_view_behavior = global::NFCSample.Droid.Resource.String.appbar_scrolling_view_behavior;
 			global::Xamarin.Forms.Platform.Android.Resource.String.bottom_sheet_behavior = global::NFCSample.Droid.Resource.String.bottom_sheet_behavior;
+			global::Xamarin.Forms.Platform.Android.Resource.String.character_counter_content_description = global::NFCSample.Droid.Resource.String.character_counter_content_description;
 			global::Xamarin.Forms.Platform.Android.Resource.String.character_counter_pattern = global::NFCSample.Droid.Resource.String.character_counter_pattern;
+			global::Xamarin.Forms.Platform.Android.Resource.String.fab_transformation_scrim_behavior = global::NFCSample.Droid.Resource.String.fab_transformation_scrim_behavior;
+			global::Xamarin.Forms.Platform.Android.Resource.String.fab_transformation_sheet_behavior = global::NFCSample.Droid.Resource.String.fab_transformation_sheet_behavior;
+			global::Xamarin.Forms.Platform.Android.Resource.String.hide_bottom_view_on_scroll_behavior = global::NFCSample.Droid.Resource.String.hide_bottom_view_on_scroll_behavior;
+			global::Xamarin.Forms.Platform.Android.Resource.String.mtrl_chip_close_icon_content_description = global::NFCSample.Droid.Resource.String.mtrl_chip_close_icon_content_description;
 			global::Xamarin.Forms.Platform.Android.Resource.String.password_toggle_content_description = global::NFCSample.Droid.Resource.String.password_toggle_content_description;
 			global::Xamarin.Forms.Platform.Android.Resource.String.path_password_eye = global::NFCSample.Droid.Resource.String.path_password_eye;
 			global::Xamarin.Forms.Platform.Android.Resource.String.path_password_eye_mask_strike_through = global::NFCSample.Droid.Resource.String.path_password_eye_mask_strike_through;
@@ -1145,6 +1411,23 @@ namespace NFCSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_Theme_AppCompat_Light_Dialog_FixedSize = global::NFCSample.Droid.Resource.Style.Base_Theme_AppCompat_Light_Dialog_FixedSize;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_Theme_AppCompat_Light_Dialog_MinWidth = global::NFCSample.Droid.Resource.Style.Base_Theme_AppCompat_Light_Dialog_MinWidth;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_Theme_AppCompat_Light_DialogWhenLarge = global::NFCSample.Droid.Resource.Style.Base_Theme_AppCompat_Light_DialogWhenLarge;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_Theme_MaterialComponents = global::NFCSample.Droid.Resource.Style.Base_Theme_MaterialComponents;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_Theme_MaterialComponents_Bridge = global::NFCSample.Droid.Resource.Style.Base_Theme_MaterialComponents_Bridge;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_Theme_MaterialComponents_CompactMenu = global::NFCSample.Droid.Resource.Style.Base_Theme_MaterialComponents_CompactMenu;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_Theme_MaterialComponents_Dialog = global::NFCSample.Droid.Resource.Style.Base_Theme_MaterialComponents_Dialog;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_Theme_MaterialComponents_Dialog_Alert = global::NFCSample.Droid.Resource.Style.Base_Theme_MaterialComponents_Dialog_Alert;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_Theme_MaterialComponents_Dialog_FixedSize = global::NFCSample.Droid.Resource.Style.Base_Theme_MaterialComponents_Dialog_FixedSize;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_Theme_MaterialComponents_Dialog_MinWidth = global::NFCSample.Droid.Resource.Style.Base_Theme_MaterialComponents_Dialog_MinWidth;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_Theme_MaterialComponents_DialogWhenLarge = global::NFCSample.Droid.Resource.Style.Base_Theme_MaterialComponents_DialogWhenLarge;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_Theme_MaterialComponents_Light = global::NFCSample.Droid.Resource.Style.Base_Theme_MaterialComponents_Light;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_Theme_MaterialComponents_Light_Bridge = global::NFCSample.Droid.Resource.Style.Base_Theme_MaterialComponents_Light_Bridge;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_Theme_MaterialComponents_Light_DarkActionBar = global::NFCSample.Droid.Resource.Style.Base_Theme_MaterialComponents_Light_DarkActionBar;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_Theme_MaterialComponents_Light_DarkActionBar_Bridge = global::NFCSample.Droid.Resource.Style.Base_Theme_MaterialComponents_Light_DarkActionBar_Bridge;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_Theme_MaterialComponents_Light_Dialog = global::NFCSample.Droid.Resource.Style.Base_Theme_MaterialComponents_Light_Dialog;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_Theme_MaterialComponents_Light_Dialog_Alert = global::NFCSample.Droid.Resource.Style.Base_Theme_MaterialComponents_Light_Dialog_Alert;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_Theme_MaterialComponents_Light_Dialog_FixedSize = global::NFCSample.Droid.Resource.Style.Base_Theme_MaterialComponents_Light_Dialog_FixedSize;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_Theme_MaterialComponents_Light_Dialog_MinWidth = global::NFCSample.Droid.Resource.Style.Base_Theme_MaterialComponents_Light_Dialog_MinWidth;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_Theme_MaterialComponents_Light_DialogWhenLarge = global::NFCSample.Droid.Resource.Style.Base_Theme_MaterialComponents_Light_DialogWhenLarge;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_ThemeOverlay_AppCompat = global::NFCSample.Droid.Resource.Style.Base_ThemeOverlay_AppCompat;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_ThemeOverlay_AppCompat_ActionBar = global::NFCSample.Droid.Resource.Style.Base_ThemeOverlay_AppCompat_ActionBar;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_ThemeOverlay_AppCompat_Dark = global::NFCSample.Droid.Resource.Style.Base_ThemeOverlay_AppCompat_Dark;
@@ -1152,18 +1435,22 @@ namespace NFCSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_ThemeOverlay_AppCompat_Dialog = global::NFCSample.Droid.Resource.Style.Base_ThemeOverlay_AppCompat_Dialog;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_ThemeOverlay_AppCompat_Dialog_Alert = global::NFCSample.Droid.Resource.Style.Base_ThemeOverlay_AppCompat_Dialog_Alert;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_ThemeOverlay_AppCompat_Light = global::NFCSample.Droid.Resource.Style.Base_ThemeOverlay_AppCompat_Light;
-			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_V11_Theme_AppCompat_Dialog = global::NFCSample.Droid.Resource.Style.Base_V11_Theme_AppCompat_Dialog;
-			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_V11_Theme_AppCompat_Light_Dialog = global::NFCSample.Droid.Resource.Style.Base_V11_Theme_AppCompat_Light_Dialog;
-			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_V11_ThemeOverlay_AppCompat_Dialog = global::NFCSample.Droid.Resource.Style.Base_V11_ThemeOverlay_AppCompat_Dialog;
-			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_V12_Widget_AppCompat_AutoCompleteTextView = global::NFCSample.Droid.Resource.Style.Base_V12_Widget_AppCompat_AutoCompleteTextView;
-			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_V12_Widget_AppCompat_EditText = global::NFCSample.Droid.Resource.Style.Base_V12_Widget_AppCompat_EditText;
-			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_V14_Widget_Design_AppBarLayout = global::NFCSample.Droid.Resource.Style.Base_V14_Widget_Design_AppBarLayout;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_ThemeOverlay_MaterialComponents_Dialog = global::NFCSample.Droid.Resource.Style.Base_ThemeOverlay_MaterialComponents_Dialog;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_ThemeOverlay_MaterialComponents_Dialog_Alert = global::NFCSample.Droid.Resource.Style.Base_ThemeOverlay_MaterialComponents_Dialog_Alert;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_V14_Theme_MaterialComponents = global::NFCSample.Droid.Resource.Style.Base_V14_Theme_MaterialComponents;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_V14_Theme_MaterialComponents_Bridge = global::NFCSample.Droid.Resource.Style.Base_V14_Theme_MaterialComponents_Bridge;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_V14_Theme_MaterialComponents_Dialog = global::NFCSample.Droid.Resource.Style.Base_V14_Theme_MaterialComponents_Dialog;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_V14_Theme_MaterialComponents_Light = global::NFCSample.Droid.Resource.Style.Base_V14_Theme_MaterialComponents_Light;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_V14_Theme_MaterialComponents_Light_Bridge = global::NFCSample.Droid.Resource.Style.Base_V14_Theme_MaterialComponents_Light_Bridge;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_V14_Theme_MaterialComponents_Light_DarkActionBar_Bridge = global::NFCSample.Droid.Resource.Style.Base_V14_Theme_MaterialComponents_Light_DarkActionBar_Bridge;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_V14_Theme_MaterialComponents_Light_Dialog = global::NFCSample.Droid.Resource.Style.Base_V14_Theme_MaterialComponents_Light_Dialog;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_V14_ThemeOverlay_MaterialComponents_Dialog = global::NFCSample.Droid.Resource.Style.Base_V14_ThemeOverlay_MaterialComponents_Dialog;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_V14_ThemeOverlay_MaterialComponents_Dialog_Alert = global::NFCSample.Droid.Resource.Style.Base_V14_ThemeOverlay_MaterialComponents_Dialog_Alert;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_V21_Theme_AppCompat = global::NFCSample.Droid.Resource.Style.Base_V21_Theme_AppCompat;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_V21_Theme_AppCompat_Dialog = global::NFCSample.Droid.Resource.Style.Base_V21_Theme_AppCompat_Dialog;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_V21_Theme_AppCompat_Light = global::NFCSample.Droid.Resource.Style.Base_V21_Theme_AppCompat_Light;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_V21_Theme_AppCompat_Light_Dialog = global::NFCSample.Droid.Resource.Style.Base_V21_Theme_AppCompat_Light_Dialog;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_V21_ThemeOverlay_AppCompat_Dialog = global::NFCSample.Droid.Resource.Style.Base_V21_ThemeOverlay_AppCompat_Dialog;
-			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_V21_Widget_Design_AppBarLayout = global::NFCSample.Droid.Resource.Style.Base_V21_Widget_Design_AppBarLayout;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_V22_Theme_AppCompat = global::NFCSample.Droid.Resource.Style.Base_V22_Theme_AppCompat;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_V22_Theme_AppCompat_Light = global::NFCSample.Droid.Resource.Style.Base_V22_Theme_AppCompat_Light;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_V23_Theme_AppCompat = global::NFCSample.Droid.Resource.Style.Base_V23_Theme_AppCompat;
@@ -1171,7 +1458,8 @@ namespace NFCSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_V26_Theme_AppCompat = global::NFCSample.Droid.Resource.Style.Base_V26_Theme_AppCompat;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_V26_Theme_AppCompat_Light = global::NFCSample.Droid.Resource.Style.Base_V26_Theme_AppCompat_Light;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_V26_Widget_AppCompat_Toolbar = global::NFCSample.Droid.Resource.Style.Base_V26_Widget_AppCompat_Toolbar;
-			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_V26_Widget_Design_AppBarLayout = global::NFCSample.Droid.Resource.Style.Base_V26_Widget_Design_AppBarLayout;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_V28_Theme_AppCompat = global::NFCSample.Droid.Resource.Style.Base_V28_Theme_AppCompat;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_V28_Theme_AppCompat_Light = global::NFCSample.Droid.Resource.Style.Base_V28_Theme_AppCompat_Light;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_V7_Theme_AppCompat = global::NFCSample.Droid.Resource.Style.Base_V7_Theme_AppCompat;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_V7_Theme_AppCompat_Dialog = global::NFCSample.Droid.Resource.Style.Base_V7_Theme_AppCompat_Dialog;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_V7_Theme_AppCompat_Light = global::NFCSample.Droid.Resource.Style.Base_V7_Theme_AppCompat_Light;
@@ -1237,21 +1525,23 @@ namespace NFCSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_Widget_AppCompat_TextView_SpinnerItem = global::NFCSample.Droid.Resource.Style.Base_Widget_AppCompat_TextView_SpinnerItem;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_Widget_AppCompat_Toolbar = global::NFCSample.Droid.Resource.Style.Base_Widget_AppCompat_Toolbar;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_Widget_AppCompat_Toolbar_Button_Navigation = global::NFCSample.Droid.Resource.Style.Base_Widget_AppCompat_Toolbar_Button_Navigation;
-			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_Widget_Design_AppBarLayout = global::NFCSample.Droid.Resource.Style.Base_Widget_Design_AppBarLayout;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_Widget_Design_TabLayout = global::NFCSample.Droid.Resource.Style.Base_Widget_Design_TabLayout;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_Widget_MaterialComponents_Chip = global::NFCSample.Droid.Resource.Style.Base_Widget_MaterialComponents_Chip;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_Widget_MaterialComponents_TextInputEditText = global::NFCSample.Droid.Resource.Style.Base_Widget_MaterialComponents_TextInputEditText;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_Widget_MaterialComponents_TextInputLayout = global::NFCSample.Droid.Resource.Style.Base_Widget_MaterialComponents_TextInputLayout;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.CardView = global::NFCSample.Droid.Resource.Style.CardView;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.CardView_Dark = global::NFCSample.Droid.Resource.Style.CardView_Dark;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.CardView_Light = global::NFCSample.Droid.Resource.Style.CardView_Light;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.NestedScrollBarStyle = global::NFCSample.Droid.Resource.Style.NestedScrollBarStyle;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Platform_AppCompat = global::NFCSample.Droid.Resource.Style.Platform_AppCompat;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Platform_AppCompat_Light = global::NFCSample.Droid.Resource.Style.Platform_AppCompat_Light;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Platform_MaterialComponents = global::NFCSample.Droid.Resource.Style.Platform_MaterialComponents;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Platform_MaterialComponents_Dialog = global::NFCSample.Droid.Resource.Style.Platform_MaterialComponents_Dialog;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Platform_MaterialComponents_Light = global::NFCSample.Droid.Resource.Style.Platform_MaterialComponents_Light;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Platform_MaterialComponents_Light_Dialog = global::NFCSample.Droid.Resource.Style.Platform_MaterialComponents_Light_Dialog;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Platform_ThemeOverlay_AppCompat = global::NFCSample.Droid.Resource.Style.Platform_ThemeOverlay_AppCompat;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Platform_ThemeOverlay_AppCompat_Dark = global::NFCSample.Droid.Resource.Style.Platform_ThemeOverlay_AppCompat_Dark;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Platform_ThemeOverlay_AppCompat_Light = global::NFCSample.Droid.Resource.Style.Platform_ThemeOverlay_AppCompat_Light;
-			global::Xamarin.Forms.Platform.Android.Resource.Style.Platform_V11_AppCompat = global::NFCSample.Droid.Resource.Style.Platform_V11_AppCompat;
-			global::Xamarin.Forms.Platform.Android.Resource.Style.Platform_V11_AppCompat_Light = global::NFCSample.Droid.Resource.Style.Platform_V11_AppCompat_Light;
-			global::Xamarin.Forms.Platform.Android.Resource.Style.Platform_V14_AppCompat = global::NFCSample.Droid.Resource.Style.Platform_V14_AppCompat;
-			global::Xamarin.Forms.Platform.Android.Resource.Style.Platform_V14_AppCompat_Light = global::NFCSample.Droid.Resource.Style.Platform_V14_AppCompat_Light;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Platform_V21_AppCompat = global::NFCSample.Droid.Resource.Style.Platform_V21_AppCompat;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Platform_V21_AppCompat_Light = global::NFCSample.Droid.Resource.Style.Platform_V21_AppCompat_Light;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Platform_V25_AppCompat = global::NFCSample.Droid.Resource.Style.Platform_V25_AppCompat;
@@ -1262,7 +1552,10 @@ namespace NFCSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Style.RtlOverlay_Widget_AppCompat_DialogTitle_Icon = global::NFCSample.Droid.Resource.Style.RtlOverlay_Widget_AppCompat_DialogTitle_Icon;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.RtlOverlay_Widget_AppCompat_PopupMenuItem = global::NFCSample.Droid.Resource.Style.RtlOverlay_Widget_AppCompat_PopupMenuItem;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.RtlOverlay_Widget_AppCompat_PopupMenuItem_InternalGroup = global::NFCSample.Droid.Resource.Style.RtlOverlay_Widget_AppCompat_PopupMenuItem_InternalGroup;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.RtlOverlay_Widget_AppCompat_PopupMenuItem_Shortcut = global::NFCSample.Droid.Resource.Style.RtlOverlay_Widget_AppCompat_PopupMenuItem_Shortcut;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.RtlOverlay_Widget_AppCompat_PopupMenuItem_SubmenuArrow = global::NFCSample.Droid.Resource.Style.RtlOverlay_Widget_AppCompat_PopupMenuItem_SubmenuArrow;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.RtlOverlay_Widget_AppCompat_PopupMenuItem_Text = global::NFCSample.Droid.Resource.Style.RtlOverlay_Widget_AppCompat_PopupMenuItem_Text;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.RtlOverlay_Widget_AppCompat_PopupMenuItem_Title = global::NFCSample.Droid.Resource.Style.RtlOverlay_Widget_AppCompat_PopupMenuItem_Title;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.RtlOverlay_Widget_AppCompat_Search_DropDown = global::NFCSample.Droid.Resource.Style.RtlOverlay_Widget_AppCompat_Search_DropDown;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.RtlOverlay_Widget_AppCompat_Search_DropDown_Icon1 = global::NFCSample.Droid.Resource.Style.RtlOverlay_Widget_AppCompat_Search_DropDown_Icon1;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.RtlOverlay_Widget_AppCompat_Search_DropDown_Icon2 = global::NFCSample.Droid.Resource.Style.RtlOverlay_Widget_AppCompat_Search_DropDown_Icon2;
@@ -1333,9 +1626,25 @@ namespace NFCSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Style.TextAppearance_Design_Counter = global::NFCSample.Droid.Resource.Style.TextAppearance_Design_Counter;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.TextAppearance_Design_Counter_Overflow = global::NFCSample.Droid.Resource.Style.TextAppearance_Design_Counter_Overflow;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.TextAppearance_Design_Error = global::NFCSample.Droid.Resource.Style.TextAppearance_Design_Error;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.TextAppearance_Design_HelperText = global::NFCSample.Droid.Resource.Style.TextAppearance_Design_HelperText;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.TextAppearance_Design_Hint = global::NFCSample.Droid.Resource.Style.TextAppearance_Design_Hint;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.TextAppearance_Design_Snackbar_Message = global::NFCSample.Droid.Resource.Style.TextAppearance_Design_Snackbar_Message;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.TextAppearance_Design_Tab = global::NFCSample.Droid.Resource.Style.TextAppearance_Design_Tab;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.TextAppearance_MaterialComponents_Body1 = global::NFCSample.Droid.Resource.Style.TextAppearance_MaterialComponents_Body1;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.TextAppearance_MaterialComponents_Body2 = global::NFCSample.Droid.Resource.Style.TextAppearance_MaterialComponents_Body2;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.TextAppearance_MaterialComponents_Button = global::NFCSample.Droid.Resource.Style.TextAppearance_MaterialComponents_Button;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.TextAppearance_MaterialComponents_Caption = global::NFCSample.Droid.Resource.Style.TextAppearance_MaterialComponents_Caption;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.TextAppearance_MaterialComponents_Chip = global::NFCSample.Droid.Resource.Style.TextAppearance_MaterialComponents_Chip;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.TextAppearance_MaterialComponents_Headline1 = global::NFCSample.Droid.Resource.Style.TextAppearance_MaterialComponents_Headline1;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.TextAppearance_MaterialComponents_Headline2 = global::NFCSample.Droid.Resource.Style.TextAppearance_MaterialComponents_Headline2;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.TextAppearance_MaterialComponents_Headline3 = global::NFCSample.Droid.Resource.Style.TextAppearance_MaterialComponents_Headline3;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.TextAppearance_MaterialComponents_Headline4 = global::NFCSample.Droid.Resource.Style.TextAppearance_MaterialComponents_Headline4;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.TextAppearance_MaterialComponents_Headline5 = global::NFCSample.Droid.Resource.Style.TextAppearance_MaterialComponents_Headline5;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.TextAppearance_MaterialComponents_Headline6 = global::NFCSample.Droid.Resource.Style.TextAppearance_MaterialComponents_Headline6;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.TextAppearance_MaterialComponents_Overline = global::NFCSample.Droid.Resource.Style.TextAppearance_MaterialComponents_Overline;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.TextAppearance_MaterialComponents_Subtitle1 = global::NFCSample.Droid.Resource.Style.TextAppearance_MaterialComponents_Subtitle1;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.TextAppearance_MaterialComponents_Subtitle2 = global::NFCSample.Droid.Resource.Style.TextAppearance_MaterialComponents_Subtitle2;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.TextAppearance_MaterialComponents_Tab = global::NFCSample.Droid.Resource.Style.TextAppearance_MaterialComponents_Tab;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.TextAppearance_Widget_AppCompat_ExpandedMenu_Item = global::NFCSample.Droid.Resource.Style.TextAppearance_Widget_AppCompat_ExpandedMenu_Item;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.TextAppearance_Widget_AppCompat_Toolbar_Subtitle = global::NFCSample.Droid.Resource.Style.TextAppearance_Widget_AppCompat_Toolbar_Subtitle;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.TextAppearance_Widget_AppCompat_Toolbar_Title = global::NFCSample.Droid.Resource.Style.TextAppearance_Widget_AppCompat_Toolbar_Title;
@@ -1366,6 +1675,27 @@ namespace NFCSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Theme_Design_Light_BottomSheetDialog = global::NFCSample.Droid.Resource.Style.Theme_Design_Light_BottomSheetDialog;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Theme_Design_Light_NoActionBar = global::NFCSample.Droid.Resource.Style.Theme_Design_Light_NoActionBar;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Theme_Design_NoActionBar = global::NFCSample.Droid.Resource.Style.Theme_Design_NoActionBar;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Theme_MaterialComponents = global::NFCSample.Droid.Resource.Style.Theme_MaterialComponents;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Theme_MaterialComponents_BottomSheetDialog = global::NFCSample.Droid.Resource.Style.Theme_MaterialComponents_BottomSheetDialog;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Theme_MaterialComponents_Bridge = global::NFCSample.Droid.Resource.Style.Theme_MaterialComponents_Bridge;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Theme_MaterialComponents_CompactMenu = global::NFCSample.Droid.Resource.Style.Theme_MaterialComponents_CompactMenu;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Theme_MaterialComponents_Dialog = global::NFCSample.Droid.Resource.Style.Theme_MaterialComponents_Dialog;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Theme_MaterialComponents_Dialog_Alert = global::NFCSample.Droid.Resource.Style.Theme_MaterialComponents_Dialog_Alert;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Theme_MaterialComponents_Dialog_MinWidth = global::NFCSample.Droid.Resource.Style.Theme_MaterialComponents_Dialog_MinWidth;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Theme_MaterialComponents_DialogWhenLarge = global::NFCSample.Droid.Resource.Style.Theme_MaterialComponents_DialogWhenLarge;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Theme_MaterialComponents_Light = global::NFCSample.Droid.Resource.Style.Theme_MaterialComponents_Light;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Theme_MaterialComponents_Light_BottomSheetDialog = global::NFCSample.Droid.Resource.Style.Theme_MaterialComponents_Light_BottomSheetDialog;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Theme_MaterialComponents_Light_Bridge = global::NFCSample.Droid.Resource.Style.Theme_MaterialComponents_Light_Bridge;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Theme_MaterialComponents_Light_DarkActionBar = global::NFCSample.Droid.Resource.Style.Theme_MaterialComponents_Light_DarkActionBar;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Theme_MaterialComponents_Light_DarkActionBar_Bridge = global::NFCSample.Droid.Resource.Style.Theme_MaterialComponents_Light_DarkActionBar_Bridge;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Theme_MaterialComponents_Light_Dialog = global::NFCSample.Droid.Resource.Style.Theme_MaterialComponents_Light_Dialog;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Theme_MaterialComponents_Light_Dialog_Alert = global::NFCSample.Droid.Resource.Style.Theme_MaterialComponents_Light_Dialog_Alert;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Theme_MaterialComponents_Light_Dialog_MinWidth = global::NFCSample.Droid.Resource.Style.Theme_MaterialComponents_Light_Dialog_MinWidth;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Theme_MaterialComponents_Light_DialogWhenLarge = global::NFCSample.Droid.Resource.Style.Theme_MaterialComponents_Light_DialogWhenLarge;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Theme_MaterialComponents_Light_NoActionBar = global::NFCSample.Droid.Resource.Style.Theme_MaterialComponents_Light_NoActionBar;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Theme_MaterialComponents_Light_NoActionBar_Bridge = global::NFCSample.Droid.Resource.Style.Theme_MaterialComponents_Light_NoActionBar_Bridge;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Theme_MaterialComponents_NoActionBar = global::NFCSample.Droid.Resource.Style.Theme_MaterialComponents_NoActionBar;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Theme_MaterialComponents_NoActionBar_Bridge = global::NFCSample.Droid.Resource.Style.Theme_MaterialComponents_NoActionBar_Bridge;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.ThemeOverlay_AppCompat = global::NFCSample.Droid.Resource.Style.ThemeOverlay_AppCompat;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.ThemeOverlay_AppCompat_ActionBar = global::NFCSample.Droid.Resource.Style.ThemeOverlay_AppCompat_ActionBar;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.ThemeOverlay_AppCompat_Dark = global::NFCSample.Droid.Resource.Style.ThemeOverlay_AppCompat_Dark;
@@ -1373,6 +1703,18 @@ namespace NFCSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Style.ThemeOverlay_AppCompat_Dialog = global::NFCSample.Droid.Resource.Style.ThemeOverlay_AppCompat_Dialog;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.ThemeOverlay_AppCompat_Dialog_Alert = global::NFCSample.Droid.Resource.Style.ThemeOverlay_AppCompat_Dialog_Alert;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.ThemeOverlay_AppCompat_Light = global::NFCSample.Droid.Resource.Style.ThemeOverlay_AppCompat_Light;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.ThemeOverlay_MaterialComponents = global::NFCSample.Droid.Resource.Style.ThemeOverlay_MaterialComponents;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.ThemeOverlay_MaterialComponents_ActionBar = global::NFCSample.Droid.Resource.Style.ThemeOverlay_MaterialComponents_ActionBar;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.ThemeOverlay_MaterialComponents_Dark = global::NFCSample.Droid.Resource.Style.ThemeOverlay_MaterialComponents_Dark;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.ThemeOverlay_MaterialComponents_Dark_ActionBar = global::NFCSample.Droid.Resource.Style.ThemeOverlay_MaterialComponents_Dark_ActionBar;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.ThemeOverlay_MaterialComponents_Dialog = global::NFCSample.Droid.Resource.Style.ThemeOverlay_MaterialComponents_Dialog;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.ThemeOverlay_MaterialComponents_Dialog_Alert = global::NFCSample.Droid.Resource.Style.ThemeOverlay_MaterialComponents_Dialog_Alert;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.ThemeOverlay_MaterialComponents_Light = global::NFCSample.Droid.Resource.Style.ThemeOverlay_MaterialComponents_Light;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.ThemeOverlay_MaterialComponents_TextInputEditText = global::NFCSample.Droid.Resource.Style.ThemeOverlay_MaterialComponents_TextInputEditText;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.ThemeOverlay_MaterialComponents_TextInputEditText_FilledBox = global::NFCSample.Droid.Resource.Style.ThemeOverlay_MaterialComponents_TextInputEditText_FilledBox;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.ThemeOverlay_MaterialComponents_TextInputEditText_FilledBox_Dense = global::NFCSample.Droid.Resource.Style.ThemeOverlay_MaterialComponents_TextInputEditText_FilledBox_Dense;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.ThemeOverlay_MaterialComponents_TextInputEditText_OutlinedBox = global::NFCSample.Droid.Resource.Style.ThemeOverlay_MaterialComponents_TextInputEditText_OutlinedBox;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.ThemeOverlay_MaterialComponents_TextInputEditText_OutlinedBox_Dense = global::NFCSample.Droid.Resource.Style.ThemeOverlay_MaterialComponents_TextInputEditText_OutlinedBox_Dense;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_AppCompat_ActionBar = global::NFCSample.Droid.Resource.Style.Widget_AppCompat_ActionBar;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_AppCompat_ActionBar_Solid = global::NFCSample.Droid.Resource.Style.Widget_AppCompat_ActionBar_Solid;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_AppCompat_ActionBar_TabBar = global::NFCSample.Droid.Resource.Style.Widget_AppCompat_ActionBar_TabBar;
@@ -1451,13 +1793,49 @@ namespace NFCSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_Design_BottomNavigationView = global::NFCSample.Droid.Resource.Style.Widget_Design_BottomNavigationView;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_Design_BottomSheet_Modal = global::NFCSample.Droid.Resource.Style.Widget_Design_BottomSheet_Modal;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_Design_CollapsingToolbar = global::NFCSample.Droid.Resource.Style.Widget_Design_CollapsingToolbar;
-			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_Design_CoordinatorLayout = global::NFCSample.Droid.Resource.Style.Widget_Design_CoordinatorLayout;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_Design_FloatingActionButton = global::NFCSample.Droid.Resource.Style.Widget_Design_FloatingActionButton;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_Design_NavigationView = global::NFCSample.Droid.Resource.Style.Widget_Design_NavigationView;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_Design_ScrimInsetsFrameLayout = global::NFCSample.Droid.Resource.Style.Widget_Design_ScrimInsetsFrameLayout;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_Design_Snackbar = global::NFCSample.Droid.Resource.Style.Widget_Design_Snackbar;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_Design_TabLayout = global::NFCSample.Droid.Resource.Style.Widget_Design_TabLayout;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_Design_TextInputLayout = global::NFCSample.Droid.Resource.Style.Widget_Design_TextInputLayout;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_MaterialComponents_BottomAppBar = global::NFCSample.Droid.Resource.Style.Widget_MaterialComponents_BottomAppBar;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_MaterialComponents_BottomAppBar_Colored = global::NFCSample.Droid.Resource.Style.Widget_MaterialComponents_BottomAppBar_Colored;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_MaterialComponents_BottomNavigationView = global::NFCSample.Droid.Resource.Style.Widget_MaterialComponents_BottomNavigationView;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_MaterialComponents_BottomNavigationView_Colored = global::NFCSample.Droid.Resource.Style.Widget_MaterialComponents_BottomNavigationView_Colored;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_MaterialComponents_BottomSheet_Modal = global::NFCSample.Droid.Resource.Style.Widget_MaterialComponents_BottomSheet_Modal;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_MaterialComponents_Button = global::NFCSample.Droid.Resource.Style.Widget_MaterialComponents_Button;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_MaterialComponents_Button_Icon = global::NFCSample.Droid.Resource.Style.Widget_MaterialComponents_Button_Icon;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_MaterialComponents_Button_OutlinedButton = global::NFCSample.Droid.Resource.Style.Widget_MaterialComponents_Button_OutlinedButton;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_MaterialComponents_Button_OutlinedButton_Icon = global::NFCSample.Droid.Resource.Style.Widget_MaterialComponents_Button_OutlinedButton_Icon;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_MaterialComponents_Button_TextButton = global::NFCSample.Droid.Resource.Style.Widget_MaterialComponents_Button_TextButton;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_MaterialComponents_Button_TextButton_Dialog = global::NFCSample.Droid.Resource.Style.Widget_MaterialComponents_Button_TextButton_Dialog;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_MaterialComponents_Button_TextButton_Dialog_Icon = global::NFCSample.Droid.Resource.Style.Widget_MaterialComponents_Button_TextButton_Dialog_Icon;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_MaterialComponents_Button_TextButton_Icon = global::NFCSample.Droid.Resource.Style.Widget_MaterialComponents_Button_TextButton_Icon;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_MaterialComponents_Button_UnelevatedButton = global::NFCSample.Droid.Resource.Style.Widget_MaterialComponents_Button_UnelevatedButton;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_MaterialComponents_Button_UnelevatedButton_Icon = global::NFCSample.Droid.Resource.Style.Widget_MaterialComponents_Button_UnelevatedButton_Icon;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_MaterialComponents_CardView = global::NFCSample.Droid.Resource.Style.Widget_MaterialComponents_CardView;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_MaterialComponents_Chip_Action = global::NFCSample.Droid.Resource.Style.Widget_MaterialComponents_Chip_Action;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_MaterialComponents_Chip_Choice = global::NFCSample.Droid.Resource.Style.Widget_MaterialComponents_Chip_Choice;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_MaterialComponents_Chip_Entry = global::NFCSample.Droid.Resource.Style.Widget_MaterialComponents_Chip_Entry;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_MaterialComponents_Chip_Filter = global::NFCSample.Droid.Resource.Style.Widget_MaterialComponents_Chip_Filter;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_MaterialComponents_ChipGroup = global::NFCSample.Droid.Resource.Style.Widget_MaterialComponents_ChipGroup;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_MaterialComponents_FloatingActionButton = global::NFCSample.Droid.Resource.Style.Widget_MaterialComponents_FloatingActionButton;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_MaterialComponents_NavigationView = global::NFCSample.Droid.Resource.Style.Widget_MaterialComponents_NavigationView;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_MaterialComponents_Snackbar = global::NFCSample.Droid.Resource.Style.Widget_MaterialComponents_Snackbar;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_MaterialComponents_Snackbar_FullWidth = global::NFCSample.Droid.Resource.Style.Widget_MaterialComponents_Snackbar_FullWidth;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_MaterialComponents_TabLayout = global::NFCSample.Droid.Resource.Style.Widget_MaterialComponents_TabLayout;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_MaterialComponents_TabLayout_Colored = global::NFCSample.Droid.Resource.Style.Widget_MaterialComponents_TabLayout_Colored;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_MaterialComponents_TextInputEditText_FilledBox = global::NFCSample.Droid.Resource.Style.Widget_MaterialComponents_TextInputEditText_FilledBox;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_MaterialComponents_TextInputEditText_FilledBox_Dense = global::NFCSample.Droid.Resource.Style.Widget_MaterialComponents_TextInputEditText_FilledBox_Dense;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_MaterialComponents_TextInputEditText_OutlinedBox = global::NFCSample.Droid.Resource.Style.Widget_MaterialComponents_TextInputEditText_OutlinedBox;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_MaterialComponents_TextInputEditText_OutlinedBox_Dense = global::NFCSample.Droid.Resource.Style.Widget_MaterialComponents_TextInputEditText_OutlinedBox_Dense;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_MaterialComponents_TextInputLayout_FilledBox = global::NFCSample.Droid.Resource.Style.Widget_MaterialComponents_TextInputLayout_FilledBox;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_MaterialComponents_TextInputLayout_FilledBox_Dense = global::NFCSample.Droid.Resource.Style.Widget_MaterialComponents_TextInputLayout_FilledBox_Dense;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_MaterialComponents_TextInputLayout_OutlinedBox = global::NFCSample.Droid.Resource.Style.Widget_MaterialComponents_TextInputLayout_OutlinedBox;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_MaterialComponents_TextInputLayout_OutlinedBox_Dense = global::NFCSample.Droid.Resource.Style.Widget_MaterialComponents_TextInputLayout_OutlinedBox_Dense;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_MaterialComponents_Toolbar = global::NFCSample.Droid.Resource.Style.Widget_MaterialComponents_Toolbar;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_Support_CoordinatorLayout = global::NFCSample.Droid.Resource.Style.Widget_Support_CoordinatorLayout;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.collectionViewStyle = global::NFCSample.Droid.Resource.Style.collectionViewStyle;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.ActionBar = global::NFCSample.Droid.Resource.Styleable.ActionBar;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.ActionBar_background = global::NFCSample.Droid.Resource.Styleable.ActionBar_background;
@@ -1506,21 +1884,40 @@ namespace NFCSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.ActivityChooserView_initialActivityCount = global::NFCSample.Droid.Resource.Styleable.ActivityChooserView_initialActivityCount;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AlertDialog = global::NFCSample.Droid.Resource.Styleable.AlertDialog;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AlertDialog_android_layout = global::NFCSample.Droid.Resource.Styleable.AlertDialog_android_layout;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AlertDialog_buttonIconDimen = global::NFCSample.Droid.Resource.Styleable.AlertDialog_buttonIconDimen;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AlertDialog_buttonPanelSideLayout = global::NFCSample.Droid.Resource.Styleable.AlertDialog_buttonPanelSideLayout;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AlertDialog_listItemLayout = global::NFCSample.Droid.Resource.Styleable.AlertDialog_listItemLayout;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AlertDialog_listLayout = global::NFCSample.Droid.Resource.Styleable.AlertDialog_listLayout;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AlertDialog_multiChoiceItemLayout = global::NFCSample.Droid.Resource.Styleable.AlertDialog_multiChoiceItemLayout;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AlertDialog_showTitle = global::NFCSample.Droid.Resource.Styleable.AlertDialog_showTitle;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AlertDialog_singleChoiceItemLayout = global::NFCSample.Droid.Resource.Styleable.AlertDialog_singleChoiceItemLayout;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AnimatedStateListDrawableCompat = global::NFCSample.Droid.Resource.Styleable.AnimatedStateListDrawableCompat;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AnimatedStateListDrawableCompat_android_constantSize = global::NFCSample.Droid.Resource.Styleable.AnimatedStateListDrawableCompat_android_constantSize;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AnimatedStateListDrawableCompat_android_dither = global::NFCSample.Droid.Resource.Styleable.AnimatedStateListDrawableCompat_android_dither;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AnimatedStateListDrawableCompat_android_enterFadeDuration = global::NFCSample.Droid.Resource.Styleable.AnimatedStateListDrawableCompat_android_enterFadeDuration;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AnimatedStateListDrawableCompat_android_exitFadeDuration = global::NFCSample.Droid.Resource.Styleable.AnimatedStateListDrawableCompat_android_exitFadeDuration;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AnimatedStateListDrawableCompat_android_variablePadding = global::NFCSample.Droid.Resource.Styleable.AnimatedStateListDrawableCompat_android_variablePadding;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AnimatedStateListDrawableCompat_android_visible = global::NFCSample.Droid.Resource.Styleable.AnimatedStateListDrawableCompat_android_visible;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AnimatedStateListDrawableItem = global::NFCSample.Droid.Resource.Styleable.AnimatedStateListDrawableItem;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AnimatedStateListDrawableItem_android_drawable = global::NFCSample.Droid.Resource.Styleable.AnimatedStateListDrawableItem_android_drawable;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AnimatedStateListDrawableItem_android_id = global::NFCSample.Droid.Resource.Styleable.AnimatedStateListDrawableItem_android_id;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AnimatedStateListDrawableTransition = global::NFCSample.Droid.Resource.Styleable.AnimatedStateListDrawableTransition;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AnimatedStateListDrawableTransition_android_drawable = global::NFCSample.Droid.Resource.Styleable.AnimatedStateListDrawableTransition_android_drawable;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AnimatedStateListDrawableTransition_android_fromId = global::NFCSample.Droid.Resource.Styleable.AnimatedStateListDrawableTransition_android_fromId;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AnimatedStateListDrawableTransition_android_reversible = global::NFCSample.Droid.Resource.Styleable.AnimatedStateListDrawableTransition_android_reversible;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AnimatedStateListDrawableTransition_android_toId = global::NFCSample.Droid.Resource.Styleable.AnimatedStateListDrawableTransition_android_toId;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppBarLayout = global::NFCSample.Droid.Resource.Styleable.AppBarLayout;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppBarLayout_android_background = global::NFCSample.Droid.Resource.Styleable.AppBarLayout_android_background;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppBarLayout_android_keyboardNavigationCluster = global::NFCSample.Droid.Resource.Styleable.AppBarLayout_android_keyboardNavigationCluster;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppBarLayout_android_touchscreenBlocksFocus = global::NFCSample.Droid.Resource.Styleable.AppBarLayout_android_touchscreenBlocksFocus;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppBarLayout_elevation = global::NFCSample.Droid.Resource.Styleable.AppBarLayout_elevation;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppBarLayout_expanded = global::NFCSample.Droid.Resource.Styleable.AppBarLayout_expanded;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppBarLayout_liftOnScroll = global::NFCSample.Droid.Resource.Styleable.AppBarLayout_liftOnScroll;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppBarLayoutStates = global::NFCSample.Droid.Resource.Styleable.AppBarLayoutStates;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppBarLayoutStates_state_collapsed = global::NFCSample.Droid.Resource.Styleable.AppBarLayoutStates_state_collapsed;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppBarLayoutStates_state_collapsible = global::NFCSample.Droid.Resource.Styleable.AppBarLayoutStates_state_collapsible;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppBarLayoutStates_state_liftable = global::NFCSample.Droid.Resource.Styleable.AppBarLayoutStates_state_liftable;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppBarLayoutStates_state_lifted = global::NFCSample.Droid.Resource.Styleable.AppBarLayoutStates_state_lifted;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppBarLayout_Layout = global::NFCSample.Droid.Resource.Styleable.AppBarLayout_Layout;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppBarLayout_Layout_layout_scrollFlags = global::NFCSample.Droid.Resource.Styleable.AppBarLayout_Layout_layout_scrollFlags;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppBarLayout_Layout_layout_scrollInterpolator = global::NFCSample.Droid.Resource.Styleable.AppBarLayout_Layout_layout_scrollInterpolator;
@@ -1549,7 +1946,10 @@ namespace NFCSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppCompatTextView_autoSizePresetSizes = global::NFCSample.Droid.Resource.Styleable.AppCompatTextView_autoSizePresetSizes;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppCompatTextView_autoSizeStepGranularity = global::NFCSample.Droid.Resource.Styleable.AppCompatTextView_autoSizeStepGranularity;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppCompatTextView_autoSizeTextType = global::NFCSample.Droid.Resource.Styleable.AppCompatTextView_autoSizeTextType;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppCompatTextView_firstBaselineToTopHeight = global::NFCSample.Droid.Resource.Styleable.AppCompatTextView_firstBaselineToTopHeight;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppCompatTextView_fontFamily = global::NFCSample.Droid.Resource.Styleable.AppCompatTextView_fontFamily;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppCompatTextView_lastBaselineToBottomHeight = global::NFCSample.Droid.Resource.Styleable.AppCompatTextView_lastBaselineToBottomHeight;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppCompatTextView_lineHeight = global::NFCSample.Droid.Resource.Styleable.AppCompatTextView_lineHeight;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppCompatTextView_textAllCaps = global::NFCSample.Droid.Resource.Styleable.AppCompatTextView_textAllCaps;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppCompatTheme = global::NFCSample.Droid.Resource.Styleable.AppCompatTheme;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppCompatTheme_actionBarDivider = global::NFCSample.Droid.Resource.Styleable.AppCompatTheme_actionBarDivider;
@@ -1611,6 +2011,7 @@ namespace NFCSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppCompatTheme_colorPrimaryDark = global::NFCSample.Droid.Resource.Styleable.AppCompatTheme_colorPrimaryDark;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppCompatTheme_colorSwitchThumbNormal = global::NFCSample.Droid.Resource.Styleable.AppCompatTheme_colorSwitchThumbNormal;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppCompatTheme_controlBackground = global::NFCSample.Droid.Resource.Styleable.AppCompatTheme_controlBackground;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppCompatTheme_dialogCornerRadius = global::NFCSample.Droid.Resource.Styleable.AppCompatTheme_dialogCornerRadius;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppCompatTheme_dialogPreferredPadding = global::NFCSample.Droid.Resource.Styleable.AppCompatTheme_dialogPreferredPadding;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppCompatTheme_dialogTheme = global::NFCSample.Droid.Resource.Styleable.AppCompatTheme_dialogTheme;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppCompatTheme_dividerHorizontal = global::NFCSample.Droid.Resource.Styleable.AppCompatTheme_dividerHorizontal;
@@ -1661,6 +2062,7 @@ namespace NFCSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppCompatTheme_toolbarStyle = global::NFCSample.Droid.Resource.Styleable.AppCompatTheme_toolbarStyle;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppCompatTheme_tooltipForegroundColor = global::NFCSample.Droid.Resource.Styleable.AppCompatTheme_tooltipForegroundColor;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppCompatTheme_tooltipFrameBackground = global::NFCSample.Droid.Resource.Styleable.AppCompatTheme_tooltipFrameBackground;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppCompatTheme_viewInflaterClass = global::NFCSample.Droid.Resource.Styleable.AppCompatTheme_viewInflaterClass;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppCompatTheme_windowActionBar = global::NFCSample.Droid.Resource.Styleable.AppCompatTheme_windowActionBar;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppCompatTheme_windowActionBarOverlay = global::NFCSample.Droid.Resource.Styleable.AppCompatTheme_windowActionBarOverlay;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppCompatTheme_windowActionModeOverlay = global::NFCSample.Droid.Resource.Styleable.AppCompatTheme_windowActionModeOverlay;
@@ -1671,13 +2073,26 @@ namespace NFCSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppCompatTheme_windowMinWidthMajor = global::NFCSample.Droid.Resource.Styleable.AppCompatTheme_windowMinWidthMajor;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppCompatTheme_windowMinWidthMinor = global::NFCSample.Droid.Resource.Styleable.AppCompatTheme_windowMinWidthMinor;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppCompatTheme_windowNoTitle = global::NFCSample.Droid.Resource.Styleable.AppCompatTheme_windowNoTitle;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.BottomAppBar = global::NFCSample.Droid.Resource.Styleable.BottomAppBar;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.BottomAppBar_backgroundTint = global::NFCSample.Droid.Resource.Styleable.BottomAppBar_backgroundTint;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.BottomAppBar_fabAlignmentMode = global::NFCSample.Droid.Resource.Styleable.BottomAppBar_fabAlignmentMode;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.BottomAppBar_fabCradleMargin = global::NFCSample.Droid.Resource.Styleable.BottomAppBar_fabCradleMargin;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.BottomAppBar_fabCradleRoundedCornerRadius = global::NFCSample.Droid.Resource.Styleable.BottomAppBar_fabCradleRoundedCornerRadius;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.BottomAppBar_fabCradleVerticalOffset = global::NFCSample.Droid.Resource.Styleable.BottomAppBar_fabCradleVerticalOffset;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.BottomAppBar_hideOnScroll = global::NFCSample.Droid.Resource.Styleable.BottomAppBar_hideOnScroll;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.BottomNavigationView = global::NFCSample.Droid.Resource.Styleable.BottomNavigationView;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.BottomNavigationView_elevation = global::NFCSample.Droid.Resource.Styleable.BottomNavigationView_elevation;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.BottomNavigationView_itemBackground = global::NFCSample.Droid.Resource.Styleable.BottomNavigationView_itemBackground;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.BottomNavigationView_itemHorizontalTranslationEnabled = global::NFCSample.Droid.Resource.Styleable.BottomNavigationView_itemHorizontalTranslationEnabled;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.BottomNavigationView_itemIconSize = global::NFCSample.Droid.Resource.Styleable.BottomNavigationView_itemIconSize;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.BottomNavigationView_itemIconTint = global::NFCSample.Droid.Resource.Styleable.BottomNavigationView_itemIconTint;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.BottomNavigationView_itemTextAppearanceActive = global::NFCSample.Droid.Resource.Styleable.BottomNavigationView_itemTextAppearanceActive;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.BottomNavigationView_itemTextAppearanceInactive = global::NFCSample.Droid.Resource.Styleable.BottomNavigationView_itemTextAppearanceInactive;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.BottomNavigationView_itemTextColor = global::NFCSample.Droid.Resource.Styleable.BottomNavigationView_itemTextColor;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.BottomNavigationView_labelVisibilityMode = global::NFCSample.Droid.Resource.Styleable.BottomNavigationView_labelVisibilityMode;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.BottomNavigationView_menu = global::NFCSample.Droid.Resource.Styleable.BottomNavigationView_menu;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.BottomSheetBehavior_Layout = global::NFCSample.Droid.Resource.Styleable.BottomSheetBehavior_Layout;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.BottomSheetBehavior_Layout_behavior_fitToContents = global::NFCSample.Droid.Resource.Styleable.BottomSheetBehavior_Layout_behavior_fitToContents;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.BottomSheetBehavior_Layout_behavior_hideable = global::NFCSample.Droid.Resource.Styleable.BottomSheetBehavior_Layout_behavior_hideable;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.BottomSheetBehavior_Layout_behavior_peekHeight = global::NFCSample.Droid.Resource.Styleable.BottomSheetBehavior_Layout_behavior_peekHeight;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.BottomSheetBehavior_Layout_behavior_skipCollapsed = global::NFCSample.Droid.Resource.Styleable.BottomSheetBehavior_Layout_behavior_skipCollapsed;
@@ -1697,6 +2112,48 @@ namespace NFCSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.CardView_contentPaddingLeft = global::NFCSample.Droid.Resource.Styleable.CardView_contentPaddingLeft;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.CardView_contentPaddingRight = global::NFCSample.Droid.Resource.Styleable.CardView_contentPaddingRight;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.CardView_contentPaddingTop = global::NFCSample.Droid.Resource.Styleable.CardView_contentPaddingTop;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Chip = global::NFCSample.Droid.Resource.Styleable.Chip;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Chip_android_checkable = global::NFCSample.Droid.Resource.Styleable.Chip_android_checkable;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Chip_android_ellipsize = global::NFCSample.Droid.Resource.Styleable.Chip_android_ellipsize;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Chip_android_maxWidth = global::NFCSample.Droid.Resource.Styleable.Chip_android_maxWidth;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Chip_android_text = global::NFCSample.Droid.Resource.Styleable.Chip_android_text;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Chip_android_textAppearance = global::NFCSample.Droid.Resource.Styleable.Chip_android_textAppearance;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Chip_checkedIcon = global::NFCSample.Droid.Resource.Styleable.Chip_checkedIcon;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Chip_checkedIconEnabled = global::NFCSample.Droid.Resource.Styleable.Chip_checkedIconEnabled;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Chip_checkedIconVisible = global::NFCSample.Droid.Resource.Styleable.Chip_checkedIconVisible;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Chip_chipBackgroundColor = global::NFCSample.Droid.Resource.Styleable.Chip_chipBackgroundColor;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Chip_chipCornerRadius = global::NFCSample.Droid.Resource.Styleable.Chip_chipCornerRadius;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Chip_chipEndPadding = global::NFCSample.Droid.Resource.Styleable.Chip_chipEndPadding;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Chip_chipIcon = global::NFCSample.Droid.Resource.Styleable.Chip_chipIcon;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Chip_chipIconEnabled = global::NFCSample.Droid.Resource.Styleable.Chip_chipIconEnabled;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Chip_chipIconSize = global::NFCSample.Droid.Resource.Styleable.Chip_chipIconSize;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Chip_chipIconTint = global::NFCSample.Droid.Resource.Styleable.Chip_chipIconTint;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Chip_chipIconVisible = global::NFCSample.Droid.Resource.Styleable.Chip_chipIconVisible;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Chip_chipMinHeight = global::NFCSample.Droid.Resource.Styleable.Chip_chipMinHeight;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Chip_chipStartPadding = global::NFCSample.Droid.Resource.Styleable.Chip_chipStartPadding;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Chip_chipStrokeColor = global::NFCSample.Droid.Resource.Styleable.Chip_chipStrokeColor;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Chip_chipStrokeWidth = global::NFCSample.Droid.Resource.Styleable.Chip_chipStrokeWidth;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Chip_closeIcon = global::NFCSample.Droid.Resource.Styleable.Chip_closeIcon;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Chip_closeIconEnabled = global::NFCSample.Droid.Resource.Styleable.Chip_closeIconEnabled;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Chip_closeIconEndPadding = global::NFCSample.Droid.Resource.Styleable.Chip_closeIconEndPadding;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Chip_closeIconSize = global::NFCSample.Droid.Resource.Styleable.Chip_closeIconSize;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Chip_closeIconStartPadding = global::NFCSample.Droid.Resource.Styleable.Chip_closeIconStartPadding;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Chip_closeIconTint = global::NFCSample.Droid.Resource.Styleable.Chip_closeIconTint;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Chip_closeIconVisible = global::NFCSample.Droid.Resource.Styleable.Chip_closeIconVisible;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Chip_hideMotionSpec = global::NFCSample.Droid.Resource.Styleable.Chip_hideMotionSpec;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Chip_iconEndPadding = global::NFCSample.Droid.Resource.Styleable.Chip_iconEndPadding;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Chip_iconStartPadding = global::NFCSample.Droid.Resource.Styleable.Chip_iconStartPadding;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Chip_rippleColor = global::NFCSample.Droid.Resource.Styleable.Chip_rippleColor;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Chip_showMotionSpec = global::NFCSample.Droid.Resource.Styleable.Chip_showMotionSpec;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Chip_textEndPadding = global::NFCSample.Droid.Resource.Styleable.Chip_textEndPadding;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Chip_textStartPadding = global::NFCSample.Droid.Resource.Styleable.Chip_textStartPadding;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.ChipGroup = global::NFCSample.Droid.Resource.Styleable.ChipGroup;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.ChipGroup_checkedChip = global::NFCSample.Droid.Resource.Styleable.ChipGroup_checkedChip;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.ChipGroup_chipSpacing = global::NFCSample.Droid.Resource.Styleable.ChipGroup_chipSpacing;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.ChipGroup_chipSpacingHorizontal = global::NFCSample.Droid.Resource.Styleable.ChipGroup_chipSpacingHorizontal;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.ChipGroup_chipSpacingVertical = global::NFCSample.Droid.Resource.Styleable.ChipGroup_chipSpacingVertical;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.ChipGroup_singleLine = global::NFCSample.Droid.Resource.Styleable.ChipGroup_singleLine;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.ChipGroup_singleSelection = global::NFCSample.Droid.Resource.Styleable.ChipGroup_singleSelection;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.CollapsingToolbarLayout = global::NFCSample.Droid.Resource.Styleable.CollapsingToolbarLayout;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.CollapsingToolbarLayout_collapsedTitleGravity = global::NFCSample.Droid.Resource.Styleable.CollapsingToolbarLayout_collapsedTitleGravity;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.CollapsingToolbarLayout_collapsedTitleTextAppearance = global::NFCSample.Droid.Resource.Styleable.CollapsingToolbarLayout_collapsedTitleTextAppearance;
@@ -1739,7 +2196,6 @@ namespace NFCSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.DesignTheme = global::NFCSample.Droid.Resource.Styleable.DesignTheme;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.DesignTheme_bottomSheetDialogTheme = global::NFCSample.Droid.Resource.Styleable.DesignTheme_bottomSheetDialogTheme;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.DesignTheme_bottomSheetStyle = global::NFCSample.Droid.Resource.Styleable.DesignTheme_bottomSheetStyle;
-			global::Xamarin.Forms.Platform.Android.Resource.Styleable.DesignTheme_textColorError = global::NFCSample.Droid.Resource.Styleable.DesignTheme_textColorError;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.DrawerArrowToggle = global::NFCSample.Droid.Resource.Styleable.DrawerArrowToggle;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.DrawerArrowToggle_arrowHeadLength = global::NFCSample.Droid.Resource.Styleable.DrawerArrowToggle_arrowHeadLength;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.DrawerArrowToggle_arrowShaftLength = global::NFCSample.Droid.Resource.Styleable.DrawerArrowToggle_arrowShaftLength;
@@ -1754,12 +2210,20 @@ namespace NFCSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.FloatingActionButton_backgroundTintMode = global::NFCSample.Droid.Resource.Styleable.FloatingActionButton_backgroundTintMode;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.FloatingActionButton_borderWidth = global::NFCSample.Droid.Resource.Styleable.FloatingActionButton_borderWidth;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.FloatingActionButton_elevation = global::NFCSample.Droid.Resource.Styleable.FloatingActionButton_elevation;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.FloatingActionButton_fabCustomSize = global::NFCSample.Droid.Resource.Styleable.FloatingActionButton_fabCustomSize;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.FloatingActionButton_fabSize = global::NFCSample.Droid.Resource.Styleable.FloatingActionButton_fabSize;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.FloatingActionButton_hideMotionSpec = global::NFCSample.Droid.Resource.Styleable.FloatingActionButton_hideMotionSpec;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.FloatingActionButton_hoveredFocusedTranslationZ = global::NFCSample.Droid.Resource.Styleable.FloatingActionButton_hoveredFocusedTranslationZ;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.FloatingActionButton_maxImageSize = global::NFCSample.Droid.Resource.Styleable.FloatingActionButton_maxImageSize;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.FloatingActionButton_pressedTranslationZ = global::NFCSample.Droid.Resource.Styleable.FloatingActionButton_pressedTranslationZ;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.FloatingActionButton_rippleColor = global::NFCSample.Droid.Resource.Styleable.FloatingActionButton_rippleColor;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.FloatingActionButton_showMotionSpec = global::NFCSample.Droid.Resource.Styleable.FloatingActionButton_showMotionSpec;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.FloatingActionButton_useCompatPadding = global::NFCSample.Droid.Resource.Styleable.FloatingActionButton_useCompatPadding;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.FloatingActionButton_Behavior_Layout = global::NFCSample.Droid.Resource.Styleable.FloatingActionButton_Behavior_Layout;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.FloatingActionButton_Behavior_Layout_behavior_autoHide = global::NFCSample.Droid.Resource.Styleable.FloatingActionButton_Behavior_Layout_behavior_autoHide;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.FlowLayout = global::NFCSample.Droid.Resource.Styleable.FlowLayout;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.FlowLayout_itemSpacing = global::NFCSample.Droid.Resource.Styleable.FlowLayout_itemSpacing;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.FlowLayout_lineSpacing = global::NFCSample.Droid.Resource.Styleable.FlowLayout_lineSpacing;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.FontFamily = global::NFCSample.Droid.Resource.Styleable.FontFamily;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.FontFamily_fontProviderAuthority = global::NFCSample.Droid.Resource.Styleable.FontFamily_fontProviderAuthority;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.FontFamily_fontProviderCerts = global::NFCSample.Droid.Resource.Styleable.FontFamily_fontProviderCerts;
@@ -1770,14 +2234,34 @@ namespace NFCSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.FontFamilyFont = global::NFCSample.Droid.Resource.Styleable.FontFamilyFont;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.FontFamilyFont_android_font = global::NFCSample.Droid.Resource.Styleable.FontFamilyFont_android_font;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.FontFamilyFont_android_fontStyle = global::NFCSample.Droid.Resource.Styleable.FontFamilyFont_android_fontStyle;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.FontFamilyFont_android_fontVariationSettings = global::NFCSample.Droid.Resource.Styleable.FontFamilyFont_android_fontVariationSettings;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.FontFamilyFont_android_fontWeight = global::NFCSample.Droid.Resource.Styleable.FontFamilyFont_android_fontWeight;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.FontFamilyFont_android_ttcIndex = global::NFCSample.Droid.Resource.Styleable.FontFamilyFont_android_ttcIndex;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.FontFamilyFont_font = global::NFCSample.Droid.Resource.Styleable.FontFamilyFont_font;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.FontFamilyFont_fontStyle = global::NFCSample.Droid.Resource.Styleable.FontFamilyFont_fontStyle;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.FontFamilyFont_fontVariationSettings = global::NFCSample.Droid.Resource.Styleable.FontFamilyFont_fontVariationSettings;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.FontFamilyFont_fontWeight = global::NFCSample.Droid.Resource.Styleable.FontFamilyFont_fontWeight;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.FontFamilyFont_ttcIndex = global::NFCSample.Droid.Resource.Styleable.FontFamilyFont_ttcIndex;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.ForegroundLinearLayout = global::NFCSample.Droid.Resource.Styleable.ForegroundLinearLayout;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.ForegroundLinearLayout_android_foreground = global::NFCSample.Droid.Resource.Styleable.ForegroundLinearLayout_android_foreground;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.ForegroundLinearLayout_android_foregroundGravity = global::NFCSample.Droid.Resource.Styleable.ForegroundLinearLayout_android_foregroundGravity;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.ForegroundLinearLayout_foregroundInsidePadding = global::NFCSample.Droid.Resource.Styleable.ForegroundLinearLayout_foregroundInsidePadding;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.GradientColor = global::NFCSample.Droid.Resource.Styleable.GradientColor;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.GradientColor_android_centerColor = global::NFCSample.Droid.Resource.Styleable.GradientColor_android_centerColor;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.GradientColor_android_centerX = global::NFCSample.Droid.Resource.Styleable.GradientColor_android_centerX;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.GradientColor_android_centerY = global::NFCSample.Droid.Resource.Styleable.GradientColor_android_centerY;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.GradientColor_android_endColor = global::NFCSample.Droid.Resource.Styleable.GradientColor_android_endColor;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.GradientColor_android_endX = global::NFCSample.Droid.Resource.Styleable.GradientColor_android_endX;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.GradientColor_android_endY = global::NFCSample.Droid.Resource.Styleable.GradientColor_android_endY;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.GradientColor_android_gradientRadius = global::NFCSample.Droid.Resource.Styleable.GradientColor_android_gradientRadius;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.GradientColor_android_startColor = global::NFCSample.Droid.Resource.Styleable.GradientColor_android_startColor;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.GradientColor_android_startX = global::NFCSample.Droid.Resource.Styleable.GradientColor_android_startX;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.GradientColor_android_startY = global::NFCSample.Droid.Resource.Styleable.GradientColor_android_startY;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.GradientColor_android_tileMode = global::NFCSample.Droid.Resource.Styleable.GradientColor_android_tileMode;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.GradientColor_android_type = global::NFCSample.Droid.Resource.Styleable.GradientColor_android_type;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.GradientColorItem = global::NFCSample.Droid.Resource.Styleable.GradientColorItem;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.GradientColorItem_android_color = global::NFCSample.Droid.Resource.Styleable.GradientColorItem_android_color;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.GradientColorItem_android_offset = global::NFCSample.Droid.Resource.Styleable.GradientColorItem_android_offset;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.LinearLayoutCompat = global::NFCSample.Droid.Resource.Styleable.LinearLayoutCompat;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.LinearLayoutCompat_android_baselineAligned = global::NFCSample.Droid.Resource.Styleable.LinearLayoutCompat_android_baselineAligned;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.LinearLayoutCompat_android_baselineAlignedChildIndex = global::NFCSample.Droid.Resource.Styleable.LinearLayoutCompat_android_baselineAlignedChildIndex;
@@ -1796,6 +2280,59 @@ namespace NFCSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.ListPopupWindow = global::NFCSample.Droid.Resource.Styleable.ListPopupWindow;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.ListPopupWindow_android_dropDownHorizontalOffset = global::NFCSample.Droid.Resource.Styleable.ListPopupWindow_android_dropDownHorizontalOffset;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.ListPopupWindow_android_dropDownVerticalOffset = global::NFCSample.Droid.Resource.Styleable.ListPopupWindow_android_dropDownVerticalOffset;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialButton = global::NFCSample.Droid.Resource.Styleable.MaterialButton;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialButton_android_insetBottom = global::NFCSample.Droid.Resource.Styleable.MaterialButton_android_insetBottom;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialButton_android_insetLeft = global::NFCSample.Droid.Resource.Styleable.MaterialButton_android_insetLeft;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialButton_android_insetRight = global::NFCSample.Droid.Resource.Styleable.MaterialButton_android_insetRight;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialButton_android_insetTop = global::NFCSample.Droid.Resource.Styleable.MaterialButton_android_insetTop;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialButton_backgroundTint = global::NFCSample.Droid.Resource.Styleable.MaterialButton_backgroundTint;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialButton_backgroundTintMode = global::NFCSample.Droid.Resource.Styleable.MaterialButton_backgroundTintMode;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialButton_cornerRadius = global::NFCSample.Droid.Resource.Styleable.MaterialButton_cornerRadius;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialButton_icon = global::NFCSample.Droid.Resource.Styleable.MaterialButton_icon;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialButton_iconGravity = global::NFCSample.Droid.Resource.Styleable.MaterialButton_iconGravity;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialButton_iconPadding = global::NFCSample.Droid.Resource.Styleable.MaterialButton_iconPadding;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialButton_iconSize = global::NFCSample.Droid.Resource.Styleable.MaterialButton_iconSize;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialButton_iconTint = global::NFCSample.Droid.Resource.Styleable.MaterialButton_iconTint;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialButton_iconTintMode = global::NFCSample.Droid.Resource.Styleable.MaterialButton_iconTintMode;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialButton_rippleColor = global::NFCSample.Droid.Resource.Styleable.MaterialButton_rippleColor;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialButton_strokeColor = global::NFCSample.Droid.Resource.Styleable.MaterialButton_strokeColor;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialButton_strokeWidth = global::NFCSample.Droid.Resource.Styleable.MaterialButton_strokeWidth;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialCardView = global::NFCSample.Droid.Resource.Styleable.MaterialCardView;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialCardView_strokeColor = global::NFCSample.Droid.Resource.Styleable.MaterialCardView_strokeColor;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialCardView_strokeWidth = global::NFCSample.Droid.Resource.Styleable.MaterialCardView_strokeWidth;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialComponentsTheme = global::NFCSample.Droid.Resource.Styleable.MaterialComponentsTheme;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialComponentsTheme_bottomSheetDialogTheme = global::NFCSample.Droid.Resource.Styleable.MaterialComponentsTheme_bottomSheetDialogTheme;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialComponentsTheme_bottomSheetStyle = global::NFCSample.Droid.Resource.Styleable.MaterialComponentsTheme_bottomSheetStyle;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialComponentsTheme_chipGroupStyle = global::NFCSample.Droid.Resource.Styleable.MaterialComponentsTheme_chipGroupStyle;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialComponentsTheme_chipStandaloneStyle = global::NFCSample.Droid.Resource.Styleable.MaterialComponentsTheme_chipStandaloneStyle;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialComponentsTheme_chipStyle = global::NFCSample.Droid.Resource.Styleable.MaterialComponentsTheme_chipStyle;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialComponentsTheme_colorAccent = global::NFCSample.Droid.Resource.Styleable.MaterialComponentsTheme_colorAccent;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialComponentsTheme_colorBackgroundFloating = global::NFCSample.Droid.Resource.Styleable.MaterialComponentsTheme_colorBackgroundFloating;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialComponentsTheme_colorPrimary = global::NFCSample.Droid.Resource.Styleable.MaterialComponentsTheme_colorPrimary;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialComponentsTheme_colorPrimaryDark = global::NFCSample.Droid.Resource.Styleable.MaterialComponentsTheme_colorPrimaryDark;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialComponentsTheme_colorSecondary = global::NFCSample.Droid.Resource.Styleable.MaterialComponentsTheme_colorSecondary;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialComponentsTheme_editTextStyle = global::NFCSample.Droid.Resource.Styleable.MaterialComponentsTheme_editTextStyle;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialComponentsTheme_floatingActionButtonStyle = global::NFCSample.Droid.Resource.Styleable.MaterialComponentsTheme_floatingActionButtonStyle;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialComponentsTheme_materialButtonStyle = global::NFCSample.Droid.Resource.Styleable.MaterialComponentsTheme_materialButtonStyle;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialComponentsTheme_materialCardViewStyle = global::NFCSample.Droid.Resource.Styleable.MaterialComponentsTheme_materialCardViewStyle;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialComponentsTheme_navigationViewStyle = global::NFCSample.Droid.Resource.Styleable.MaterialComponentsTheme_navigationViewStyle;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialComponentsTheme_scrimBackground = global::NFCSample.Droid.Resource.Styleable.MaterialComponentsTheme_scrimBackground;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialComponentsTheme_snackbarButtonStyle = global::NFCSample.Droid.Resource.Styleable.MaterialComponentsTheme_snackbarButtonStyle;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialComponentsTheme_tabStyle = global::NFCSample.Droid.Resource.Styleable.MaterialComponentsTheme_tabStyle;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialComponentsTheme_textAppearanceBody1 = global::NFCSample.Droid.Resource.Styleable.MaterialComponentsTheme_textAppearanceBody1;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialComponentsTheme_textAppearanceBody2 = global::NFCSample.Droid.Resource.Styleable.MaterialComponentsTheme_textAppearanceBody2;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialComponentsTheme_textAppearanceButton = global::NFCSample.Droid.Resource.Styleable.MaterialComponentsTheme_textAppearanceButton;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialComponentsTheme_textAppearanceCaption = global::NFCSample.Droid.Resource.Styleable.MaterialComponentsTheme_textAppearanceCaption;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialComponentsTheme_textAppearanceHeadline1 = global::NFCSample.Droid.Resource.Styleable.MaterialComponentsTheme_textAppearanceHeadline1;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialComponentsTheme_textAppearanceHeadline2 = global::NFCSample.Droid.Resource.Styleable.MaterialComponentsTheme_textAppearanceHeadline2;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialComponentsTheme_textAppearanceHeadline3 = global::NFCSample.Droid.Resource.Styleable.MaterialComponentsTheme_textAppearanceHeadline3;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialComponentsTheme_textAppearanceHeadline4 = global::NFCSample.Droid.Resource.Styleable.MaterialComponentsTheme_textAppearanceHeadline4;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialComponentsTheme_textAppearanceHeadline5 = global::NFCSample.Droid.Resource.Styleable.MaterialComponentsTheme_textAppearanceHeadline5;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialComponentsTheme_textAppearanceHeadline6 = global::NFCSample.Droid.Resource.Styleable.MaterialComponentsTheme_textAppearanceHeadline6;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialComponentsTheme_textAppearanceOverline = global::NFCSample.Droid.Resource.Styleable.MaterialComponentsTheme_textAppearanceOverline;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialComponentsTheme_textAppearanceSubtitle1 = global::NFCSample.Droid.Resource.Styleable.MaterialComponentsTheme_textAppearanceSubtitle1;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialComponentsTheme_textAppearanceSubtitle2 = global::NFCSample.Droid.Resource.Styleable.MaterialComponentsTheme_textAppearanceSubtitle2;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialComponentsTheme_textInputStyle = global::NFCSample.Droid.Resource.Styleable.MaterialComponentsTheme_textInputStyle;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MenuGroup = global::NFCSample.Droid.Resource.Styleable.MenuGroup;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MenuGroup_android_checkableBehavior = global::NFCSample.Droid.Resource.Styleable.MenuGroup_android_checkableBehavior;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MenuGroup_android_enabled = global::NFCSample.Droid.Resource.Styleable.MenuGroup_android_enabled;
@@ -1844,6 +2381,8 @@ namespace NFCSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.NavigationView_elevation = global::NFCSample.Droid.Resource.Styleable.NavigationView_elevation;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.NavigationView_headerLayout = global::NFCSample.Droid.Resource.Styleable.NavigationView_headerLayout;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.NavigationView_itemBackground = global::NFCSample.Droid.Resource.Styleable.NavigationView_itemBackground;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.NavigationView_itemHorizontalPadding = global::NFCSample.Droid.Resource.Styleable.NavigationView_itemHorizontalPadding;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.NavigationView_itemIconPadding = global::NFCSample.Droid.Resource.Styleable.NavigationView_itemIconPadding;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.NavigationView_itemIconTint = global::NFCSample.Droid.Resource.Styleable.NavigationView_itemIconTint;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.NavigationView_itemTextAppearance = global::NFCSample.Droid.Resource.Styleable.NavigationView_itemTextAppearance;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.NavigationView_itemTextColor = global::NFCSample.Droid.Resource.Styleable.NavigationView_itemTextColor;
@@ -1891,6 +2430,9 @@ namespace NFCSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.SearchView_submitBackground = global::NFCSample.Droid.Resource.Styleable.SearchView_submitBackground;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.SearchView_suggestionRowLayout = global::NFCSample.Droid.Resource.Styleable.SearchView_suggestionRowLayout;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.SearchView_voiceIcon = global::NFCSample.Droid.Resource.Styleable.SearchView_voiceIcon;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Snackbar = global::NFCSample.Droid.Resource.Styleable.Snackbar;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Snackbar_snackbarButtonStyle = global::NFCSample.Droid.Resource.Styleable.Snackbar_snackbarButtonStyle;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Snackbar_snackbarStyle = global::NFCSample.Droid.Resource.Styleable.Snackbar_snackbarStyle;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.SnackbarLayout = global::NFCSample.Droid.Resource.Styleable.SnackbarLayout;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.SnackbarLayout_android_maxWidth = global::NFCSample.Droid.Resource.Styleable.SnackbarLayout_android_maxWidth;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.SnackbarLayout_elevation = global::NFCSample.Droid.Resource.Styleable.SnackbarLayout_elevation;
@@ -1901,6 +2443,15 @@ namespace NFCSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Spinner_android_popupBackground = global::NFCSample.Droid.Resource.Styleable.Spinner_android_popupBackground;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Spinner_android_prompt = global::NFCSample.Droid.Resource.Styleable.Spinner_android_prompt;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Spinner_popupTheme = global::NFCSample.Droid.Resource.Styleable.Spinner_popupTheme;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.StateListDrawable = global::NFCSample.Droid.Resource.Styleable.StateListDrawable;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.StateListDrawable_android_constantSize = global::NFCSample.Droid.Resource.Styleable.StateListDrawable_android_constantSize;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.StateListDrawable_android_dither = global::NFCSample.Droid.Resource.Styleable.StateListDrawable_android_dither;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.StateListDrawable_android_enterFadeDuration = global::NFCSample.Droid.Resource.Styleable.StateListDrawable_android_enterFadeDuration;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.StateListDrawable_android_exitFadeDuration = global::NFCSample.Droid.Resource.Styleable.StateListDrawable_android_exitFadeDuration;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.StateListDrawable_android_variablePadding = global::NFCSample.Droid.Resource.Styleable.StateListDrawable_android_variablePadding;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.StateListDrawable_android_visible = global::NFCSample.Droid.Resource.Styleable.StateListDrawable_android_visible;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.StateListDrawableItem = global::NFCSample.Droid.Resource.Styleable.StateListDrawableItem;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.StateListDrawableItem_android_drawable = global::NFCSample.Droid.Resource.Styleable.StateListDrawableItem_android_drawable;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.SwitchCompat = global::NFCSample.Droid.Resource.Styleable.SwitchCompat;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.SwitchCompat_android_textOff = global::NFCSample.Droid.Resource.Styleable.SwitchCompat_android_textOff;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.SwitchCompat_android_textOn = global::NFCSample.Droid.Resource.Styleable.SwitchCompat_android_textOn;
@@ -1924,8 +2475,15 @@ namespace NFCSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TabLayout_tabBackground = global::NFCSample.Droid.Resource.Styleable.TabLayout_tabBackground;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TabLayout_tabContentStart = global::NFCSample.Droid.Resource.Styleable.TabLayout_tabContentStart;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TabLayout_tabGravity = global::NFCSample.Droid.Resource.Styleable.TabLayout_tabGravity;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TabLayout_tabIconTint = global::NFCSample.Droid.Resource.Styleable.TabLayout_tabIconTint;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TabLayout_tabIconTintMode = global::NFCSample.Droid.Resource.Styleable.TabLayout_tabIconTintMode;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TabLayout_tabIndicator = global::NFCSample.Droid.Resource.Styleable.TabLayout_tabIndicator;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TabLayout_tabIndicatorAnimationDuration = global::NFCSample.Droid.Resource.Styleable.TabLayout_tabIndicatorAnimationDuration;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TabLayout_tabIndicatorColor = global::NFCSample.Droid.Resource.Styleable.TabLayout_tabIndicatorColor;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TabLayout_tabIndicatorFullWidth = global::NFCSample.Droid.Resource.Styleable.TabLayout_tabIndicatorFullWidth;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TabLayout_tabIndicatorGravity = global::NFCSample.Droid.Resource.Styleable.TabLayout_tabIndicatorGravity;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TabLayout_tabIndicatorHeight = global::NFCSample.Droid.Resource.Styleable.TabLayout_tabIndicatorHeight;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TabLayout_tabInlineLabel = global::NFCSample.Droid.Resource.Styleable.TabLayout_tabInlineLabel;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TabLayout_tabMaxWidth = global::NFCSample.Droid.Resource.Styleable.TabLayout_tabMaxWidth;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TabLayout_tabMinWidth = global::NFCSample.Droid.Resource.Styleable.TabLayout_tabMinWidth;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TabLayout_tabMode = global::NFCSample.Droid.Resource.Styleable.TabLayout_tabMode;
@@ -1934,9 +2492,11 @@ namespace NFCSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TabLayout_tabPaddingEnd = global::NFCSample.Droid.Resource.Styleable.TabLayout_tabPaddingEnd;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TabLayout_tabPaddingStart = global::NFCSample.Droid.Resource.Styleable.TabLayout_tabPaddingStart;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TabLayout_tabPaddingTop = global::NFCSample.Droid.Resource.Styleable.TabLayout_tabPaddingTop;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TabLayout_tabRippleColor = global::NFCSample.Droid.Resource.Styleable.TabLayout_tabRippleColor;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TabLayout_tabSelectedTextColor = global::NFCSample.Droid.Resource.Styleable.TabLayout_tabSelectedTextColor;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TabLayout_tabTextAppearance = global::NFCSample.Droid.Resource.Styleable.TabLayout_tabTextAppearance;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TabLayout_tabTextColor = global::NFCSample.Droid.Resource.Styleable.TabLayout_tabTextColor;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TabLayout_tabUnboundedRipple = global::NFCSample.Droid.Resource.Styleable.TabLayout_tabUnboundedRipple;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TextAppearance = global::NFCSample.Droid.Resource.Styleable.TextAppearance;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TextAppearance_android_fontFamily = global::NFCSample.Droid.Resource.Styleable.TextAppearance_android_fontFamily;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TextAppearance_android_shadowColor = global::NFCSample.Droid.Resource.Styleable.TextAppearance_android_shadowColor;
@@ -1954,12 +2514,24 @@ namespace NFCSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TextInputLayout = global::NFCSample.Droid.Resource.Styleable.TextInputLayout;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TextInputLayout_android_hint = global::NFCSample.Droid.Resource.Styleable.TextInputLayout_android_hint;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TextInputLayout_android_textColorHint = global::NFCSample.Droid.Resource.Styleable.TextInputLayout_android_textColorHint;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TextInputLayout_boxBackgroundColor = global::NFCSample.Droid.Resource.Styleable.TextInputLayout_boxBackgroundColor;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TextInputLayout_boxBackgroundMode = global::NFCSample.Droid.Resource.Styleable.TextInputLayout_boxBackgroundMode;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TextInputLayout_boxCollapsedPaddingTop = global::NFCSample.Droid.Resource.Styleable.TextInputLayout_boxCollapsedPaddingTop;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TextInputLayout_boxCornerRadiusBottomEnd = global::NFCSample.Droid.Resource.Styleable.TextInputLayout_boxCornerRadiusBottomEnd;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TextInputLayout_boxCornerRadiusBottomStart = global::NFCSample.Droid.Resource.Styleable.TextInputLayout_boxCornerRadiusBottomStart;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TextInputLayout_boxCornerRadiusTopEnd = global::NFCSample.Droid.Resource.Styleable.TextInputLayout_boxCornerRadiusTopEnd;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TextInputLayout_boxCornerRadiusTopStart = global::NFCSample.Droid.Resource.Styleable.TextInputLayout_boxCornerRadiusTopStart;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TextInputLayout_boxStrokeColor = global::NFCSample.Droid.Resource.Styleable.TextInputLayout_boxStrokeColor;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TextInputLayout_boxStrokeWidth = global::NFCSample.Droid.Resource.Styleable.TextInputLayout_boxStrokeWidth;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TextInputLayout_counterEnabled = global::NFCSample.Droid.Resource.Styleable.TextInputLayout_counterEnabled;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TextInputLayout_counterMaxLength = global::NFCSample.Droid.Resource.Styleable.TextInputLayout_counterMaxLength;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TextInputLayout_counterOverflowTextAppearance = global::NFCSample.Droid.Resource.Styleable.TextInputLayout_counterOverflowTextAppearance;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TextInputLayout_counterTextAppearance = global::NFCSample.Droid.Resource.Styleable.TextInputLayout_counterTextAppearance;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TextInputLayout_errorEnabled = global::NFCSample.Droid.Resource.Styleable.TextInputLayout_errorEnabled;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TextInputLayout_errorTextAppearance = global::NFCSample.Droid.Resource.Styleable.TextInputLayout_errorTextAppearance;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TextInputLayout_helperText = global::NFCSample.Droid.Resource.Styleable.TextInputLayout_helperText;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TextInputLayout_helperTextEnabled = global::NFCSample.Droid.Resource.Styleable.TextInputLayout_helperTextEnabled;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TextInputLayout_helperTextTextAppearance = global::NFCSample.Droid.Resource.Styleable.TextInputLayout_helperTextTextAppearance;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TextInputLayout_hintAnimationEnabled = global::NFCSample.Droid.Resource.Styleable.TextInputLayout_hintAnimationEnabled;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TextInputLayout_hintEnabled = global::NFCSample.Droid.Resource.Styleable.TextInputLayout_hintEnabled;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TextInputLayout_hintTextAppearance = global::NFCSample.Droid.Resource.Styleable.TextInputLayout_hintTextAppearance;
@@ -1968,6 +2540,10 @@ namespace NFCSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TextInputLayout_passwordToggleEnabled = global::NFCSample.Droid.Resource.Styleable.TextInputLayout_passwordToggleEnabled;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TextInputLayout_passwordToggleTint = global::NFCSample.Droid.Resource.Styleable.TextInputLayout_passwordToggleTint;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TextInputLayout_passwordToggleTintMode = global::NFCSample.Droid.Resource.Styleable.TextInputLayout_passwordToggleTintMode;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.ThemeEnforcement = global::NFCSample.Droid.Resource.Styleable.ThemeEnforcement;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.ThemeEnforcement_android_textAppearance = global::NFCSample.Droid.Resource.Styleable.ThemeEnforcement_android_textAppearance;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.ThemeEnforcement_enforceMaterialTheme = global::NFCSample.Droid.Resource.Styleable.ThemeEnforcement_enforceMaterialTheme;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.ThemeEnforcement_enforceTextAppearance = global::NFCSample.Droid.Resource.Styleable.ThemeEnforcement_enforceTextAppearance;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Toolbar = global::NFCSample.Droid.Resource.Styleable.Toolbar;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Toolbar_android_gravity = global::NFCSample.Droid.Resource.Styleable.Toolbar_android_gravity;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Toolbar_android_minHeight = global::NFCSample.Droid.Resource.Styleable.Toolbar_android_minHeight;
@@ -2048,34 +2624,34 @@ namespace NFCSample.Droid
 			public const int abc_slide_out_top = 2130771977;
 			
 			// aapt resource value: 0x7F01000A
-			public const int design_bottom_sheet_slide_in = 2130771978;
+			public const int abc_tooltip_enter = 2130771978;
 			
 			// aapt resource value: 0x7F01000B
-			public const int design_bottom_sheet_slide_out = 2130771979;
+			public const int abc_tooltip_exit = 2130771979;
 			
 			// aapt resource value: 0x7F01000C
-			public const int design_snackbar_in = 2130771980;
+			public const int design_bottom_sheet_slide_in = 2130771980;
 			
 			// aapt resource value: 0x7F01000D
-			public const int design_snackbar_out = 2130771981;
+			public const int design_bottom_sheet_slide_out = 2130771981;
 			
 			// aapt resource value: 0x7F01000E
-			public const int EnterFromLeft = 2130771982;
+			public const int design_snackbar_in = 2130771982;
 			
 			// aapt resource value: 0x7F01000F
-			public const int EnterFromRight = 2130771983;
+			public const int design_snackbar_out = 2130771983;
 			
 			// aapt resource value: 0x7F010010
-			public const int ExitToLeft = 2130771984;
+			public const int EnterFromLeft = 2130771984;
 			
 			// aapt resource value: 0x7F010011
-			public const int ExitToRight = 2130771985;
+			public const int EnterFromRight = 2130771985;
 			
 			// aapt resource value: 0x7F010012
-			public const int tooltip_enter = 2130771986;
+			public const int ExitToLeft = 2130771986;
 			
 			// aapt resource value: 0x7F010013
-			public const int tooltip_exit = 2130771987;
+			public const int ExitToRight = 2130771987;
 			
 			static Animation()
 			{
@@ -2092,6 +2668,33 @@ namespace NFCSample.Droid
 			
 			// aapt resource value: 0x7F020000
 			public const int design_appbar_state_list_animator = 2130837504;
+			
+			// aapt resource value: 0x7F020001
+			public const int design_fab_hide_motion_spec = 2130837505;
+			
+			// aapt resource value: 0x7F020002
+			public const int design_fab_show_motion_spec = 2130837506;
+			
+			// aapt resource value: 0x7F020003
+			public const int mtrl_btn_state_list_anim = 2130837507;
+			
+			// aapt resource value: 0x7F020004
+			public const int mtrl_btn_unelevated_state_list_anim = 2130837508;
+			
+			// aapt resource value: 0x7F020005
+			public const int mtrl_chip_state_list_anim = 2130837509;
+			
+			// aapt resource value: 0x7F020006
+			public const int mtrl_fab_hide_motion_spec = 2130837510;
+			
+			// aapt resource value: 0x7F020007
+			public const int mtrl_fab_show_motion_spec = 2130837511;
+			
+			// aapt resource value: 0x7F020008
+			public const int mtrl_fab_transformation_sheet_collapse_spec = 2130837512;
+			
+			// aapt resource value: 0x7F020009
+			public const int mtrl_fab_transformation_sheet_expand_spec = 2130837513;
 			
 			static Animator()
 			{
@@ -2275,949 +2878,1309 @@ namespace NFCSample.Droid
 			public const int behavior_autoHide = 2130903095;
 			
 			// aapt resource value: 0x7F030038
-			public const int behavior_hideable = 2130903096;
+			public const int behavior_fitToContents = 2130903096;
 			
 			// aapt resource value: 0x7F030039
-			public const int behavior_overlapTop = 2130903097;
+			public const int behavior_hideable = 2130903097;
 			
 			// aapt resource value: 0x7F03003A
-			public const int behavior_peekHeight = 2130903098;
+			public const int behavior_overlapTop = 2130903098;
 			
 			// aapt resource value: 0x7F03003B
-			public const int behavior_skipCollapsed = 2130903099;
-			
-			// aapt resource value: 0x7F03003D
-			public const int borderlessButtonStyle = 2130903101;
+			public const int behavior_peekHeight = 2130903099;
 			
 			// aapt resource value: 0x7F03003C
-			public const int borderWidth = 2130903100;
+			public const int behavior_skipCollapsed = 2130903100;
 			
 			// aapt resource value: 0x7F03003E
-			public const int bottomSheetDialogTheme = 2130903102;
+			public const int borderlessButtonStyle = 2130903102;
+			
+			// aapt resource value: 0x7F03003D
+			public const int borderWidth = 2130903101;
 			
 			// aapt resource value: 0x7F03003F
-			public const int bottomSheetStyle = 2130903103;
+			public const int bottomAppBarStyle = 2130903103;
 			
 			// aapt resource value: 0x7F030040
-			public const int buttonBarButtonStyle = 2130903104;
+			public const int bottomNavigationStyle = 2130903104;
 			
 			// aapt resource value: 0x7F030041
-			public const int buttonBarNegativeButtonStyle = 2130903105;
+			public const int bottomSheetDialogTheme = 2130903105;
 			
 			// aapt resource value: 0x7F030042
-			public const int buttonBarNeutralButtonStyle = 2130903106;
+			public const int bottomSheetStyle = 2130903106;
 			
 			// aapt resource value: 0x7F030043
-			public const int buttonBarPositiveButtonStyle = 2130903107;
+			public const int boxBackgroundColor = 2130903107;
 			
 			// aapt resource value: 0x7F030044
-			public const int buttonBarStyle = 2130903108;
+			public const int boxBackgroundMode = 2130903108;
 			
 			// aapt resource value: 0x7F030045
-			public const int buttonGravity = 2130903109;
+			public const int boxCollapsedPaddingTop = 2130903109;
 			
 			// aapt resource value: 0x7F030046
-			public const int buttonPanelSideLayout = 2130903110;
+			public const int boxCornerRadiusBottomEnd = 2130903110;
 			
 			// aapt resource value: 0x7F030047
-			public const int buttonStyle = 2130903111;
+			public const int boxCornerRadiusBottomStart = 2130903111;
 			
 			// aapt resource value: 0x7F030048
-			public const int buttonStyleSmall = 2130903112;
+			public const int boxCornerRadiusTopEnd = 2130903112;
 			
 			// aapt resource value: 0x7F030049
-			public const int buttonTint = 2130903113;
+			public const int boxCornerRadiusTopStart = 2130903113;
 			
 			// aapt resource value: 0x7F03004A
-			public const int buttonTintMode = 2130903114;
+			public const int boxStrokeColor = 2130903114;
 			
 			// aapt resource value: 0x7F03004B
-			public const int cardBackgroundColor = 2130903115;
+			public const int boxStrokeWidth = 2130903115;
 			
 			// aapt resource value: 0x7F03004C
-			public const int cardCornerRadius = 2130903116;
+			public const int buttonBarButtonStyle = 2130903116;
 			
 			// aapt resource value: 0x7F03004D
-			public const int cardElevation = 2130903117;
+			public const int buttonBarNegativeButtonStyle = 2130903117;
 			
 			// aapt resource value: 0x7F03004E
-			public const int cardMaxElevation = 2130903118;
+			public const int buttonBarNeutralButtonStyle = 2130903118;
 			
 			// aapt resource value: 0x7F03004F
-			public const int cardPreventCornerOverlap = 2130903119;
+			public const int buttonBarPositiveButtonStyle = 2130903119;
 			
 			// aapt resource value: 0x7F030050
-			public const int cardUseCompatPadding = 2130903120;
+			public const int buttonBarStyle = 2130903120;
 			
 			// aapt resource value: 0x7F030051
-			public const int checkboxStyle = 2130903121;
+			public const int buttonGravity = 2130903121;
 			
 			// aapt resource value: 0x7F030052
-			public const int checkedTextViewStyle = 2130903122;
+			public const int buttonIconDimen = 2130903122;
 			
 			// aapt resource value: 0x7F030053
-			public const int closeIcon = 2130903123;
+			public const int buttonPanelSideLayout = 2130903123;
 			
 			// aapt resource value: 0x7F030054
-			public const int closeItemLayout = 2130903124;
+			public const int buttonStyle = 2130903124;
 			
 			// aapt resource value: 0x7F030055
-			public const int collapseContentDescription = 2130903125;
-			
-			// aapt resource value: 0x7F030057
-			public const int collapsedTitleGravity = 2130903127;
-			
-			// aapt resource value: 0x7F030058
-			public const int collapsedTitleTextAppearance = 2130903128;
+			public const int buttonStyleSmall = 2130903125;
 			
 			// aapt resource value: 0x7F030056
-			public const int collapseIcon = 2130903126;
+			public const int buttonTint = 2130903126;
+			
+			// aapt resource value: 0x7F030057
+			public const int buttonTintMode = 2130903127;
+			
+			// aapt resource value: 0x7F030058
+			public const int cardBackgroundColor = 2130903128;
 			
 			// aapt resource value: 0x7F030059
-			public const int color = 2130903129;
+			public const int cardCornerRadius = 2130903129;
 			
 			// aapt resource value: 0x7F03005A
-			public const int colorAccent = 2130903130;
+			public const int cardElevation = 2130903130;
 			
 			// aapt resource value: 0x7F03005B
-			public const int colorBackgroundFloating = 2130903131;
+			public const int cardMaxElevation = 2130903131;
 			
 			// aapt resource value: 0x7F03005C
-			public const int colorButtonNormal = 2130903132;
+			public const int cardPreventCornerOverlap = 2130903132;
 			
 			// aapt resource value: 0x7F03005D
-			public const int colorControlActivated = 2130903133;
+			public const int cardUseCompatPadding = 2130903133;
 			
 			// aapt resource value: 0x7F03005E
-			public const int colorControlHighlight = 2130903134;
+			public const int cardViewStyle = 2130903134;
 			
 			// aapt resource value: 0x7F03005F
-			public const int colorControlNormal = 2130903135;
+			public const int checkboxStyle = 2130903135;
 			
 			// aapt resource value: 0x7F030060
-			public const int colorError = 2130903136;
+			public const int checkedChip = 2130903136;
 			
 			// aapt resource value: 0x7F030061
-			public const int colorPrimary = 2130903137;
+			public const int checkedIcon = 2130903137;
 			
 			// aapt resource value: 0x7F030062
-			public const int colorPrimaryDark = 2130903138;
+			public const int checkedIconEnabled = 2130903138;
 			
 			// aapt resource value: 0x7F030063
-			public const int colorSwitchThumbNormal = 2130903139;
+			public const int checkedIconVisible = 2130903139;
 			
 			// aapt resource value: 0x7F030064
-			public const int commitIcon = 2130903140;
+			public const int checkedTextViewStyle = 2130903140;
 			
 			// aapt resource value: 0x7F030065
-			public const int contentDescription = 2130903141;
+			public const int chipBackgroundColor = 2130903141;
 			
 			// aapt resource value: 0x7F030066
-			public const int contentInsetEnd = 2130903142;
+			public const int chipCornerRadius = 2130903142;
 			
 			// aapt resource value: 0x7F030067
-			public const int contentInsetEndWithActions = 2130903143;
+			public const int chipEndPadding = 2130903143;
 			
 			// aapt resource value: 0x7F030068
-			public const int contentInsetLeft = 2130903144;
+			public const int chipGroupStyle = 2130903144;
 			
 			// aapt resource value: 0x7F030069
-			public const int contentInsetRight = 2130903145;
+			public const int chipIcon = 2130903145;
 			
 			// aapt resource value: 0x7F03006A
-			public const int contentInsetStart = 2130903146;
+			public const int chipIconEnabled = 2130903146;
 			
 			// aapt resource value: 0x7F03006B
-			public const int contentInsetStartWithNavigation = 2130903147;
+			public const int chipIconSize = 2130903147;
 			
 			// aapt resource value: 0x7F03006C
-			public const int contentPadding = 2130903148;
+			public const int chipIconTint = 2130903148;
 			
 			// aapt resource value: 0x7F03006D
-			public const int contentPaddingBottom = 2130903149;
+			public const int chipIconVisible = 2130903149;
 			
 			// aapt resource value: 0x7F03006E
-			public const int contentPaddingLeft = 2130903150;
+			public const int chipMinHeight = 2130903150;
 			
 			// aapt resource value: 0x7F03006F
-			public const int contentPaddingRight = 2130903151;
+			public const int chipSpacing = 2130903151;
 			
 			// aapt resource value: 0x7F030070
-			public const int contentPaddingTop = 2130903152;
+			public const int chipSpacingHorizontal = 2130903152;
 			
 			// aapt resource value: 0x7F030071
-			public const int contentScrim = 2130903153;
+			public const int chipSpacingVertical = 2130903153;
 			
 			// aapt resource value: 0x7F030072
-			public const int controlBackground = 2130903154;
+			public const int chipStandaloneStyle = 2130903154;
 			
 			// aapt resource value: 0x7F030073
-			public const int counterEnabled = 2130903155;
+			public const int chipStartPadding = 2130903155;
 			
 			// aapt resource value: 0x7F030074
-			public const int counterMaxLength = 2130903156;
+			public const int chipStrokeColor = 2130903156;
 			
 			// aapt resource value: 0x7F030075
-			public const int counterOverflowTextAppearance = 2130903157;
+			public const int chipStrokeWidth = 2130903157;
 			
 			// aapt resource value: 0x7F030076
-			public const int counterTextAppearance = 2130903158;
+			public const int chipStyle = 2130903158;
 			
 			// aapt resource value: 0x7F030077
-			public const int customNavigationLayout = 2130903159;
+			public const int closeIcon = 2130903159;
 			
 			// aapt resource value: 0x7F030078
-			public const int defaultQueryHint = 2130903160;
+			public const int closeIconEnabled = 2130903160;
 			
 			// aapt resource value: 0x7F030079
-			public const int dialogPreferredPadding = 2130903161;
+			public const int closeIconEndPadding = 2130903161;
 			
 			// aapt resource value: 0x7F03007A
-			public const int dialogTheme = 2130903162;
+			public const int closeIconSize = 2130903162;
 			
 			// aapt resource value: 0x7F03007B
-			public const int displayOptions = 2130903163;
+			public const int closeIconStartPadding = 2130903163;
 			
 			// aapt resource value: 0x7F03007C
-			public const int divider = 2130903164;
+			public const int closeIconTint = 2130903164;
 			
 			// aapt resource value: 0x7F03007D
-			public const int dividerHorizontal = 2130903165;
+			public const int closeIconVisible = 2130903165;
 			
 			// aapt resource value: 0x7F03007E
-			public const int dividerPadding = 2130903166;
+			public const int closeItemLayout = 2130903166;
 			
 			// aapt resource value: 0x7F03007F
-			public const int dividerVertical = 2130903167;
-			
-			// aapt resource value: 0x7F030080
-			public const int drawableSize = 2130903168;
+			public const int collapseContentDescription = 2130903167;
 			
 			// aapt resource value: 0x7F030081
-			public const int drawerArrowStyle = 2130903169;
-			
-			// aapt resource value: 0x7F030083
-			public const int dropdownListPreferredItemHeight = 2130903171;
+			public const int collapsedTitleGravity = 2130903169;
 			
 			// aapt resource value: 0x7F030082
-			public const int dropDownListViewStyle = 2130903170;
+			public const int collapsedTitleTextAppearance = 2130903170;
+			
+			// aapt resource value: 0x7F030080
+			public const int collapseIcon = 2130903168;
+			
+			// aapt resource value: 0x7F030083
+			public const int color = 2130903171;
 			
 			// aapt resource value: 0x7F030084
-			public const int editTextBackground = 2130903172;
+			public const int colorAccent = 2130903172;
 			
 			// aapt resource value: 0x7F030085
-			public const int editTextColor = 2130903173;
+			public const int colorBackgroundFloating = 2130903173;
 			
 			// aapt resource value: 0x7F030086
-			public const int editTextStyle = 2130903174;
+			public const int colorButtonNormal = 2130903174;
 			
 			// aapt resource value: 0x7F030087
-			public const int elevation = 2130903175;
+			public const int colorControlActivated = 2130903175;
 			
 			// aapt resource value: 0x7F030088
-			public const int errorEnabled = 2130903176;
+			public const int colorControlHighlight = 2130903176;
 			
 			// aapt resource value: 0x7F030089
-			public const int errorTextAppearance = 2130903177;
+			public const int colorControlNormal = 2130903177;
 			
 			// aapt resource value: 0x7F03008A
-			public const int expandActivityOverflowButtonDrawable = 2130903178;
+			public const int colorError = 2130903178;
 			
 			// aapt resource value: 0x7F03008B
-			public const int expanded = 2130903179;
+			public const int colorPrimary = 2130903179;
 			
 			// aapt resource value: 0x7F03008C
-			public const int expandedTitleGravity = 2130903180;
+			public const int colorPrimaryDark = 2130903180;
 			
 			// aapt resource value: 0x7F03008D
-			public const int expandedTitleMargin = 2130903181;
+			public const int colorSecondary = 2130903181;
 			
 			// aapt resource value: 0x7F03008E
-			public const int expandedTitleMarginBottom = 2130903182;
+			public const int colorSwitchThumbNormal = 2130903182;
 			
 			// aapt resource value: 0x7F03008F
-			public const int expandedTitleMarginEnd = 2130903183;
+			public const int commitIcon = 2130903183;
 			
 			// aapt resource value: 0x7F030090
-			public const int expandedTitleMarginStart = 2130903184;
+			public const int contentDescription = 2130903184;
 			
 			// aapt resource value: 0x7F030091
-			public const int expandedTitleMarginTop = 2130903185;
+			public const int contentInsetEnd = 2130903185;
 			
 			// aapt resource value: 0x7F030092
-			public const int expandedTitleTextAppearance = 2130903186;
+			public const int contentInsetEndWithActions = 2130903186;
 			
 			// aapt resource value: 0x7F030093
-			public const int externalRouteEnabledDrawable = 2130903187;
+			public const int contentInsetLeft = 2130903187;
 			
 			// aapt resource value: 0x7F030094
-			public const int fabSize = 2130903188;
+			public const int contentInsetRight = 2130903188;
 			
 			// aapt resource value: 0x7F030095
-			public const int fastScrollEnabled = 2130903189;
+			public const int contentInsetStart = 2130903189;
 			
 			// aapt resource value: 0x7F030096
-			public const int fastScrollHorizontalThumbDrawable = 2130903190;
+			public const int contentInsetStartWithNavigation = 2130903190;
 			
 			// aapt resource value: 0x7F030097
-			public const int fastScrollHorizontalTrackDrawable = 2130903191;
+			public const int contentPadding = 2130903191;
 			
 			// aapt resource value: 0x7F030098
-			public const int fastScrollVerticalThumbDrawable = 2130903192;
+			public const int contentPaddingBottom = 2130903192;
 			
 			// aapt resource value: 0x7F030099
-			public const int fastScrollVerticalTrackDrawable = 2130903193;
+			public const int contentPaddingLeft = 2130903193;
 			
 			// aapt resource value: 0x7F03009A
-			public const int font = 2130903194;
+			public const int contentPaddingRight = 2130903194;
 			
 			// aapt resource value: 0x7F03009B
-			public const int fontFamily = 2130903195;
+			public const int contentPaddingTop = 2130903195;
 			
 			// aapt resource value: 0x7F03009C
-			public const int fontProviderAuthority = 2130903196;
+			public const int contentScrim = 2130903196;
 			
 			// aapt resource value: 0x7F03009D
-			public const int fontProviderCerts = 2130903197;
+			public const int controlBackground = 2130903197;
 			
 			// aapt resource value: 0x7F03009E
-			public const int fontProviderFetchStrategy = 2130903198;
+			public const int coordinatorLayoutStyle = 2130903198;
 			
 			// aapt resource value: 0x7F03009F
-			public const int fontProviderFetchTimeout = 2130903199;
+			public const int cornerRadius = 2130903199;
 			
 			// aapt resource value: 0x7F0300A0
-			public const int fontProviderPackage = 2130903200;
+			public const int counterEnabled = 2130903200;
 			
 			// aapt resource value: 0x7F0300A1
-			public const int fontProviderQuery = 2130903201;
+			public const int counterMaxLength = 2130903201;
 			
 			// aapt resource value: 0x7F0300A2
-			public const int fontStyle = 2130903202;
+			public const int counterOverflowTextAppearance = 2130903202;
 			
 			// aapt resource value: 0x7F0300A3
-			public const int fontWeight = 2130903203;
+			public const int counterTextAppearance = 2130903203;
 			
 			// aapt resource value: 0x7F0300A4
-			public const int foregroundInsidePadding = 2130903204;
+			public const int customNavigationLayout = 2130903204;
 			
 			// aapt resource value: 0x7F0300A5
-			public const int gapBetweenBars = 2130903205;
+			public const int defaultQueryHint = 2130903205;
 			
 			// aapt resource value: 0x7F0300A6
-			public const int goIcon = 2130903206;
+			public const int dialogCornerRadius = 2130903206;
 			
 			// aapt resource value: 0x7F0300A7
-			public const int headerLayout = 2130903207;
+			public const int dialogPreferredPadding = 2130903207;
 			
 			// aapt resource value: 0x7F0300A8
-			public const int height = 2130903208;
+			public const int dialogTheme = 2130903208;
 			
 			// aapt resource value: 0x7F0300A9
-			public const int hideOnContentScroll = 2130903209;
+			public const int displayOptions = 2130903209;
 			
 			// aapt resource value: 0x7F0300AA
-			public const int hintAnimationEnabled = 2130903210;
+			public const int divider = 2130903210;
 			
 			// aapt resource value: 0x7F0300AB
-			public const int hintEnabled = 2130903211;
+			public const int dividerHorizontal = 2130903211;
 			
 			// aapt resource value: 0x7F0300AC
-			public const int hintTextAppearance = 2130903212;
+			public const int dividerPadding = 2130903212;
 			
 			// aapt resource value: 0x7F0300AD
-			public const int homeAsUpIndicator = 2130903213;
+			public const int dividerVertical = 2130903213;
 			
 			// aapt resource value: 0x7F0300AE
-			public const int homeLayout = 2130903214;
+			public const int drawableSize = 2130903214;
 			
 			// aapt resource value: 0x7F0300AF
-			public const int icon = 2130903215;
-			
-			// aapt resource value: 0x7F0300B2
-			public const int iconifiedByDefault = 2130903218;
-			
-			// aapt resource value: 0x7F0300B0
-			public const int iconTint = 2130903216;
+			public const int drawerArrowStyle = 2130903215;
 			
 			// aapt resource value: 0x7F0300B1
-			public const int iconTintMode = 2130903217;
+			public const int dropdownListPreferredItemHeight = 2130903217;
+			
+			// aapt resource value: 0x7F0300B0
+			public const int dropDownListViewStyle = 2130903216;
+			
+			// aapt resource value: 0x7F0300B2
+			public const int editTextBackground = 2130903218;
 			
 			// aapt resource value: 0x7F0300B3
-			public const int imageButtonStyle = 2130903219;
+			public const int editTextColor = 2130903219;
 			
 			// aapt resource value: 0x7F0300B4
-			public const int indeterminateProgressStyle = 2130903220;
+			public const int editTextStyle = 2130903220;
 			
 			// aapt resource value: 0x7F0300B5
-			public const int initialActivityCount = 2130903221;
+			public const int elevation = 2130903221;
 			
 			// aapt resource value: 0x7F0300B6
-			public const int insetForeground = 2130903222;
+			public const int enforceMaterialTheme = 2130903222;
 			
 			// aapt resource value: 0x7F0300B7
-			public const int isLightTheme = 2130903223;
+			public const int enforceTextAppearance = 2130903223;
 			
 			// aapt resource value: 0x7F0300B8
-			public const int itemBackground = 2130903224;
+			public const int errorEnabled = 2130903224;
 			
 			// aapt resource value: 0x7F0300B9
-			public const int itemIconTint = 2130903225;
+			public const int errorTextAppearance = 2130903225;
 			
 			// aapt resource value: 0x7F0300BA
-			public const int itemPadding = 2130903226;
+			public const int expandActivityOverflowButtonDrawable = 2130903226;
 			
 			// aapt resource value: 0x7F0300BB
-			public const int itemTextAppearance = 2130903227;
+			public const int expanded = 2130903227;
 			
 			// aapt resource value: 0x7F0300BC
-			public const int itemTextColor = 2130903228;
+			public const int expandedTitleGravity = 2130903228;
 			
 			// aapt resource value: 0x7F0300BD
-			public const int keylines = 2130903229;
+			public const int expandedTitleMargin = 2130903229;
 			
 			// aapt resource value: 0x7F0300BE
-			public const int layout = 2130903230;
+			public const int expandedTitleMarginBottom = 2130903230;
 			
 			// aapt resource value: 0x7F0300BF
-			public const int layoutManager = 2130903231;
+			public const int expandedTitleMarginEnd = 2130903231;
 			
 			// aapt resource value: 0x7F0300C0
-			public const int layout_anchor = 2130903232;
+			public const int expandedTitleMarginStart = 2130903232;
 			
 			// aapt resource value: 0x7F0300C1
-			public const int layout_anchorGravity = 2130903233;
+			public const int expandedTitleMarginTop = 2130903233;
 			
 			// aapt resource value: 0x7F0300C2
-			public const int layout_behavior = 2130903234;
+			public const int expandedTitleTextAppearance = 2130903234;
 			
 			// aapt resource value: 0x7F0300C3
-			public const int layout_collapseMode = 2130903235;
+			public const int externalRouteEnabledDrawable = 2130903235;
 			
 			// aapt resource value: 0x7F0300C4
-			public const int layout_collapseParallaxMultiplier = 2130903236;
+			public const int fabAlignmentMode = 2130903236;
 			
 			// aapt resource value: 0x7F0300C5
-			public const int layout_dodgeInsetEdges = 2130903237;
+			public const int fabCradleMargin = 2130903237;
 			
 			// aapt resource value: 0x7F0300C6
-			public const int layout_insetEdge = 2130903238;
+			public const int fabCradleRoundedCornerRadius = 2130903238;
 			
 			// aapt resource value: 0x7F0300C7
-			public const int layout_keyline = 2130903239;
+			public const int fabCradleVerticalOffset = 2130903239;
 			
 			// aapt resource value: 0x7F0300C8
-			public const int layout_scrollFlags = 2130903240;
+			public const int fabCustomSize = 2130903240;
 			
 			// aapt resource value: 0x7F0300C9
-			public const int layout_scrollInterpolator = 2130903241;
+			public const int fabSize = 2130903241;
 			
 			// aapt resource value: 0x7F0300CA
-			public const int listChoiceBackgroundIndicator = 2130903242;
+			public const int fastScrollEnabled = 2130903242;
 			
 			// aapt resource value: 0x7F0300CB
-			public const int listDividerAlertDialog = 2130903243;
+			public const int fastScrollHorizontalThumbDrawable = 2130903243;
 			
 			// aapt resource value: 0x7F0300CC
-			public const int listItemLayout = 2130903244;
+			public const int fastScrollHorizontalTrackDrawable = 2130903244;
 			
 			// aapt resource value: 0x7F0300CD
-			public const int listLayout = 2130903245;
+			public const int fastScrollVerticalThumbDrawable = 2130903245;
 			
 			// aapt resource value: 0x7F0300CE
-			public const int listMenuViewStyle = 2130903246;
+			public const int fastScrollVerticalTrackDrawable = 2130903246;
 			
 			// aapt resource value: 0x7F0300CF
-			public const int listPopupWindowStyle = 2130903247;
+			public const int firstBaselineToTopHeight = 2130903247;
 			
 			// aapt resource value: 0x7F0300D0
-			public const int listPreferredItemHeight = 2130903248;
+			public const int floatingActionButtonStyle = 2130903248;
 			
 			// aapt resource value: 0x7F0300D1
-			public const int listPreferredItemHeightLarge = 2130903249;
+			public const int font = 2130903249;
 			
 			// aapt resource value: 0x7F0300D2
-			public const int listPreferredItemHeightSmall = 2130903250;
+			public const int fontFamily = 2130903250;
 			
 			// aapt resource value: 0x7F0300D3
-			public const int listPreferredItemPaddingLeft = 2130903251;
+			public const int fontProviderAuthority = 2130903251;
 			
 			// aapt resource value: 0x7F0300D4
-			public const int listPreferredItemPaddingRight = 2130903252;
+			public const int fontProviderCerts = 2130903252;
 			
 			// aapt resource value: 0x7F0300D5
-			public const int logo = 2130903253;
+			public const int fontProviderFetchStrategy = 2130903253;
 			
 			// aapt resource value: 0x7F0300D6
-			public const int logoDescription = 2130903254;
+			public const int fontProviderFetchTimeout = 2130903254;
 			
 			// aapt resource value: 0x7F0300D7
-			public const int maxActionInlineWidth = 2130903255;
+			public const int fontProviderPackage = 2130903255;
 			
 			// aapt resource value: 0x7F0300D8
-			public const int maxButtonHeight = 2130903256;
+			public const int fontProviderQuery = 2130903256;
 			
 			// aapt resource value: 0x7F0300D9
-			public const int measureWithLargestChild = 2130903257;
+			public const int fontStyle = 2130903257;
 			
 			// aapt resource value: 0x7F0300DA
-			public const int mediaRouteAudioTrackDrawable = 2130903258;
+			public const int fontVariationSettings = 2130903258;
 			
 			// aapt resource value: 0x7F0300DB
-			public const int mediaRouteButtonStyle = 2130903259;
+			public const int fontWeight = 2130903259;
 			
 			// aapt resource value: 0x7F0300DC
-			public const int mediaRouteButtonTint = 2130903260;
+			public const int foregroundInsidePadding = 2130903260;
 			
 			// aapt resource value: 0x7F0300DD
-			public const int mediaRouteCloseDrawable = 2130903261;
+			public const int gapBetweenBars = 2130903261;
 			
 			// aapt resource value: 0x7F0300DE
-			public const int mediaRouteControlPanelThemeOverlay = 2130903262;
+			public const int goIcon = 2130903262;
 			
 			// aapt resource value: 0x7F0300DF
-			public const int mediaRouteDefaultIconDrawable = 2130903263;
+			public const int headerLayout = 2130903263;
 			
 			// aapt resource value: 0x7F0300E0
-			public const int mediaRoutePauseDrawable = 2130903264;
+			public const int height = 2130903264;
 			
 			// aapt resource value: 0x7F0300E1
-			public const int mediaRoutePlayDrawable = 2130903265;
+			public const int helperText = 2130903265;
 			
 			// aapt resource value: 0x7F0300E2
-			public const int mediaRouteSpeakerGroupIconDrawable = 2130903266;
+			public const int helperTextEnabled = 2130903266;
 			
 			// aapt resource value: 0x7F0300E3
-			public const int mediaRouteSpeakerIconDrawable = 2130903267;
+			public const int helperTextTextAppearance = 2130903267;
 			
 			// aapt resource value: 0x7F0300E4
-			public const int mediaRouteStopDrawable = 2130903268;
+			public const int hideMotionSpec = 2130903268;
 			
 			// aapt resource value: 0x7F0300E5
-			public const int mediaRouteTheme = 2130903269;
+			public const int hideOnContentScroll = 2130903269;
 			
 			// aapt resource value: 0x7F0300E6
-			public const int mediaRouteTvIconDrawable = 2130903270;
+			public const int hideOnScroll = 2130903270;
 			
 			// aapt resource value: 0x7F0300E7
-			public const int menu = 2130903271;
+			public const int hintAnimationEnabled = 2130903271;
 			
 			// aapt resource value: 0x7F0300E8
-			public const int multiChoiceItemLayout = 2130903272;
+			public const int hintEnabled = 2130903272;
 			
 			// aapt resource value: 0x7F0300E9
-			public const int navigationContentDescription = 2130903273;
+			public const int hintTextAppearance = 2130903273;
 			
 			// aapt resource value: 0x7F0300EA
-			public const int navigationIcon = 2130903274;
+			public const int homeAsUpIndicator = 2130903274;
 			
 			// aapt resource value: 0x7F0300EB
-			public const int navigationMode = 2130903275;
+			public const int homeLayout = 2130903275;
 			
 			// aapt resource value: 0x7F0300EC
-			public const int numericModifiers = 2130903276;
+			public const int hoveredFocusedTranslationZ = 2130903276;
 			
 			// aapt resource value: 0x7F0300ED
-			public const int overlapAnchor = 2130903277;
+			public const int icon = 2130903277;
 			
 			// aapt resource value: 0x7F0300EE
-			public const int paddingBottomNoButtons = 2130903278;
+			public const int iconEndPadding = 2130903278;
 			
 			// aapt resource value: 0x7F0300EF
-			public const int paddingEnd = 2130903279;
-			
-			// aapt resource value: 0x7F0300F0
-			public const int paddingStart = 2130903280;
-			
-			// aapt resource value: 0x7F0300F1
-			public const int paddingTopNoTitle = 2130903281;
-			
-			// aapt resource value: 0x7F0300F2
-			public const int panelBackground = 2130903282;
-			
-			// aapt resource value: 0x7F0300F3
-			public const int panelMenuListTheme = 2130903283;
-			
-			// aapt resource value: 0x7F0300F4
-			public const int panelMenuListWidth = 2130903284;
+			public const int iconGravity = 2130903279;
 			
 			// aapt resource value: 0x7F0300F5
-			public const int passwordToggleContentDescription = 2130903285;
+			public const int iconifiedByDefault = 2130903285;
+			
+			// aapt resource value: 0x7F0300F0
+			public const int iconPadding = 2130903280;
+			
+			// aapt resource value: 0x7F0300F1
+			public const int iconSize = 2130903281;
+			
+			// aapt resource value: 0x7F0300F2
+			public const int iconStartPadding = 2130903282;
+			
+			// aapt resource value: 0x7F0300F3
+			public const int iconTint = 2130903283;
+			
+			// aapt resource value: 0x7F0300F4
+			public const int iconTintMode = 2130903284;
 			
 			// aapt resource value: 0x7F0300F6
-			public const int passwordToggleDrawable = 2130903286;
+			public const int imageButtonStyle = 2130903286;
 			
 			// aapt resource value: 0x7F0300F7
-			public const int passwordToggleEnabled = 2130903287;
+			public const int indeterminateProgressStyle = 2130903287;
 			
 			// aapt resource value: 0x7F0300F8
-			public const int passwordToggleTint = 2130903288;
+			public const int initialActivityCount = 2130903288;
 			
 			// aapt resource value: 0x7F0300F9
-			public const int passwordToggleTintMode = 2130903289;
+			public const int insetForeground = 2130903289;
 			
 			// aapt resource value: 0x7F0300FA
-			public const int popupMenuStyle = 2130903290;
+			public const int isLightTheme = 2130903290;
 			
 			// aapt resource value: 0x7F0300FB
-			public const int popupTheme = 2130903291;
+			public const int itemBackground = 2130903291;
 			
 			// aapt resource value: 0x7F0300FC
-			public const int popupWindowStyle = 2130903292;
+			public const int itemHorizontalPadding = 2130903292;
 			
 			// aapt resource value: 0x7F0300FD
-			public const int preserveIconSpacing = 2130903293;
+			public const int itemHorizontalTranslationEnabled = 2130903293;
 			
 			// aapt resource value: 0x7F0300FE
-			public const int pressedTranslationZ = 2130903294;
+			public const int itemIconPadding = 2130903294;
 			
 			// aapt resource value: 0x7F0300FF
-			public const int progressBarPadding = 2130903295;
+			public const int itemIconSize = 2130903295;
 			
 			// aapt resource value: 0x7F030100
-			public const int progressBarStyle = 2130903296;
+			public const int itemIconTint = 2130903296;
 			
 			// aapt resource value: 0x7F030101
-			public const int queryBackground = 2130903297;
+			public const int itemPadding = 2130903297;
 			
 			// aapt resource value: 0x7F030102
-			public const int queryHint = 2130903298;
+			public const int itemSpacing = 2130903298;
 			
 			// aapt resource value: 0x7F030103
-			public const int radioButtonStyle = 2130903299;
+			public const int itemTextAppearance = 2130903299;
 			
 			// aapt resource value: 0x7F030104
-			public const int ratingBarStyle = 2130903300;
+			public const int itemTextAppearanceActive = 2130903300;
 			
 			// aapt resource value: 0x7F030105
-			public const int ratingBarStyleIndicator = 2130903301;
+			public const int itemTextAppearanceInactive = 2130903301;
 			
 			// aapt resource value: 0x7F030106
-			public const int ratingBarStyleSmall = 2130903302;
+			public const int itemTextColor = 2130903302;
 			
 			// aapt resource value: 0x7F030107
-			public const int reverseLayout = 2130903303;
+			public const int keylines = 2130903303;
 			
 			// aapt resource value: 0x7F030108
-			public const int rippleColor = 2130903304;
+			public const int labelVisibilityMode = 2130903304;
 			
 			// aapt resource value: 0x7F030109
-			public const int scrimAnimationDuration = 2130903305;
+			public const int lastBaselineToBottomHeight = 2130903305;
 			
 			// aapt resource value: 0x7F03010A
-			public const int scrimVisibleHeightTrigger = 2130903306;
+			public const int layout = 2130903306;
 			
 			// aapt resource value: 0x7F03010B
-			public const int searchHintIcon = 2130903307;
+			public const int layoutManager = 2130903307;
 			
 			// aapt resource value: 0x7F03010C
-			public const int searchIcon = 2130903308;
+			public const int layout_anchor = 2130903308;
 			
 			// aapt resource value: 0x7F03010D
-			public const int searchViewStyle = 2130903309;
+			public const int layout_anchorGravity = 2130903309;
 			
 			// aapt resource value: 0x7F03010E
-			public const int seekBarStyle = 2130903310;
+			public const int layout_behavior = 2130903310;
 			
 			// aapt resource value: 0x7F03010F
-			public const int selectableItemBackground = 2130903311;
+			public const int layout_collapseMode = 2130903311;
 			
 			// aapt resource value: 0x7F030110
-			public const int selectableItemBackgroundBorderless = 2130903312;
+			public const int layout_collapseParallaxMultiplier = 2130903312;
 			
 			// aapt resource value: 0x7F030111
-			public const int showAsAction = 2130903313;
+			public const int layout_dodgeInsetEdges = 2130903313;
 			
 			// aapt resource value: 0x7F030112
-			public const int showDividers = 2130903314;
+			public const int layout_insetEdge = 2130903314;
 			
 			// aapt resource value: 0x7F030113
-			public const int showText = 2130903315;
+			public const int layout_keyline = 2130903315;
 			
 			// aapt resource value: 0x7F030114
-			public const int showTitle = 2130903316;
+			public const int layout_scrollFlags = 2130903316;
 			
 			// aapt resource value: 0x7F030115
-			public const int singleChoiceItemLayout = 2130903317;
+			public const int layout_scrollInterpolator = 2130903317;
 			
 			// aapt resource value: 0x7F030116
-			public const int spanCount = 2130903318;
+			public const int liftOnScroll = 2130903318;
 			
 			// aapt resource value: 0x7F030117
-			public const int spinBars = 2130903319;
+			public const int lineHeight = 2130903319;
 			
 			// aapt resource value: 0x7F030118
-			public const int spinnerDropDownItemStyle = 2130903320;
+			public const int lineSpacing = 2130903320;
 			
 			// aapt resource value: 0x7F030119
-			public const int spinnerStyle = 2130903321;
+			public const int listChoiceBackgroundIndicator = 2130903321;
 			
 			// aapt resource value: 0x7F03011A
-			public const int splitTrack = 2130903322;
+			public const int listDividerAlertDialog = 2130903322;
 			
 			// aapt resource value: 0x7F03011B
-			public const int srcCompat = 2130903323;
+			public const int listItemLayout = 2130903323;
 			
 			// aapt resource value: 0x7F03011C
-			public const int stackFromEnd = 2130903324;
+			public const int listLayout = 2130903324;
 			
 			// aapt resource value: 0x7F03011D
-			public const int state_above_anchor = 2130903325;
+			public const int listMenuViewStyle = 2130903325;
 			
 			// aapt resource value: 0x7F03011E
-			public const int state_collapsed = 2130903326;
+			public const int listPopupWindowStyle = 2130903326;
 			
 			// aapt resource value: 0x7F03011F
-			public const int state_collapsible = 2130903327;
+			public const int listPreferredItemHeight = 2130903327;
 			
 			// aapt resource value: 0x7F030120
-			public const int statusBarBackground = 2130903328;
+			public const int listPreferredItemHeightLarge = 2130903328;
 			
 			// aapt resource value: 0x7F030121
-			public const int statusBarScrim = 2130903329;
+			public const int listPreferredItemHeightSmall = 2130903329;
 			
 			// aapt resource value: 0x7F030122
-			public const int subMenuArrow = 2130903330;
+			public const int listPreferredItemPaddingLeft = 2130903330;
 			
 			// aapt resource value: 0x7F030123
-			public const int submitBackground = 2130903331;
+			public const int listPreferredItemPaddingRight = 2130903331;
 			
 			// aapt resource value: 0x7F030124
-			public const int subtitle = 2130903332;
+			public const int logo = 2130903332;
 			
 			// aapt resource value: 0x7F030125
-			public const int subtitleTextAppearance = 2130903333;
+			public const int logoDescription = 2130903333;
 			
 			// aapt resource value: 0x7F030126
-			public const int subtitleTextColor = 2130903334;
+			public const int materialButtonStyle = 2130903334;
 			
 			// aapt resource value: 0x7F030127
-			public const int subtitleTextStyle = 2130903335;
+			public const int materialCardViewStyle = 2130903335;
 			
 			// aapt resource value: 0x7F030128
-			public const int suggestionRowLayout = 2130903336;
+			public const int maxActionInlineWidth = 2130903336;
 			
 			// aapt resource value: 0x7F030129
-			public const int switchMinWidth = 2130903337;
+			public const int maxButtonHeight = 2130903337;
 			
 			// aapt resource value: 0x7F03012A
-			public const int switchPadding = 2130903338;
+			public const int maxImageSize = 2130903338;
 			
 			// aapt resource value: 0x7F03012B
-			public const int switchStyle = 2130903339;
+			public const int measureWithLargestChild = 2130903339;
 			
 			// aapt resource value: 0x7F03012C
-			public const int switchTextAppearance = 2130903340;
+			public const int mediaRouteAudioTrackDrawable = 2130903340;
 			
 			// aapt resource value: 0x7F03012D
-			public const int tabBackground = 2130903341;
+			public const int mediaRouteButtonStyle = 2130903341;
 			
 			// aapt resource value: 0x7F03012E
-			public const int tabContentStart = 2130903342;
+			public const int mediaRouteButtonTint = 2130903342;
 			
 			// aapt resource value: 0x7F03012F
-			public const int tabGravity = 2130903343;
+			public const int mediaRouteCloseDrawable = 2130903343;
 			
 			// aapt resource value: 0x7F030130
-			public const int tabIndicatorColor = 2130903344;
+			public const int mediaRouteControlPanelThemeOverlay = 2130903344;
 			
 			// aapt resource value: 0x7F030131
-			public const int tabIndicatorHeight = 2130903345;
+			public const int mediaRouteDefaultIconDrawable = 2130903345;
 			
 			// aapt resource value: 0x7F030132
-			public const int tabMaxWidth = 2130903346;
+			public const int mediaRoutePauseDrawable = 2130903346;
 			
 			// aapt resource value: 0x7F030133
-			public const int tabMinWidth = 2130903347;
+			public const int mediaRoutePlayDrawable = 2130903347;
 			
 			// aapt resource value: 0x7F030134
-			public const int tabMode = 2130903348;
+			public const int mediaRouteSpeakerGroupIconDrawable = 2130903348;
 			
 			// aapt resource value: 0x7F030135
-			public const int tabPadding = 2130903349;
+			public const int mediaRouteSpeakerIconDrawable = 2130903349;
 			
 			// aapt resource value: 0x7F030136
-			public const int tabPaddingBottom = 2130903350;
+			public const int mediaRouteStopDrawable = 2130903350;
 			
 			// aapt resource value: 0x7F030137
-			public const int tabPaddingEnd = 2130903351;
+			public const int mediaRouteTheme = 2130903351;
 			
 			// aapt resource value: 0x7F030138
-			public const int tabPaddingStart = 2130903352;
+			public const int mediaRouteTvIconDrawable = 2130903352;
 			
 			// aapt resource value: 0x7F030139
-			public const int tabPaddingTop = 2130903353;
+			public const int menu = 2130903353;
 			
 			// aapt resource value: 0x7F03013A
-			public const int tabSelectedTextColor = 2130903354;
+			public const int multiChoiceItemLayout = 2130903354;
 			
 			// aapt resource value: 0x7F03013B
-			public const int tabTextAppearance = 2130903355;
+			public const int navigationContentDescription = 2130903355;
 			
 			// aapt resource value: 0x7F03013C
-			public const int tabTextColor = 2130903356;
+			public const int navigationIcon = 2130903356;
 			
 			// aapt resource value: 0x7F03013D
-			public const int textAllCaps = 2130903357;
+			public const int navigationMode = 2130903357;
 			
 			// aapt resource value: 0x7F03013E
-			public const int textAppearanceLargePopupMenu = 2130903358;
+			public const int navigationViewStyle = 2130903358;
 			
 			// aapt resource value: 0x7F03013F
-			public const int textAppearanceListItem = 2130903359;
+			public const int numericModifiers = 2130903359;
 			
 			// aapt resource value: 0x7F030140
-			public const int textAppearanceListItemSecondary = 2130903360;
+			public const int overlapAnchor = 2130903360;
 			
 			// aapt resource value: 0x7F030141
-			public const int textAppearanceListItemSmall = 2130903361;
+			public const int paddingBottomNoButtons = 2130903361;
 			
 			// aapt resource value: 0x7F030142
-			public const int textAppearancePopupMenuHeader = 2130903362;
+			public const int paddingEnd = 2130903362;
 			
 			// aapt resource value: 0x7F030143
-			public const int textAppearanceSearchResultSubtitle = 2130903363;
+			public const int paddingStart = 2130903363;
 			
 			// aapt resource value: 0x7F030144
-			public const int textAppearanceSearchResultTitle = 2130903364;
+			public const int paddingTopNoTitle = 2130903364;
 			
 			// aapt resource value: 0x7F030145
-			public const int textAppearanceSmallPopupMenu = 2130903365;
+			public const int panelBackground = 2130903365;
 			
 			// aapt resource value: 0x7F030146
-			public const int textColorAlertDialogListItem = 2130903366;
+			public const int panelMenuListTheme = 2130903366;
 			
 			// aapt resource value: 0x7F030147
-			public const int textColorError = 2130903367;
+			public const int panelMenuListWidth = 2130903367;
 			
 			// aapt resource value: 0x7F030148
-			public const int textColorSearchUrl = 2130903368;
+			public const int passwordToggleContentDescription = 2130903368;
 			
 			// aapt resource value: 0x7F030149
-			public const int theme = 2130903369;
+			public const int passwordToggleDrawable = 2130903369;
 			
 			// aapt resource value: 0x7F03014A
-			public const int thickness = 2130903370;
+			public const int passwordToggleEnabled = 2130903370;
 			
 			// aapt resource value: 0x7F03014B
-			public const int thumbTextPadding = 2130903371;
+			public const int passwordToggleTint = 2130903371;
 			
 			// aapt resource value: 0x7F03014C
-			public const int thumbTint = 2130903372;
+			public const int passwordToggleTintMode = 2130903372;
 			
 			// aapt resource value: 0x7F03014D
-			public const int thumbTintMode = 2130903373;
+			public const int popupMenuStyle = 2130903373;
 			
 			// aapt resource value: 0x7F03014E
-			public const int tickMark = 2130903374;
+			public const int popupTheme = 2130903374;
 			
 			// aapt resource value: 0x7F03014F
-			public const int tickMarkTint = 2130903375;
+			public const int popupWindowStyle = 2130903375;
 			
 			// aapt resource value: 0x7F030150
-			public const int tickMarkTintMode = 2130903376;
+			public const int preserveIconSpacing = 2130903376;
 			
 			// aapt resource value: 0x7F030151
-			public const int tint = 2130903377;
+			public const int pressedTranslationZ = 2130903377;
 			
 			// aapt resource value: 0x7F030152
-			public const int tintMode = 2130903378;
+			public const int progressBarPadding = 2130903378;
 			
 			// aapt resource value: 0x7F030153
-			public const int title = 2130903379;
+			public const int progressBarStyle = 2130903379;
 			
 			// aapt resource value: 0x7F030154
-			public const int titleEnabled = 2130903380;
+			public const int queryBackground = 2130903380;
 			
 			// aapt resource value: 0x7F030155
-			public const int titleMargin = 2130903381;
+			public const int queryHint = 2130903381;
 			
 			// aapt resource value: 0x7F030156
-			public const int titleMarginBottom = 2130903382;
+			public const int radioButtonStyle = 2130903382;
 			
 			// aapt resource value: 0x7F030157
-			public const int titleMarginEnd = 2130903383;
-			
-			// aapt resource value: 0x7F03015A
-			public const int titleMargins = 2130903386;
+			public const int ratingBarStyle = 2130903383;
 			
 			// aapt resource value: 0x7F030158
-			public const int titleMarginStart = 2130903384;
+			public const int ratingBarStyleIndicator = 2130903384;
 			
 			// aapt resource value: 0x7F030159
-			public const int titleMarginTop = 2130903385;
+			public const int ratingBarStyleSmall = 2130903385;
+			
+			// aapt resource value: 0x7F03015A
+			public const int reverseLayout = 2130903386;
 			
 			// aapt resource value: 0x7F03015B
-			public const int titleTextAppearance = 2130903387;
+			public const int rippleColor = 2130903387;
 			
 			// aapt resource value: 0x7F03015C
-			public const int titleTextColor = 2130903388;
+			public const int scrimAnimationDuration = 2130903388;
 			
 			// aapt resource value: 0x7F03015D
-			public const int titleTextStyle = 2130903389;
+			public const int scrimBackground = 2130903389;
 			
 			// aapt resource value: 0x7F03015E
-			public const int toolbarId = 2130903390;
+			public const int scrimVisibleHeightTrigger = 2130903390;
 			
 			// aapt resource value: 0x7F03015F
-			public const int toolbarNavigationButtonStyle = 2130903391;
+			public const int searchHintIcon = 2130903391;
 			
 			// aapt resource value: 0x7F030160
-			public const int toolbarStyle = 2130903392;
+			public const int searchIcon = 2130903392;
 			
 			// aapt resource value: 0x7F030161
-			public const int tooltipForegroundColor = 2130903393;
+			public const int searchViewStyle = 2130903393;
 			
 			// aapt resource value: 0x7F030162
-			public const int tooltipFrameBackground = 2130903394;
+			public const int seekBarStyle = 2130903394;
 			
 			// aapt resource value: 0x7F030163
-			public const int tooltipText = 2130903395;
+			public const int selectableItemBackground = 2130903395;
 			
 			// aapt resource value: 0x7F030164
-			public const int track = 2130903396;
+			public const int selectableItemBackgroundBorderless = 2130903396;
 			
 			// aapt resource value: 0x7F030165
-			public const int trackTint = 2130903397;
+			public const int showAsAction = 2130903397;
 			
 			// aapt resource value: 0x7F030166
-			public const int trackTintMode = 2130903398;
+			public const int showDividers = 2130903398;
 			
 			// aapt resource value: 0x7F030167
-			public const int useCompatPadding = 2130903399;
+			public const int showMotionSpec = 2130903399;
 			
 			// aapt resource value: 0x7F030168
-			public const int voiceIcon = 2130903400;
+			public const int showText = 2130903400;
 			
 			// aapt resource value: 0x7F030169
-			public const int windowActionBar = 2130903401;
+			public const int showTitle = 2130903401;
 			
 			// aapt resource value: 0x7F03016A
-			public const int windowActionBarOverlay = 2130903402;
+			public const int singleChoiceItemLayout = 2130903402;
 			
 			// aapt resource value: 0x7F03016B
-			public const int windowActionModeOverlay = 2130903403;
+			public const int singleLine = 2130903403;
 			
 			// aapt resource value: 0x7F03016C
-			public const int windowFixedHeightMajor = 2130903404;
+			public const int singleSelection = 2130903404;
 			
 			// aapt resource value: 0x7F03016D
-			public const int windowFixedHeightMinor = 2130903405;
+			public const int snackbarButtonStyle = 2130903405;
 			
 			// aapt resource value: 0x7F03016E
-			public const int windowFixedWidthMajor = 2130903406;
+			public const int snackbarStyle = 2130903406;
 			
 			// aapt resource value: 0x7F03016F
-			public const int windowFixedWidthMinor = 2130903407;
+			public const int spanCount = 2130903407;
 			
 			// aapt resource value: 0x7F030170
-			public const int windowMinWidthMajor = 2130903408;
+			public const int spinBars = 2130903408;
 			
 			// aapt resource value: 0x7F030171
-			public const int windowMinWidthMinor = 2130903409;
+			public const int spinnerDropDownItemStyle = 2130903409;
 			
 			// aapt resource value: 0x7F030172
-			public const int windowNoTitle = 2130903410;
+			public const int spinnerStyle = 2130903410;
+			
+			// aapt resource value: 0x7F030173
+			public const int splitTrack = 2130903411;
+			
+			// aapt resource value: 0x7F030174
+			public const int srcCompat = 2130903412;
+			
+			// aapt resource value: 0x7F030175
+			public const int stackFromEnd = 2130903413;
+			
+			// aapt resource value: 0x7F030176
+			public const int state_above_anchor = 2130903414;
+			
+			// aapt resource value: 0x7F030177
+			public const int state_collapsed = 2130903415;
+			
+			// aapt resource value: 0x7F030178
+			public const int state_collapsible = 2130903416;
+			
+			// aapt resource value: 0x7F030179
+			public const int state_liftable = 2130903417;
+			
+			// aapt resource value: 0x7F03017A
+			public const int state_lifted = 2130903418;
+			
+			// aapt resource value: 0x7F03017B
+			public const int statusBarBackground = 2130903419;
+			
+			// aapt resource value: 0x7F03017C
+			public const int statusBarScrim = 2130903420;
+			
+			// aapt resource value: 0x7F03017D
+			public const int strokeColor = 2130903421;
+			
+			// aapt resource value: 0x7F03017E
+			public const int strokeWidth = 2130903422;
+			
+			// aapt resource value: 0x7F03017F
+			public const int subMenuArrow = 2130903423;
+			
+			// aapt resource value: 0x7F030180
+			public const int submitBackground = 2130903424;
+			
+			// aapt resource value: 0x7F030181
+			public const int subtitle = 2130903425;
+			
+			// aapt resource value: 0x7F030182
+			public const int subtitleTextAppearance = 2130903426;
+			
+			// aapt resource value: 0x7F030183
+			public const int subtitleTextColor = 2130903427;
+			
+			// aapt resource value: 0x7F030184
+			public const int subtitleTextStyle = 2130903428;
+			
+			// aapt resource value: 0x7F030185
+			public const int suggestionRowLayout = 2130903429;
+			
+			// aapt resource value: 0x7F030186
+			public const int switchMinWidth = 2130903430;
+			
+			// aapt resource value: 0x7F030187
+			public const int switchPadding = 2130903431;
+			
+			// aapt resource value: 0x7F030188
+			public const int switchStyle = 2130903432;
+			
+			// aapt resource value: 0x7F030189
+			public const int switchTextAppearance = 2130903433;
+			
+			// aapt resource value: 0x7F03018A
+			public const int tabBackground = 2130903434;
+			
+			// aapt resource value: 0x7F03018B
+			public const int tabContentStart = 2130903435;
+			
+			// aapt resource value: 0x7F03018C
+			public const int tabGravity = 2130903436;
+			
+			// aapt resource value: 0x7F03018D
+			public const int tabIconTint = 2130903437;
+			
+			// aapt resource value: 0x7F03018E
+			public const int tabIconTintMode = 2130903438;
+			
+			// aapt resource value: 0x7F03018F
+			public const int tabIndicator = 2130903439;
+			
+			// aapt resource value: 0x7F030190
+			public const int tabIndicatorAnimationDuration = 2130903440;
+			
+			// aapt resource value: 0x7F030191
+			public const int tabIndicatorColor = 2130903441;
+			
+			// aapt resource value: 0x7F030192
+			public const int tabIndicatorFullWidth = 2130903442;
+			
+			// aapt resource value: 0x7F030193
+			public const int tabIndicatorGravity = 2130903443;
+			
+			// aapt resource value: 0x7F030194
+			public const int tabIndicatorHeight = 2130903444;
+			
+			// aapt resource value: 0x7F030195
+			public const int tabInlineLabel = 2130903445;
+			
+			// aapt resource value: 0x7F030196
+			public const int tabMaxWidth = 2130903446;
+			
+			// aapt resource value: 0x7F030197
+			public const int tabMinWidth = 2130903447;
+			
+			// aapt resource value: 0x7F030198
+			public const int tabMode = 2130903448;
+			
+			// aapt resource value: 0x7F030199
+			public const int tabPadding = 2130903449;
+			
+			// aapt resource value: 0x7F03019A
+			public const int tabPaddingBottom = 2130903450;
+			
+			// aapt resource value: 0x7F03019B
+			public const int tabPaddingEnd = 2130903451;
+			
+			// aapt resource value: 0x7F03019C
+			public const int tabPaddingStart = 2130903452;
+			
+			// aapt resource value: 0x7F03019D
+			public const int tabPaddingTop = 2130903453;
+			
+			// aapt resource value: 0x7F03019E
+			public const int tabRippleColor = 2130903454;
+			
+			// aapt resource value: 0x7F03019F
+			public const int tabSelectedTextColor = 2130903455;
+			
+			// aapt resource value: 0x7F0301A0
+			public const int tabStyle = 2130903456;
+			
+			// aapt resource value: 0x7F0301A1
+			public const int tabTextAppearance = 2130903457;
+			
+			// aapt resource value: 0x7F0301A2
+			public const int tabTextColor = 2130903458;
+			
+			// aapt resource value: 0x7F0301A3
+			public const int tabUnboundedRipple = 2130903459;
+			
+			// aapt resource value: 0x7F0301A4
+			public const int textAllCaps = 2130903460;
+			
+			// aapt resource value: 0x7F0301A5
+			public const int textAppearanceBody1 = 2130903461;
+			
+			// aapt resource value: 0x7F0301A6
+			public const int textAppearanceBody2 = 2130903462;
+			
+			// aapt resource value: 0x7F0301A7
+			public const int textAppearanceButton = 2130903463;
+			
+			// aapt resource value: 0x7F0301A8
+			public const int textAppearanceCaption = 2130903464;
+			
+			// aapt resource value: 0x7F0301A9
+			public const int textAppearanceHeadline1 = 2130903465;
+			
+			// aapt resource value: 0x7F0301AA
+			public const int textAppearanceHeadline2 = 2130903466;
+			
+			// aapt resource value: 0x7F0301AB
+			public const int textAppearanceHeadline3 = 2130903467;
+			
+			// aapt resource value: 0x7F0301AC
+			public const int textAppearanceHeadline4 = 2130903468;
+			
+			// aapt resource value: 0x7F0301AD
+			public const int textAppearanceHeadline5 = 2130903469;
+			
+			// aapt resource value: 0x7F0301AE
+			public const int textAppearanceHeadline6 = 2130903470;
+			
+			// aapt resource value: 0x7F0301AF
+			public const int textAppearanceLargePopupMenu = 2130903471;
+			
+			// aapt resource value: 0x7F0301B0
+			public const int textAppearanceListItem = 2130903472;
+			
+			// aapt resource value: 0x7F0301B1
+			public const int textAppearanceListItemSecondary = 2130903473;
+			
+			// aapt resource value: 0x7F0301B2
+			public const int textAppearanceListItemSmall = 2130903474;
+			
+			// aapt resource value: 0x7F0301B3
+			public const int textAppearanceOverline = 2130903475;
+			
+			// aapt resource value: 0x7F0301B4
+			public const int textAppearancePopupMenuHeader = 2130903476;
+			
+			// aapt resource value: 0x7F0301B5
+			public const int textAppearanceSearchResultSubtitle = 2130903477;
+			
+			// aapt resource value: 0x7F0301B6
+			public const int textAppearanceSearchResultTitle = 2130903478;
+			
+			// aapt resource value: 0x7F0301B7
+			public const int textAppearanceSmallPopupMenu = 2130903479;
+			
+			// aapt resource value: 0x7F0301B8
+			public const int textAppearanceSubtitle1 = 2130903480;
+			
+			// aapt resource value: 0x7F0301B9
+			public const int textAppearanceSubtitle2 = 2130903481;
+			
+			// aapt resource value: 0x7F0301BA
+			public const int textColorAlertDialogListItem = 2130903482;
+			
+			// aapt resource value: 0x7F0301BB
+			public const int textColorSearchUrl = 2130903483;
+			
+			// aapt resource value: 0x7F0301BC
+			public const int textEndPadding = 2130903484;
+			
+			// aapt resource value: 0x7F0301BD
+			public const int textInputStyle = 2130903485;
+			
+			// aapt resource value: 0x7F0301BE
+			public const int textStartPadding = 2130903486;
+			
+			// aapt resource value: 0x7F0301BF
+			public const int theme = 2130903487;
+			
+			// aapt resource value: 0x7F0301C0
+			public const int thickness = 2130903488;
+			
+			// aapt resource value: 0x7F0301C1
+			public const int thumbTextPadding = 2130903489;
+			
+			// aapt resource value: 0x7F0301C2
+			public const int thumbTint = 2130903490;
+			
+			// aapt resource value: 0x7F0301C3
+			public const int thumbTintMode = 2130903491;
+			
+			// aapt resource value: 0x7F0301C4
+			public const int tickMark = 2130903492;
+			
+			// aapt resource value: 0x7F0301C5
+			public const int tickMarkTint = 2130903493;
+			
+			// aapt resource value: 0x7F0301C6
+			public const int tickMarkTintMode = 2130903494;
+			
+			// aapt resource value: 0x7F0301C7
+			public const int tint = 2130903495;
+			
+			// aapt resource value: 0x7F0301C8
+			public const int tintMode = 2130903496;
+			
+			// aapt resource value: 0x7F0301C9
+			public const int title = 2130903497;
+			
+			// aapt resource value: 0x7F0301CA
+			public const int titleEnabled = 2130903498;
+			
+			// aapt resource value: 0x7F0301CB
+			public const int titleMargin = 2130903499;
+			
+			// aapt resource value: 0x7F0301CC
+			public const int titleMarginBottom = 2130903500;
+			
+			// aapt resource value: 0x7F0301CD
+			public const int titleMarginEnd = 2130903501;
+			
+			// aapt resource value: 0x7F0301D0
+			public const int titleMargins = 2130903504;
+			
+			// aapt resource value: 0x7F0301CE
+			public const int titleMarginStart = 2130903502;
+			
+			// aapt resource value: 0x7F0301CF
+			public const int titleMarginTop = 2130903503;
+			
+			// aapt resource value: 0x7F0301D1
+			public const int titleTextAppearance = 2130903505;
+			
+			// aapt resource value: 0x7F0301D2
+			public const int titleTextColor = 2130903506;
+			
+			// aapt resource value: 0x7F0301D3
+			public const int titleTextStyle = 2130903507;
+			
+			// aapt resource value: 0x7F0301D4
+			public const int toolbarId = 2130903508;
+			
+			// aapt resource value: 0x7F0301D5
+			public const int toolbarNavigationButtonStyle = 2130903509;
+			
+			// aapt resource value: 0x7F0301D6
+			public const int toolbarStyle = 2130903510;
+			
+			// aapt resource value: 0x7F0301D7
+			public const int tooltipForegroundColor = 2130903511;
+			
+			// aapt resource value: 0x7F0301D8
+			public const int tooltipFrameBackground = 2130903512;
+			
+			// aapt resource value: 0x7F0301D9
+			public const int tooltipText = 2130903513;
+			
+			// aapt resource value: 0x7F0301DA
+			public const int track = 2130903514;
+			
+			// aapt resource value: 0x7F0301DB
+			public const int trackTint = 2130903515;
+			
+			// aapt resource value: 0x7F0301DC
+			public const int trackTintMode = 2130903516;
+			
+			// aapt resource value: 0x7F0301DD
+			public const int ttcIndex = 2130903517;
+			
+			// aapt resource value: 0x7F0301DE
+			public const int useCompatPadding = 2130903518;
+			
+			// aapt resource value: 0x7F0301DF
+			public const int viewInflaterClass = 2130903519;
+			
+			// aapt resource value: 0x7F0301E0
+			public const int voiceIcon = 2130903520;
+			
+			// aapt resource value: 0x7F0301E1
+			public const int windowActionBar = 2130903521;
+			
+			// aapt resource value: 0x7F0301E2
+			public const int windowActionBarOverlay = 2130903522;
+			
+			// aapt resource value: 0x7F0301E3
+			public const int windowActionModeOverlay = 2130903523;
+			
+			// aapt resource value: 0x7F0301E4
+			public const int windowFixedHeightMajor = 2130903524;
+			
+			// aapt resource value: 0x7F0301E5
+			public const int windowFixedHeightMinor = 2130903525;
+			
+			// aapt resource value: 0x7F0301E6
+			public const int windowFixedWidthMajor = 2130903526;
+			
+			// aapt resource value: 0x7F0301E7
+			public const int windowFixedWidthMinor = 2130903527;
+			
+			// aapt resource value: 0x7F0301E8
+			public const int windowMinWidthMajor = 2130903528;
+			
+			// aapt resource value: 0x7F0301E9
+			public const int windowMinWidthMinor = 2130903529;
+			
+			// aapt resource value: 0x7F0301EA
+			public const int windowNoTitle = 2130903530;
 			
 			static Attribute()
 			{
@@ -3242,10 +4205,7 @@ namespace NFCSample.Droid
 			public const int abc_config_actionMenuItemAllCaps = 2130968578;
 			
 			// aapt resource value: 0x7F040003
-			public const int abc_config_closeDialogWhenTouchOutside = 2130968579;
-			
-			// aapt resource value: 0x7F040004
-			public const int abc_config_showMenuShortcutsWhenKeyboardPresent = 2130968580;
+			public const int mtrl_btn_textappearance_all_caps = 2130968579;
 			
 			static Boolean()
 			{
@@ -3369,205 +4329,304 @@ namespace NFCSample.Droid
 			public const int bright_foreground_material_light = 2131034147;
 			
 			// aapt resource value: 0x7F050024
-			public const int button_material_dark = 2131034148;
+			public const int browser_actions_bg_grey = 2131034148;
 			
 			// aapt resource value: 0x7F050025
-			public const int button_material_light = 2131034149;
+			public const int browser_actions_divider_color = 2131034149;
 			
 			// aapt resource value: 0x7F050026
-			public const int cardview_dark_background = 2131034150;
+			public const int browser_actions_text_color = 2131034150;
 			
 			// aapt resource value: 0x7F050027
-			public const int cardview_light_background = 2131034151;
+			public const int browser_actions_title_color = 2131034151;
 			
 			// aapt resource value: 0x7F050028
-			public const int cardview_shadow_end_color = 2131034152;
+			public const int button_material_dark = 2131034152;
 			
 			// aapt resource value: 0x7F050029
-			public const int cardview_shadow_start_color = 2131034153;
+			public const int button_material_light = 2131034153;
 			
 			// aapt resource value: 0x7F05002A
-			public const int colorAccent = 2131034154;
+			public const int cardview_dark_background = 2131034154;
 			
 			// aapt resource value: 0x7F05002B
-			public const int colorPrimary = 2131034155;
+			public const int cardview_light_background = 2131034155;
 			
 			// aapt resource value: 0x7F05002C
-			public const int colorPrimaryDark = 2131034156;
+			public const int cardview_shadow_end_color = 2131034156;
 			
 			// aapt resource value: 0x7F05002D
-			public const int design_bottom_navigation_shadow_color = 2131034157;
+			public const int cardview_shadow_start_color = 2131034157;
 			
 			// aapt resource value: 0x7F05002E
-			public const int design_error = 2131034158;
+			public const int colorAccent = 2131034158;
 			
 			// aapt resource value: 0x7F05002F
-			public const int design_fab_shadow_end_color = 2131034159;
+			public const int colorPrimary = 2131034159;
 			
 			// aapt resource value: 0x7F050030
-			public const int design_fab_shadow_mid_color = 2131034160;
+			public const int colorPrimaryDark = 2131034160;
 			
 			// aapt resource value: 0x7F050031
-			public const int design_fab_shadow_start_color = 2131034161;
+			public const int design_bottom_navigation_shadow_color = 2131034161;
 			
 			// aapt resource value: 0x7F050032
-			public const int design_fab_stroke_end_inner_color = 2131034162;
+			public const int design_default_color_primary = 2131034162;
 			
 			// aapt resource value: 0x7F050033
-			public const int design_fab_stroke_end_outer_color = 2131034163;
+			public const int design_default_color_primary_dark = 2131034163;
 			
 			// aapt resource value: 0x7F050034
-			public const int design_fab_stroke_top_inner_color = 2131034164;
+			public const int design_error = 2131034164;
 			
 			// aapt resource value: 0x7F050035
-			public const int design_fab_stroke_top_outer_color = 2131034165;
+			public const int design_fab_shadow_end_color = 2131034165;
 			
 			// aapt resource value: 0x7F050036
-			public const int design_snackbar_background_color = 2131034166;
+			public const int design_fab_shadow_mid_color = 2131034166;
 			
 			// aapt resource value: 0x7F050037
-			public const int design_tint_password_toggle = 2131034167;
+			public const int design_fab_shadow_start_color = 2131034167;
 			
 			// aapt resource value: 0x7F050038
-			public const int dim_foreground_disabled_material_dark = 2131034168;
+			public const int design_fab_stroke_end_inner_color = 2131034168;
 			
 			// aapt resource value: 0x7F050039
-			public const int dim_foreground_disabled_material_light = 2131034169;
+			public const int design_fab_stroke_end_outer_color = 2131034169;
 			
 			// aapt resource value: 0x7F05003A
-			public const int dim_foreground_material_dark = 2131034170;
+			public const int design_fab_stroke_top_inner_color = 2131034170;
 			
 			// aapt resource value: 0x7F05003B
-			public const int dim_foreground_material_light = 2131034171;
+			public const int design_fab_stroke_top_outer_color = 2131034171;
 			
 			// aapt resource value: 0x7F05003C
-			public const int error_color_material = 2131034172;
+			public const int design_snackbar_background_color = 2131034172;
 			
 			// aapt resource value: 0x7F05003D
-			public const int foreground_material_dark = 2131034173;
+			public const int design_tint_password_toggle = 2131034173;
 			
 			// aapt resource value: 0x7F05003E
-			public const int foreground_material_light = 2131034174;
+			public const int dim_foreground_disabled_material_dark = 2131034174;
 			
 			// aapt resource value: 0x7F05003F
-			public const int highlighted_text_material_dark = 2131034175;
+			public const int dim_foreground_disabled_material_light = 2131034175;
 			
 			// aapt resource value: 0x7F050040
-			public const int highlighted_text_material_light = 2131034176;
+			public const int dim_foreground_material_dark = 2131034176;
 			
 			// aapt resource value: 0x7F050041
-			public const int launcher_background = 2131034177;
+			public const int dim_foreground_material_light = 2131034177;
 			
 			// aapt resource value: 0x7F050042
-			public const int material_blue_grey_800 = 2131034178;
+			public const int error_color_material_dark = 2131034178;
 			
 			// aapt resource value: 0x7F050043
-			public const int material_blue_grey_900 = 2131034179;
+			public const int error_color_material_light = 2131034179;
 			
 			// aapt resource value: 0x7F050044
-			public const int material_blue_grey_950 = 2131034180;
+			public const int foreground_material_dark = 2131034180;
 			
 			// aapt resource value: 0x7F050045
-			public const int material_deep_teal_200 = 2131034181;
+			public const int foreground_material_light = 2131034181;
 			
 			// aapt resource value: 0x7F050046
-			public const int material_deep_teal_500 = 2131034182;
+			public const int highlighted_text_material_dark = 2131034182;
 			
 			// aapt resource value: 0x7F050047
-			public const int material_grey_100 = 2131034183;
+			public const int highlighted_text_material_light = 2131034183;
 			
 			// aapt resource value: 0x7F050048
-			public const int material_grey_300 = 2131034184;
+			public const int launcher_background = 2131034184;
 			
 			// aapt resource value: 0x7F050049
-			public const int material_grey_50 = 2131034185;
+			public const int material_blue_grey_800 = 2131034185;
 			
 			// aapt resource value: 0x7F05004A
-			public const int material_grey_600 = 2131034186;
+			public const int material_blue_grey_900 = 2131034186;
 			
 			// aapt resource value: 0x7F05004B
-			public const int material_grey_800 = 2131034187;
+			public const int material_blue_grey_950 = 2131034187;
 			
 			// aapt resource value: 0x7F05004C
-			public const int material_grey_850 = 2131034188;
+			public const int material_deep_teal_200 = 2131034188;
 			
 			// aapt resource value: 0x7F05004D
-			public const int material_grey_900 = 2131034189;
+			public const int material_deep_teal_500 = 2131034189;
 			
 			// aapt resource value: 0x7F05004E
-			public const int notification_action_color_filter = 2131034190;
+			public const int material_grey_100 = 2131034190;
 			
 			// aapt resource value: 0x7F05004F
-			public const int notification_icon_bg_color = 2131034191;
+			public const int material_grey_300 = 2131034191;
 			
 			// aapt resource value: 0x7F050050
-			public const int notification_material_background_media_default_color = 2131034192;
+			public const int material_grey_50 = 2131034192;
 			
 			// aapt resource value: 0x7F050051
-			public const int primary_dark_material_dark = 2131034193;
+			public const int material_grey_600 = 2131034193;
 			
 			// aapt resource value: 0x7F050052
-			public const int primary_dark_material_light = 2131034194;
+			public const int material_grey_800 = 2131034194;
 			
 			// aapt resource value: 0x7F050053
-			public const int primary_material_dark = 2131034195;
+			public const int material_grey_850 = 2131034195;
 			
 			// aapt resource value: 0x7F050054
-			public const int primary_material_light = 2131034196;
+			public const int material_grey_900 = 2131034196;
 			
 			// aapt resource value: 0x7F050055
-			public const int primary_text_default_material_dark = 2131034197;
+			public const int mtrl_bottom_nav_colored_item_tint = 2131034197;
 			
 			// aapt resource value: 0x7F050056
-			public const int primary_text_default_material_light = 2131034198;
+			public const int mtrl_bottom_nav_item_tint = 2131034198;
 			
 			// aapt resource value: 0x7F050057
-			public const int primary_text_disabled_material_dark = 2131034199;
+			public const int mtrl_btn_bg_color_disabled = 2131034199;
 			
 			// aapt resource value: 0x7F050058
-			public const int primary_text_disabled_material_light = 2131034200;
+			public const int mtrl_btn_bg_color_selector = 2131034200;
 			
 			// aapt resource value: 0x7F050059
-			public const int ripple_material_dark = 2131034201;
+			public const int mtrl_btn_ripple_color = 2131034201;
 			
 			// aapt resource value: 0x7F05005A
-			public const int ripple_material_light = 2131034202;
+			public const int mtrl_btn_stroke_color_selector = 2131034202;
 			
 			// aapt resource value: 0x7F05005B
-			public const int secondary_text_default_material_dark = 2131034203;
+			public const int mtrl_btn_text_btn_ripple_color = 2131034203;
 			
 			// aapt resource value: 0x7F05005C
-			public const int secondary_text_default_material_light = 2131034204;
+			public const int mtrl_btn_text_color_disabled = 2131034204;
 			
 			// aapt resource value: 0x7F05005D
-			public const int secondary_text_disabled_material_dark = 2131034205;
+			public const int mtrl_btn_text_color_selector = 2131034205;
 			
 			// aapt resource value: 0x7F05005E
-			public const int secondary_text_disabled_material_light = 2131034206;
+			public const int mtrl_btn_transparent_bg_color = 2131034206;
 			
 			// aapt resource value: 0x7F05005F
-			public const int switch_thumb_disabled_material_dark = 2131034207;
+			public const int mtrl_chip_background_color = 2131034207;
 			
 			// aapt resource value: 0x7F050060
-			public const int switch_thumb_disabled_material_light = 2131034208;
+			public const int mtrl_chip_close_icon_tint = 2131034208;
 			
 			// aapt resource value: 0x7F050061
-			public const int switch_thumb_material_dark = 2131034209;
+			public const int mtrl_chip_ripple_color = 2131034209;
 			
 			// aapt resource value: 0x7F050062
-			public const int switch_thumb_material_light = 2131034210;
+			public const int mtrl_chip_text_color = 2131034210;
 			
 			// aapt resource value: 0x7F050063
-			public const int switch_thumb_normal_material_dark = 2131034211;
+			public const int mtrl_fab_ripple_color = 2131034211;
 			
 			// aapt resource value: 0x7F050064
-			public const int switch_thumb_normal_material_light = 2131034212;
+			public const int mtrl_scrim_color = 2131034212;
 			
 			// aapt resource value: 0x7F050065
-			public const int tooltip_background_dark = 2131034213;
+			public const int mtrl_tabs_colored_ripple_color = 2131034213;
 			
 			// aapt resource value: 0x7F050066
-			public const int tooltip_background_light = 2131034214;
+			public const int mtrl_tabs_icon_color_selector = 2131034214;
+			
+			// aapt resource value: 0x7F050067
+			public const int mtrl_tabs_icon_color_selector_colored = 2131034215;
+			
+			// aapt resource value: 0x7F050068
+			public const int mtrl_tabs_legacy_text_color_selector = 2131034216;
+			
+			// aapt resource value: 0x7F050069
+			public const int mtrl_tabs_ripple_color = 2131034217;
+			
+			// aapt resource value: 0x7F05006B
+			public const int mtrl_textinput_default_box_stroke_color = 2131034219;
+			
+			// aapt resource value: 0x7F05006C
+			public const int mtrl_textinput_disabled_color = 2131034220;
+			
+			// aapt resource value: 0x7F05006D
+			public const int mtrl_textinput_filled_box_default_background_color = 2131034221;
+			
+			// aapt resource value: 0x7F05006E
+			public const int mtrl_textinput_hovered_box_stroke_color = 2131034222;
+			
+			// aapt resource value: 0x7F05006A
+			public const int mtrl_text_btn_text_color_selector = 2131034218;
+			
+			// aapt resource value: 0x7F05006F
+			public const int notification_action_color_filter = 2131034223;
+			
+			// aapt resource value: 0x7F050070
+			public const int notification_icon_bg_color = 2131034224;
+			
+			// aapt resource value: 0x7F050071
+			public const int notification_material_background_media_default_color = 2131034225;
+			
+			// aapt resource value: 0x7F050072
+			public const int primary_dark_material_dark = 2131034226;
+			
+			// aapt resource value: 0x7F050073
+			public const int primary_dark_material_light = 2131034227;
+			
+			// aapt resource value: 0x7F050074
+			public const int primary_material_dark = 2131034228;
+			
+			// aapt resource value: 0x7F050075
+			public const int primary_material_light = 2131034229;
+			
+			// aapt resource value: 0x7F050076
+			public const int primary_text_default_material_dark = 2131034230;
+			
+			// aapt resource value: 0x7F050077
+			public const int primary_text_default_material_light = 2131034231;
+			
+			// aapt resource value: 0x7F050078
+			public const int primary_text_disabled_material_dark = 2131034232;
+			
+			// aapt resource value: 0x7F050079
+			public const int primary_text_disabled_material_light = 2131034233;
+			
+			// aapt resource value: 0x7F05007A
+			public const int ripple_material_dark = 2131034234;
+			
+			// aapt resource value: 0x7F05007B
+			public const int ripple_material_light = 2131034235;
+			
+			// aapt resource value: 0x7F05007C
+			public const int secondary_text_default_material_dark = 2131034236;
+			
+			// aapt resource value: 0x7F05007D
+			public const int secondary_text_default_material_light = 2131034237;
+			
+			// aapt resource value: 0x7F05007E
+			public const int secondary_text_disabled_material_dark = 2131034238;
+			
+			// aapt resource value: 0x7F05007F
+			public const int secondary_text_disabled_material_light = 2131034239;
+			
+			// aapt resource value: 0x7F050080
+			public const int switch_thumb_disabled_material_dark = 2131034240;
+			
+			// aapt resource value: 0x7F050081
+			public const int switch_thumb_disabled_material_light = 2131034241;
+			
+			// aapt resource value: 0x7F050082
+			public const int switch_thumb_material_dark = 2131034242;
+			
+			// aapt resource value: 0x7F050083
+			public const int switch_thumb_material_light = 2131034243;
+			
+			// aapt resource value: 0x7F050084
+			public const int switch_thumb_normal_material_dark = 2131034244;
+			
+			// aapt resource value: 0x7F050085
+			public const int switch_thumb_normal_material_light = 2131034245;
+			
+			// aapt resource value: 0x7F050086
+			public const int tooltip_background_dark = 2131034246;
+			
+			// aapt resource value: 0x7F050087
+			public const int tooltip_background_light = 2131034247;
 			
 			static Color()
 			{
@@ -3610,31 +4669,31 @@ namespace NFCSample.Droid
 			public const int abc_action_bar_overflow_padding_start_material = 2131099656;
 			
 			// aapt resource value: 0x7F060009
-			public const int abc_action_bar_progress_bar_size = 2131099657;
+			public const int abc_action_bar_stacked_max_height = 2131099657;
 			
 			// aapt resource value: 0x7F06000A
-			public const int abc_action_bar_stacked_max_height = 2131099658;
+			public const int abc_action_bar_stacked_tab_max_width = 2131099658;
 			
 			// aapt resource value: 0x7F06000B
-			public const int abc_action_bar_stacked_tab_max_width = 2131099659;
+			public const int abc_action_bar_subtitle_bottom_margin_material = 2131099659;
 			
 			// aapt resource value: 0x7F06000C
-			public const int abc_action_bar_subtitle_bottom_margin_material = 2131099660;
+			public const int abc_action_bar_subtitle_top_margin_material = 2131099660;
 			
 			// aapt resource value: 0x7F06000D
-			public const int abc_action_bar_subtitle_top_margin_material = 2131099661;
+			public const int abc_action_button_min_height_material = 2131099661;
 			
 			// aapt resource value: 0x7F06000E
-			public const int abc_action_button_min_height_material = 2131099662;
+			public const int abc_action_button_min_width_material = 2131099662;
 			
 			// aapt resource value: 0x7F06000F
-			public const int abc_action_button_min_width_material = 2131099663;
+			public const int abc_action_button_min_width_overflow_material = 2131099663;
 			
 			// aapt resource value: 0x7F060010
-			public const int abc_action_button_min_width_overflow_material = 2131099664;
+			public const int abc_alert_dialog_button_bar_height = 2131099664;
 			
 			// aapt resource value: 0x7F060011
-			public const int abc_alert_dialog_button_bar_height = 2131099665;
+			public const int abc_alert_dialog_button_dimen = 2131099665;
 			
 			// aapt resource value: 0x7F060012
 			public const int abc_button_inset_horizontal_material = 2131099666;
@@ -3664,415 +4723,604 @@ namespace NFCSample.Droid
 			public const int abc_control_padding_material = 2131099674;
 			
 			// aapt resource value: 0x7F06001B
-			public const int abc_dialog_fixed_height_major = 2131099675;
+			public const int abc_dialog_corner_radius_material = 2131099675;
 			
 			// aapt resource value: 0x7F06001C
-			public const int abc_dialog_fixed_height_minor = 2131099676;
+			public const int abc_dialog_fixed_height_major = 2131099676;
 			
 			// aapt resource value: 0x7F06001D
-			public const int abc_dialog_fixed_width_major = 2131099677;
+			public const int abc_dialog_fixed_height_minor = 2131099677;
 			
 			// aapt resource value: 0x7F06001E
-			public const int abc_dialog_fixed_width_minor = 2131099678;
+			public const int abc_dialog_fixed_width_major = 2131099678;
 			
 			// aapt resource value: 0x7F06001F
-			public const int abc_dialog_list_padding_bottom_no_buttons = 2131099679;
+			public const int abc_dialog_fixed_width_minor = 2131099679;
 			
 			// aapt resource value: 0x7F060020
-			public const int abc_dialog_list_padding_top_no_title = 2131099680;
+			public const int abc_dialog_list_padding_bottom_no_buttons = 2131099680;
 			
 			// aapt resource value: 0x7F060021
-			public const int abc_dialog_min_width_major = 2131099681;
+			public const int abc_dialog_list_padding_top_no_title = 2131099681;
 			
 			// aapt resource value: 0x7F060022
-			public const int abc_dialog_min_width_minor = 2131099682;
+			public const int abc_dialog_min_width_major = 2131099682;
 			
 			// aapt resource value: 0x7F060023
-			public const int abc_dialog_padding_material = 2131099683;
+			public const int abc_dialog_min_width_minor = 2131099683;
 			
 			// aapt resource value: 0x7F060024
-			public const int abc_dialog_padding_top_material = 2131099684;
+			public const int abc_dialog_padding_material = 2131099684;
 			
 			// aapt resource value: 0x7F060025
-			public const int abc_dialog_title_divider_material = 2131099685;
+			public const int abc_dialog_padding_top_material = 2131099685;
 			
 			// aapt resource value: 0x7F060026
-			public const int abc_disabled_alpha_material_dark = 2131099686;
+			public const int abc_dialog_title_divider_material = 2131099686;
 			
 			// aapt resource value: 0x7F060027
-			public const int abc_disabled_alpha_material_light = 2131099687;
+			public const int abc_disabled_alpha_material_dark = 2131099687;
 			
 			// aapt resource value: 0x7F060028
-			public const int abc_dropdownitem_icon_width = 2131099688;
+			public const int abc_disabled_alpha_material_light = 2131099688;
 			
 			// aapt resource value: 0x7F060029
-			public const int abc_dropdownitem_text_padding_left = 2131099689;
+			public const int abc_dropdownitem_icon_width = 2131099689;
 			
 			// aapt resource value: 0x7F06002A
-			public const int abc_dropdownitem_text_padding_right = 2131099690;
+			public const int abc_dropdownitem_text_padding_left = 2131099690;
 			
 			// aapt resource value: 0x7F06002B
-			public const int abc_edit_text_inset_bottom_material = 2131099691;
+			public const int abc_dropdownitem_text_padding_right = 2131099691;
 			
 			// aapt resource value: 0x7F06002C
-			public const int abc_edit_text_inset_horizontal_material = 2131099692;
+			public const int abc_edit_text_inset_bottom_material = 2131099692;
 			
 			// aapt resource value: 0x7F06002D
-			public const int abc_edit_text_inset_top_material = 2131099693;
+			public const int abc_edit_text_inset_horizontal_material = 2131099693;
 			
 			// aapt resource value: 0x7F06002E
-			public const int abc_floating_window_z = 2131099694;
+			public const int abc_edit_text_inset_top_material = 2131099694;
 			
 			// aapt resource value: 0x7F06002F
-			public const int abc_list_item_padding_horizontal_material = 2131099695;
+			public const int abc_floating_window_z = 2131099695;
 			
 			// aapt resource value: 0x7F060030
-			public const int abc_panel_menu_list_width = 2131099696;
+			public const int abc_list_item_padding_horizontal_material = 2131099696;
 			
 			// aapt resource value: 0x7F060031
-			public const int abc_progress_bar_height_material = 2131099697;
+			public const int abc_panel_menu_list_width = 2131099697;
 			
 			// aapt resource value: 0x7F060032
-			public const int abc_search_view_preferred_height = 2131099698;
+			public const int abc_progress_bar_height_material = 2131099698;
 			
 			// aapt resource value: 0x7F060033
-			public const int abc_search_view_preferred_width = 2131099699;
+			public const int abc_search_view_preferred_height = 2131099699;
 			
 			// aapt resource value: 0x7F060034
-			public const int abc_seekbar_track_background_height_material = 2131099700;
+			public const int abc_search_view_preferred_width = 2131099700;
 			
 			// aapt resource value: 0x7F060035
-			public const int abc_seekbar_track_progress_height_material = 2131099701;
+			public const int abc_seekbar_track_background_height_material = 2131099701;
 			
 			// aapt resource value: 0x7F060036
-			public const int abc_select_dialog_padding_start_material = 2131099702;
+			public const int abc_seekbar_track_progress_height_material = 2131099702;
 			
 			// aapt resource value: 0x7F060037
-			public const int abc_switch_padding = 2131099703;
+			public const int abc_select_dialog_padding_start_material = 2131099703;
 			
 			// aapt resource value: 0x7F060038
-			public const int abc_text_size_body_1_material = 2131099704;
+			public const int abc_switch_padding = 2131099704;
 			
 			// aapt resource value: 0x7F060039
-			public const int abc_text_size_body_2_material = 2131099705;
+			public const int abc_text_size_body_1_material = 2131099705;
 			
 			// aapt resource value: 0x7F06003A
-			public const int abc_text_size_button_material = 2131099706;
+			public const int abc_text_size_body_2_material = 2131099706;
 			
 			// aapt resource value: 0x7F06003B
-			public const int abc_text_size_caption_material = 2131099707;
+			public const int abc_text_size_button_material = 2131099707;
 			
 			// aapt resource value: 0x7F06003C
-			public const int abc_text_size_display_1_material = 2131099708;
+			public const int abc_text_size_caption_material = 2131099708;
 			
 			// aapt resource value: 0x7F06003D
-			public const int abc_text_size_display_2_material = 2131099709;
+			public const int abc_text_size_display_1_material = 2131099709;
 			
 			// aapt resource value: 0x7F06003E
-			public const int abc_text_size_display_3_material = 2131099710;
+			public const int abc_text_size_display_2_material = 2131099710;
 			
 			// aapt resource value: 0x7F06003F
-			public const int abc_text_size_display_4_material = 2131099711;
+			public const int abc_text_size_display_3_material = 2131099711;
 			
 			// aapt resource value: 0x7F060040
-			public const int abc_text_size_headline_material = 2131099712;
+			public const int abc_text_size_display_4_material = 2131099712;
 			
 			// aapt resource value: 0x7F060041
-			public const int abc_text_size_large_material = 2131099713;
+			public const int abc_text_size_headline_material = 2131099713;
 			
 			// aapt resource value: 0x7F060042
-			public const int abc_text_size_medium_material = 2131099714;
+			public const int abc_text_size_large_material = 2131099714;
 			
 			// aapt resource value: 0x7F060043
-			public const int abc_text_size_menu_header_material = 2131099715;
+			public const int abc_text_size_medium_material = 2131099715;
 			
 			// aapt resource value: 0x7F060044
-			public const int abc_text_size_menu_material = 2131099716;
+			public const int abc_text_size_menu_header_material = 2131099716;
 			
 			// aapt resource value: 0x7F060045
-			public const int abc_text_size_small_material = 2131099717;
+			public const int abc_text_size_menu_material = 2131099717;
 			
 			// aapt resource value: 0x7F060046
-			public const int abc_text_size_subhead_material = 2131099718;
+			public const int abc_text_size_small_material = 2131099718;
 			
 			// aapt resource value: 0x7F060047
-			public const int abc_text_size_subtitle_material_toolbar = 2131099719;
+			public const int abc_text_size_subhead_material = 2131099719;
 			
 			// aapt resource value: 0x7F060048
-			public const int abc_text_size_title_material = 2131099720;
+			public const int abc_text_size_subtitle_material_toolbar = 2131099720;
 			
 			// aapt resource value: 0x7F060049
-			public const int abc_text_size_title_material_toolbar = 2131099721;
+			public const int abc_text_size_title_material = 2131099721;
 			
 			// aapt resource value: 0x7F06004A
-			public const int cardview_compat_inset_shadow = 2131099722;
+			public const int abc_text_size_title_material_toolbar = 2131099722;
 			
 			// aapt resource value: 0x7F06004B
-			public const int cardview_default_elevation = 2131099723;
+			public const int browser_actions_context_menu_max_width = 2131099723;
 			
 			// aapt resource value: 0x7F06004C
-			public const int cardview_default_radius = 2131099724;
+			public const int browser_actions_context_menu_min_padding = 2131099724;
 			
 			// aapt resource value: 0x7F06004D
-			public const int compat_button_inset_horizontal_material = 2131099725;
+			public const int cardview_compat_inset_shadow = 2131099725;
 			
 			// aapt resource value: 0x7F06004E
-			public const int compat_button_inset_vertical_material = 2131099726;
+			public const int cardview_default_elevation = 2131099726;
 			
 			// aapt resource value: 0x7F06004F
-			public const int compat_button_padding_horizontal_material = 2131099727;
+			public const int cardview_default_radius = 2131099727;
 			
 			// aapt resource value: 0x7F060050
-			public const int compat_button_padding_vertical_material = 2131099728;
+			public const int compat_button_inset_horizontal_material = 2131099728;
 			
 			// aapt resource value: 0x7F060051
-			public const int compat_control_corner_material = 2131099729;
+			public const int compat_button_inset_vertical_material = 2131099729;
 			
 			// aapt resource value: 0x7F060052
-			public const int design_appbar_elevation = 2131099730;
+			public const int compat_button_padding_horizontal_material = 2131099730;
 			
 			// aapt resource value: 0x7F060053
-			public const int design_bottom_navigation_active_item_max_width = 2131099731;
+			public const int compat_button_padding_vertical_material = 2131099731;
 			
 			// aapt resource value: 0x7F060054
-			public const int design_bottom_navigation_active_text_size = 2131099732;
+			public const int compat_control_corner_material = 2131099732;
 			
 			// aapt resource value: 0x7F060055
-			public const int design_bottom_navigation_elevation = 2131099733;
+			public const int compat_notification_large_icon_max_height = 2131099733;
 			
 			// aapt resource value: 0x7F060056
-			public const int design_bottom_navigation_height = 2131099734;
+			public const int compat_notification_large_icon_max_width = 2131099734;
 			
 			// aapt resource value: 0x7F060057
-			public const int design_bottom_navigation_item_max_width = 2131099735;
+			public const int design_appbar_elevation = 2131099735;
 			
 			// aapt resource value: 0x7F060058
-			public const int design_bottom_navigation_item_min_width = 2131099736;
+			public const int design_bottom_navigation_active_item_max_width = 2131099736;
 			
 			// aapt resource value: 0x7F060059
-			public const int design_bottom_navigation_margin = 2131099737;
+			public const int design_bottom_navigation_active_item_min_width = 2131099737;
 			
 			// aapt resource value: 0x7F06005A
-			public const int design_bottom_navigation_shadow_height = 2131099738;
+			public const int design_bottom_navigation_active_text_size = 2131099738;
 			
 			// aapt resource value: 0x7F06005B
-			public const int design_bottom_navigation_text_size = 2131099739;
+			public const int design_bottom_navigation_elevation = 2131099739;
 			
 			// aapt resource value: 0x7F06005C
-			public const int design_bottom_sheet_modal_elevation = 2131099740;
+			public const int design_bottom_navigation_height = 2131099740;
 			
 			// aapt resource value: 0x7F06005D
-			public const int design_bottom_sheet_peek_height_min = 2131099741;
+			public const int design_bottom_navigation_icon_size = 2131099741;
 			
 			// aapt resource value: 0x7F06005E
-			public const int design_fab_border_width = 2131099742;
+			public const int design_bottom_navigation_item_max_width = 2131099742;
 			
 			// aapt resource value: 0x7F06005F
-			public const int design_fab_elevation = 2131099743;
+			public const int design_bottom_navigation_item_min_width = 2131099743;
 			
 			// aapt resource value: 0x7F060060
-			public const int design_fab_image_size = 2131099744;
+			public const int design_bottom_navigation_margin = 2131099744;
 			
 			// aapt resource value: 0x7F060061
-			public const int design_fab_size_mini = 2131099745;
+			public const int design_bottom_navigation_shadow_height = 2131099745;
 			
 			// aapt resource value: 0x7F060062
-			public const int design_fab_size_normal = 2131099746;
+			public const int design_bottom_navigation_text_size = 2131099746;
 			
 			// aapt resource value: 0x7F060063
-			public const int design_fab_translation_z_pressed = 2131099747;
+			public const int design_bottom_sheet_modal_elevation = 2131099747;
 			
 			// aapt resource value: 0x7F060064
-			public const int design_navigation_elevation = 2131099748;
+			public const int design_bottom_sheet_peek_height_min = 2131099748;
 			
 			// aapt resource value: 0x7F060065
-			public const int design_navigation_icon_padding = 2131099749;
+			public const int design_fab_border_width = 2131099749;
 			
 			// aapt resource value: 0x7F060066
-			public const int design_navigation_icon_size = 2131099750;
+			public const int design_fab_elevation = 2131099750;
 			
 			// aapt resource value: 0x7F060067
-			public const int design_navigation_max_width = 2131099751;
+			public const int design_fab_image_size = 2131099751;
 			
 			// aapt resource value: 0x7F060068
-			public const int design_navigation_padding_bottom = 2131099752;
+			public const int design_fab_size_mini = 2131099752;
 			
 			// aapt resource value: 0x7F060069
-			public const int design_navigation_separator_vertical_padding = 2131099753;
+			public const int design_fab_size_normal = 2131099753;
 			
 			// aapt resource value: 0x7F06006A
-			public const int design_snackbar_action_inline_max_width = 2131099754;
+			public const int design_fab_translation_z_hovered_focused = 2131099754;
 			
 			// aapt resource value: 0x7F06006B
-			public const int design_snackbar_background_corner_radius = 2131099755;
+			public const int design_fab_translation_z_pressed = 2131099755;
 			
 			// aapt resource value: 0x7F06006C
-			public const int design_snackbar_elevation = 2131099756;
+			public const int design_navigation_elevation = 2131099756;
 			
 			// aapt resource value: 0x7F06006D
-			public const int design_snackbar_extra_spacing_horizontal = 2131099757;
+			public const int design_navigation_icon_padding = 2131099757;
 			
 			// aapt resource value: 0x7F06006E
-			public const int design_snackbar_max_width = 2131099758;
+			public const int design_navigation_icon_size = 2131099758;
 			
 			// aapt resource value: 0x7F06006F
-			public const int design_snackbar_min_width = 2131099759;
+			public const int design_navigation_item_horizontal_padding = 2131099759;
 			
 			// aapt resource value: 0x7F060070
-			public const int design_snackbar_padding_horizontal = 2131099760;
+			public const int design_navigation_item_icon_padding = 2131099760;
 			
 			// aapt resource value: 0x7F060071
-			public const int design_snackbar_padding_vertical = 2131099761;
+			public const int design_navigation_max_width = 2131099761;
 			
 			// aapt resource value: 0x7F060072
-			public const int design_snackbar_padding_vertical_2lines = 2131099762;
+			public const int design_navigation_padding_bottom = 2131099762;
 			
 			// aapt resource value: 0x7F060073
-			public const int design_snackbar_text_size = 2131099763;
+			public const int design_navigation_separator_vertical_padding = 2131099763;
 			
 			// aapt resource value: 0x7F060074
-			public const int design_tab_max_width = 2131099764;
+			public const int design_snackbar_action_inline_max_width = 2131099764;
 			
 			// aapt resource value: 0x7F060075
-			public const int design_tab_scrollable_min_width = 2131099765;
+			public const int design_snackbar_background_corner_radius = 2131099765;
 			
 			// aapt resource value: 0x7F060076
-			public const int design_tab_text_size = 2131099766;
+			public const int design_snackbar_elevation = 2131099766;
 			
 			// aapt resource value: 0x7F060077
-			public const int design_tab_text_size_2line = 2131099767;
+			public const int design_snackbar_extra_spacing_horizontal = 2131099767;
 			
 			// aapt resource value: 0x7F060078
-			public const int disabled_alpha_material_dark = 2131099768;
+			public const int design_snackbar_max_width = 2131099768;
 			
 			// aapt resource value: 0x7F060079
-			public const int disabled_alpha_material_light = 2131099769;
+			public const int design_snackbar_min_width = 2131099769;
 			
 			// aapt resource value: 0x7F06007A
-			public const int fastscroll_default_thickness = 2131099770;
+			public const int design_snackbar_padding_horizontal = 2131099770;
 			
 			// aapt resource value: 0x7F06007B
-			public const int fastscroll_margin = 2131099771;
+			public const int design_snackbar_padding_vertical = 2131099771;
 			
 			// aapt resource value: 0x7F06007C
-			public const int fastscroll_minimum_range = 2131099772;
+			public const int design_snackbar_padding_vertical_2lines = 2131099772;
 			
 			// aapt resource value: 0x7F06007D
-			public const int highlight_alpha_material_colored = 2131099773;
+			public const int design_snackbar_text_size = 2131099773;
 			
 			// aapt resource value: 0x7F06007E
-			public const int highlight_alpha_material_dark = 2131099774;
+			public const int design_tab_max_width = 2131099774;
 			
 			// aapt resource value: 0x7F06007F
-			public const int highlight_alpha_material_light = 2131099775;
+			public const int design_tab_scrollable_min_width = 2131099775;
 			
 			// aapt resource value: 0x7F060080
-			public const int hint_alpha_material_dark = 2131099776;
+			public const int design_tab_text_size = 2131099776;
 			
 			// aapt resource value: 0x7F060081
-			public const int hint_alpha_material_light = 2131099777;
+			public const int design_tab_text_size_2line = 2131099777;
 			
 			// aapt resource value: 0x7F060082
-			public const int hint_pressed_alpha_material_dark = 2131099778;
+			public const int design_textinput_caption_translate_y = 2131099778;
 			
 			// aapt resource value: 0x7F060083
-			public const int hint_pressed_alpha_material_light = 2131099779;
+			public const int disabled_alpha_material_dark = 2131099779;
 			
 			// aapt resource value: 0x7F060084
-			public const int item_touch_helper_max_drag_scroll_per_frame = 2131099780;
+			public const int disabled_alpha_material_light = 2131099780;
 			
 			// aapt resource value: 0x7F060085
-			public const int item_touch_helper_swipe_escape_max_velocity = 2131099781;
+			public const int fastscroll_default_thickness = 2131099781;
 			
 			// aapt resource value: 0x7F060086
-			public const int item_touch_helper_swipe_escape_velocity = 2131099782;
+			public const int fastscroll_margin = 2131099782;
 			
 			// aapt resource value: 0x7F060087
-			public const int mr_controller_volume_group_list_item_height = 2131099783;
+			public const int fastscroll_minimum_range = 2131099783;
 			
 			// aapt resource value: 0x7F060088
-			public const int mr_controller_volume_group_list_item_icon_size = 2131099784;
+			public const int highlight_alpha_material_colored = 2131099784;
 			
 			// aapt resource value: 0x7F060089
-			public const int mr_controller_volume_group_list_max_height = 2131099785;
+			public const int highlight_alpha_material_dark = 2131099785;
 			
 			// aapt resource value: 0x7F06008A
-			public const int mr_controller_volume_group_list_padding_top = 2131099786;
+			public const int highlight_alpha_material_light = 2131099786;
 			
 			// aapt resource value: 0x7F06008B
-			public const int mr_dialog_fixed_width_major = 2131099787;
+			public const int hint_alpha_material_dark = 2131099787;
 			
 			// aapt resource value: 0x7F06008C
-			public const int mr_dialog_fixed_width_minor = 2131099788;
+			public const int hint_alpha_material_light = 2131099788;
 			
 			// aapt resource value: 0x7F06008D
-			public const int notification_action_icon_size = 2131099789;
+			public const int hint_pressed_alpha_material_dark = 2131099789;
 			
 			// aapt resource value: 0x7F06008E
-			public const int notification_action_text_size = 2131099790;
+			public const int hint_pressed_alpha_material_light = 2131099790;
 			
 			// aapt resource value: 0x7F06008F
-			public const int notification_big_circle_margin = 2131099791;
+			public const int item_touch_helper_max_drag_scroll_per_frame = 2131099791;
 			
 			// aapt resource value: 0x7F060090
-			public const int notification_content_margin_start = 2131099792;
+			public const int item_touch_helper_swipe_escape_max_velocity = 2131099792;
 			
 			// aapt resource value: 0x7F060091
-			public const int notification_large_icon_height = 2131099793;
+			public const int item_touch_helper_swipe_escape_velocity = 2131099793;
 			
 			// aapt resource value: 0x7F060092
-			public const int notification_large_icon_width = 2131099794;
+			public const int mr_controller_volume_group_list_item_height = 2131099794;
 			
 			// aapt resource value: 0x7F060093
-			public const int notification_main_column_padding_top = 2131099795;
+			public const int mr_controller_volume_group_list_item_icon_size = 2131099795;
 			
 			// aapt resource value: 0x7F060094
-			public const int notification_media_narrow_margin = 2131099796;
+			public const int mr_controller_volume_group_list_max_height = 2131099796;
 			
 			// aapt resource value: 0x7F060095
-			public const int notification_right_icon_size = 2131099797;
+			public const int mr_controller_volume_group_list_padding_top = 2131099797;
 			
 			// aapt resource value: 0x7F060096
-			public const int notification_right_side_padding_top = 2131099798;
+			public const int mr_dialog_fixed_width_major = 2131099798;
 			
 			// aapt resource value: 0x7F060097
-			public const int notification_small_icon_background_padding = 2131099799;
+			public const int mr_dialog_fixed_width_minor = 2131099799;
 			
 			// aapt resource value: 0x7F060098
-			public const int notification_small_icon_size_as_large = 2131099800;
+			public const int mtrl_bottomappbar_fabOffsetEndMode = 2131099800;
 			
 			// aapt resource value: 0x7F060099
-			public const int notification_subtext_size = 2131099801;
+			public const int mtrl_bottomappbar_fab_cradle_margin = 2131099801;
 			
 			// aapt resource value: 0x7F06009A
-			public const int notification_top_pad = 2131099802;
+			public const int mtrl_bottomappbar_fab_cradle_rounded_corner_radius = 2131099802;
 			
 			// aapt resource value: 0x7F06009B
-			public const int notification_top_pad_large_text = 2131099803;
+			public const int mtrl_bottomappbar_fab_cradle_vertical_offset = 2131099803;
 			
 			// aapt resource value: 0x7F06009C
-			public const int tooltip_corner_radius = 2131099804;
+			public const int mtrl_bottomappbar_height = 2131099804;
 			
 			// aapt resource value: 0x7F06009D
-			public const int tooltip_horizontal_padding = 2131099805;
+			public const int mtrl_btn_corner_radius = 2131099805;
 			
 			// aapt resource value: 0x7F06009E
-			public const int tooltip_margin = 2131099806;
+			public const int mtrl_btn_dialog_btn_min_width = 2131099806;
 			
 			// aapt resource value: 0x7F06009F
-			public const int tooltip_precise_anchor_extra_offset = 2131099807;
+			public const int mtrl_btn_disabled_elevation = 2131099807;
 			
 			// aapt resource value: 0x7F0600A0
-			public const int tooltip_precise_anchor_threshold = 2131099808;
+			public const int mtrl_btn_disabled_z = 2131099808;
 			
 			// aapt resource value: 0x7F0600A1
-			public const int tooltip_vertical_padding = 2131099809;
+			public const int mtrl_btn_elevation = 2131099809;
 			
 			// aapt resource value: 0x7F0600A2
-			public const int tooltip_y_offset_non_touch = 2131099810;
+			public const int mtrl_btn_focused_z = 2131099810;
 			
 			// aapt resource value: 0x7F0600A3
-			public const int tooltip_y_offset_touch = 2131099811;
+			public const int mtrl_btn_hovered_z = 2131099811;
+			
+			// aapt resource value: 0x7F0600A4
+			public const int mtrl_btn_icon_btn_padding_left = 2131099812;
+			
+			// aapt resource value: 0x7F0600A5
+			public const int mtrl_btn_icon_padding = 2131099813;
+			
+			// aapt resource value: 0x7F0600A6
+			public const int mtrl_btn_inset = 2131099814;
+			
+			// aapt resource value: 0x7F0600A7
+			public const int mtrl_btn_letter_spacing = 2131099815;
+			
+			// aapt resource value: 0x7F0600A8
+			public const int mtrl_btn_padding_bottom = 2131099816;
+			
+			// aapt resource value: 0x7F0600A9
+			public const int mtrl_btn_padding_left = 2131099817;
+			
+			// aapt resource value: 0x7F0600AA
+			public const int mtrl_btn_padding_right = 2131099818;
+			
+			// aapt resource value: 0x7F0600AB
+			public const int mtrl_btn_padding_top = 2131099819;
+			
+			// aapt resource value: 0x7F0600AC
+			public const int mtrl_btn_pressed_z = 2131099820;
+			
+			// aapt resource value: 0x7F0600AD
+			public const int mtrl_btn_stroke_size = 2131099821;
+			
+			// aapt resource value: 0x7F0600AE
+			public const int mtrl_btn_text_btn_icon_padding = 2131099822;
+			
+			// aapt resource value: 0x7F0600AF
+			public const int mtrl_btn_text_btn_padding_left = 2131099823;
+			
+			// aapt resource value: 0x7F0600B0
+			public const int mtrl_btn_text_btn_padding_right = 2131099824;
+			
+			// aapt resource value: 0x7F0600B1
+			public const int mtrl_btn_text_size = 2131099825;
+			
+			// aapt resource value: 0x7F0600B2
+			public const int mtrl_btn_z = 2131099826;
+			
+			// aapt resource value: 0x7F0600B3
+			public const int mtrl_card_elevation = 2131099827;
+			
+			// aapt resource value: 0x7F0600B4
+			public const int mtrl_card_spacing = 2131099828;
+			
+			// aapt resource value: 0x7F0600B5
+			public const int mtrl_chip_pressed_translation_z = 2131099829;
+			
+			// aapt resource value: 0x7F0600B6
+			public const int mtrl_chip_text_size = 2131099830;
+			
+			// aapt resource value: 0x7F0600B7
+			public const int mtrl_fab_elevation = 2131099831;
+			
+			// aapt resource value: 0x7F0600B8
+			public const int mtrl_fab_translation_z_hovered_focused = 2131099832;
+			
+			// aapt resource value: 0x7F0600B9
+			public const int mtrl_fab_translation_z_pressed = 2131099833;
+			
+			// aapt resource value: 0x7F0600BA
+			public const int mtrl_navigation_elevation = 2131099834;
+			
+			// aapt resource value: 0x7F0600BB
+			public const int mtrl_navigation_item_horizontal_padding = 2131099835;
+			
+			// aapt resource value: 0x7F0600BC
+			public const int mtrl_navigation_item_icon_padding = 2131099836;
+			
+			// aapt resource value: 0x7F0600BD
+			public const int mtrl_snackbar_background_corner_radius = 2131099837;
+			
+			// aapt resource value: 0x7F0600BE
+			public const int mtrl_snackbar_margin = 2131099838;
+			
+			// aapt resource value: 0x7F0600BF
+			public const int mtrl_textinput_box_bottom_offset = 2131099839;
+			
+			// aapt resource value: 0x7F0600C0
+			public const int mtrl_textinput_box_corner_radius_medium = 2131099840;
+			
+			// aapt resource value: 0x7F0600C1
+			public const int mtrl_textinput_box_corner_radius_small = 2131099841;
+			
+			// aapt resource value: 0x7F0600C2
+			public const int mtrl_textinput_box_label_cutout_padding = 2131099842;
+			
+			// aapt resource value: 0x7F0600C3
+			public const int mtrl_textinput_box_padding_end = 2131099843;
+			
+			// aapt resource value: 0x7F0600C4
+			public const int mtrl_textinput_box_stroke_width_default = 2131099844;
+			
+			// aapt resource value: 0x7F0600C5
+			public const int mtrl_textinput_box_stroke_width_focused = 2131099845;
+			
+			// aapt resource value: 0x7F0600C6
+			public const int mtrl_textinput_outline_box_expanded_padding = 2131099846;
+			
+			// aapt resource value: 0x7F0600C7
+			public const int mtrl_toolbar_default_height = 2131099847;
+			
+			// aapt resource value: 0x7F0600C8
+			public const int notification_action_icon_size = 2131099848;
+			
+			// aapt resource value: 0x7F0600C9
+			public const int notification_action_text_size = 2131099849;
+			
+			// aapt resource value: 0x7F0600CA
+			public const int notification_big_circle_margin = 2131099850;
+			
+			// aapt resource value: 0x7F0600CB
+			public const int notification_content_margin_start = 2131099851;
+			
+			// aapt resource value: 0x7F0600CC
+			public const int notification_large_icon_height = 2131099852;
+			
+			// aapt resource value: 0x7F0600CD
+			public const int notification_large_icon_width = 2131099853;
+			
+			// aapt resource value: 0x7F0600CE
+			public const int notification_main_column_padding_top = 2131099854;
+			
+			// aapt resource value: 0x7F0600CF
+			public const int notification_media_narrow_margin = 2131099855;
+			
+			// aapt resource value: 0x7F0600D0
+			public const int notification_right_icon_size = 2131099856;
+			
+			// aapt resource value: 0x7F0600D1
+			public const int notification_right_side_padding_top = 2131099857;
+			
+			// aapt resource value: 0x7F0600D2
+			public const int notification_small_icon_background_padding = 2131099858;
+			
+			// aapt resource value: 0x7F0600D3
+			public const int notification_small_icon_size_as_large = 2131099859;
+			
+			// aapt resource value: 0x7F0600D4
+			public const int notification_subtext_size = 2131099860;
+			
+			// aapt resource value: 0x7F0600D5
+			public const int notification_top_pad = 2131099861;
+			
+			// aapt resource value: 0x7F0600D6
+			public const int notification_top_pad_large_text = 2131099862;
+			
+			// aapt resource value: 0x7F0600D7
+			public const int subtitle_corner_radius = 2131099863;
+			
+			// aapt resource value: 0x7F0600D8
+			public const int subtitle_outline_width = 2131099864;
+			
+			// aapt resource value: 0x7F0600D9
+			public const int subtitle_shadow_offset = 2131099865;
+			
+			// aapt resource value: 0x7F0600DA
+			public const int subtitle_shadow_radius = 2131099866;
+			
+			// aapt resource value: 0x7F0600DB
+			public const int tooltip_corner_radius = 2131099867;
+			
+			// aapt resource value: 0x7F0600DC
+			public const int tooltip_horizontal_padding = 2131099868;
+			
+			// aapt resource value: 0x7F0600DD
+			public const int tooltip_margin = 2131099869;
+			
+			// aapt resource value: 0x7F0600DE
+			public const int tooltip_precise_anchor_extra_offset = 2131099870;
+			
+			// aapt resource value: 0x7F0600DF
+			public const int tooltip_precise_anchor_threshold = 2131099871;
+			
+			// aapt resource value: 0x7F0600E0
+			public const int tooltip_vertical_padding = 2131099872;
+			
+			// aapt resource value: 0x7F0600E1
+			public const int tooltip_y_offset_non_touch = 2131099873;
+			
+			// aapt resource value: 0x7F0600E2
+			public const int tooltip_y_offset_touch = 2131099874;
 			
 			static Dimension()
 			{
@@ -4208,793 +5456,811 @@ namespace NFCSample.Droid
 			public const int abc_item_background_holo_light = 2131165229;
 			
 			// aapt resource value: 0x7F07002E
-			public const int abc_list_divider_mtrl_alpha = 2131165230;
+			public const int abc_list_divider_material = 2131165230;
 			
 			// aapt resource value: 0x7F07002F
-			public const int abc_list_focused_holo = 2131165231;
+			public const int abc_list_divider_mtrl_alpha = 2131165231;
 			
 			// aapt resource value: 0x7F070030
-			public const int abc_list_longpressed_holo = 2131165232;
+			public const int abc_list_focused_holo = 2131165232;
 			
 			// aapt resource value: 0x7F070031
-			public const int abc_list_pressed_holo_dark = 2131165233;
+			public const int abc_list_longpressed_holo = 2131165233;
 			
 			// aapt resource value: 0x7F070032
-			public const int abc_list_pressed_holo_light = 2131165234;
+			public const int abc_list_pressed_holo_dark = 2131165234;
 			
 			// aapt resource value: 0x7F070033
-			public const int abc_list_selector_background_transition_holo_dark = 2131165235;
+			public const int abc_list_pressed_holo_light = 2131165235;
 			
 			// aapt resource value: 0x7F070034
-			public const int abc_list_selector_background_transition_holo_light = 2131165236;
+			public const int abc_list_selector_background_transition_holo_dark = 2131165236;
 			
 			// aapt resource value: 0x7F070035
-			public const int abc_list_selector_disabled_holo_dark = 2131165237;
+			public const int abc_list_selector_background_transition_holo_light = 2131165237;
 			
 			// aapt resource value: 0x7F070036
-			public const int abc_list_selector_disabled_holo_light = 2131165238;
+			public const int abc_list_selector_disabled_holo_dark = 2131165238;
 			
 			// aapt resource value: 0x7F070037
-			public const int abc_list_selector_holo_dark = 2131165239;
+			public const int abc_list_selector_disabled_holo_light = 2131165239;
 			
 			// aapt resource value: 0x7F070038
-			public const int abc_list_selector_holo_light = 2131165240;
+			public const int abc_list_selector_holo_dark = 2131165240;
 			
 			// aapt resource value: 0x7F070039
-			public const int abc_menu_hardkey_panel_mtrl_mult = 2131165241;
+			public const int abc_list_selector_holo_light = 2131165241;
 			
 			// aapt resource value: 0x7F07003A
-			public const int abc_popup_background_mtrl_mult = 2131165242;
+			public const int abc_menu_hardkey_panel_mtrl_mult = 2131165242;
 			
 			// aapt resource value: 0x7F07003B
-			public const int abc_ratingbar_indicator_material = 2131165243;
+			public const int abc_popup_background_mtrl_mult = 2131165243;
 			
 			// aapt resource value: 0x7F07003C
-			public const int abc_ratingbar_material = 2131165244;
+			public const int abc_ratingbar_indicator_material = 2131165244;
 			
 			// aapt resource value: 0x7F07003D
-			public const int abc_ratingbar_small_material = 2131165245;
+			public const int abc_ratingbar_material = 2131165245;
 			
 			// aapt resource value: 0x7F07003E
-			public const int abc_scrubber_control_off_mtrl_alpha = 2131165246;
+			public const int abc_ratingbar_small_material = 2131165246;
 			
 			// aapt resource value: 0x7F07003F
-			public const int abc_scrubber_control_to_pressed_mtrl_000 = 2131165247;
+			public const int abc_scrubber_control_off_mtrl_alpha = 2131165247;
 			
 			// aapt resource value: 0x7F070040
-			public const int abc_scrubber_control_to_pressed_mtrl_005 = 2131165248;
+			public const int abc_scrubber_control_to_pressed_mtrl_000 = 2131165248;
 			
 			// aapt resource value: 0x7F070041
-			public const int abc_scrubber_primary_mtrl_alpha = 2131165249;
+			public const int abc_scrubber_control_to_pressed_mtrl_005 = 2131165249;
 			
 			// aapt resource value: 0x7F070042
-			public const int abc_scrubber_track_mtrl_alpha = 2131165250;
+			public const int abc_scrubber_primary_mtrl_alpha = 2131165250;
 			
 			// aapt resource value: 0x7F070043
-			public const int abc_seekbar_thumb_material = 2131165251;
+			public const int abc_scrubber_track_mtrl_alpha = 2131165251;
 			
 			// aapt resource value: 0x7F070044
-			public const int abc_seekbar_tick_mark_material = 2131165252;
+			public const int abc_seekbar_thumb_material = 2131165252;
 			
 			// aapt resource value: 0x7F070045
-			public const int abc_seekbar_track_material = 2131165253;
+			public const int abc_seekbar_tick_mark_material = 2131165253;
 			
 			// aapt resource value: 0x7F070046
-			public const int abc_spinner_mtrl_am_alpha = 2131165254;
+			public const int abc_seekbar_track_material = 2131165254;
 			
 			// aapt resource value: 0x7F070047
-			public const int abc_spinner_textfield_background_material = 2131165255;
+			public const int abc_spinner_mtrl_am_alpha = 2131165255;
 			
 			// aapt resource value: 0x7F070048
-			public const int abc_switch_thumb_material = 2131165256;
+			public const int abc_spinner_textfield_background_material = 2131165256;
 			
 			// aapt resource value: 0x7F070049
-			public const int abc_switch_track_mtrl_alpha = 2131165257;
+			public const int abc_switch_thumb_material = 2131165257;
 			
 			// aapt resource value: 0x7F07004A
-			public const int abc_tab_indicator_material = 2131165258;
+			public const int abc_switch_track_mtrl_alpha = 2131165258;
 			
 			// aapt resource value: 0x7F07004B
-			public const int abc_tab_indicator_mtrl_alpha = 2131165259;
-			
-			// aapt resource value: 0x7F070053
-			public const int abc_textfield_activated_mtrl_alpha = 2131165267;
-			
-			// aapt resource value: 0x7F070054
-			public const int abc_textfield_default_mtrl_alpha = 2131165268;
-			
-			// aapt resource value: 0x7F070055
-			public const int abc_textfield_search_activated_mtrl_alpha = 2131165269;
-			
-			// aapt resource value: 0x7F070056
-			public const int abc_textfield_search_default_mtrl_alpha = 2131165270;
-			
-			// aapt resource value: 0x7F070057
-			public const int abc_textfield_search_material = 2131165271;
+			public const int abc_tab_indicator_material = 2131165259;
 			
 			// aapt resource value: 0x7F07004C
-			public const int abc_text_cursor_material = 2131165260;
+			public const int abc_tab_indicator_mtrl_alpha = 2131165260;
 			
-			// aapt resource value: 0x7F07004D
-			public const int abc_text_select_handle_left_mtrl_dark = 2131165261;
+			// aapt resource value: 0x7F070054
+			public const int abc_textfield_activated_mtrl_alpha = 2131165268;
 			
-			// aapt resource value: 0x7F07004E
-			public const int abc_text_select_handle_left_mtrl_light = 2131165262;
+			// aapt resource value: 0x7F070055
+			public const int abc_textfield_default_mtrl_alpha = 2131165269;
 			
-			// aapt resource value: 0x7F07004F
-			public const int abc_text_select_handle_middle_mtrl_dark = 2131165263;
+			// aapt resource value: 0x7F070056
+			public const int abc_textfield_search_activated_mtrl_alpha = 2131165270;
 			
-			// aapt resource value: 0x7F070050
-			public const int abc_text_select_handle_middle_mtrl_light = 2131165264;
-			
-			// aapt resource value: 0x7F070051
-			public const int abc_text_select_handle_right_mtrl_dark = 2131165265;
-			
-			// aapt resource value: 0x7F070052
-			public const int abc_text_select_handle_right_mtrl_light = 2131165266;
+			// aapt resource value: 0x7F070057
+			public const int abc_textfield_search_default_mtrl_alpha = 2131165271;
 			
 			// aapt resource value: 0x7F070058
-			public const int abc_vector_test = 2131165272;
+			public const int abc_textfield_search_material = 2131165272;
+			
+			// aapt resource value: 0x7F07004D
+			public const int abc_text_cursor_material = 2131165261;
+			
+			// aapt resource value: 0x7F07004E
+			public const int abc_text_select_handle_left_mtrl_dark = 2131165262;
+			
+			// aapt resource value: 0x7F07004F
+			public const int abc_text_select_handle_left_mtrl_light = 2131165263;
+			
+			// aapt resource value: 0x7F070050
+			public const int abc_text_select_handle_middle_mtrl_dark = 2131165264;
+			
+			// aapt resource value: 0x7F070051
+			public const int abc_text_select_handle_middle_mtrl_light = 2131165265;
+			
+			// aapt resource value: 0x7F070052
+			public const int abc_text_select_handle_right_mtrl_dark = 2131165266;
+			
+			// aapt resource value: 0x7F070053
+			public const int abc_text_select_handle_right_mtrl_light = 2131165267;
 			
 			// aapt resource value: 0x7F070059
-			public const int avd_hide_password = 2131165273;
+			public const int abc_vector_test = 2131165273;
 			
 			// aapt resource value: 0x7F07005A
-			public const int avd_show_password = 2131165274;
+			public const int avd_hide_password = 2131165274;
 			
 			// aapt resource value: 0x7F07005B
-			public const int design_bottom_navigation_item_background = 2131165275;
+			public const int avd_show_password = 2131165275;
 			
 			// aapt resource value: 0x7F07005C
-			public const int design_fab_background = 2131165276;
+			public const int design_bottom_navigation_item_background = 2131165276;
 			
 			// aapt resource value: 0x7F07005D
-			public const int design_ic_visibility = 2131165277;
+			public const int design_fab_background = 2131165277;
 			
 			// aapt resource value: 0x7F07005E
-			public const int design_ic_visibility_off = 2131165278;
+			public const int design_ic_visibility = 2131165278;
 			
 			// aapt resource value: 0x7F07005F
-			public const int design_password_eye = 2131165279;
+			public const int design_ic_visibility_off = 2131165279;
 			
 			// aapt resource value: 0x7F070060
-			public const int design_snackbar_background = 2131165280;
+			public const int design_password_eye = 2131165280;
 			
 			// aapt resource value: 0x7F070061
-			public const int ic_audiotrack_dark = 2131165281;
+			public const int design_snackbar_background = 2131165281;
 			
 			// aapt resource value: 0x7F070062
-			public const int ic_audiotrack_light = 2131165282;
+			public const int ic_audiotrack_dark = 2131165282;
 			
 			// aapt resource value: 0x7F070063
-			public const int ic_dialog_close_dark = 2131165283;
+			public const int ic_audiotrack_light = 2131165283;
 			
 			// aapt resource value: 0x7F070064
-			public const int ic_dialog_close_light = 2131165284;
+			public const int ic_dialog_close_dark = 2131165284;
 			
 			// aapt resource value: 0x7F070065
-			public const int ic_group_collapse_00 = 2131165285;
+			public const int ic_dialog_close_light = 2131165285;
 			
 			// aapt resource value: 0x7F070066
-			public const int ic_group_collapse_01 = 2131165286;
+			public const int ic_group_collapse_00 = 2131165286;
 			
 			// aapt resource value: 0x7F070067
-			public const int ic_group_collapse_02 = 2131165287;
+			public const int ic_group_collapse_01 = 2131165287;
 			
 			// aapt resource value: 0x7F070068
-			public const int ic_group_collapse_03 = 2131165288;
+			public const int ic_group_collapse_02 = 2131165288;
 			
 			// aapt resource value: 0x7F070069
-			public const int ic_group_collapse_04 = 2131165289;
+			public const int ic_group_collapse_03 = 2131165289;
 			
 			// aapt resource value: 0x7F07006A
-			public const int ic_group_collapse_05 = 2131165290;
+			public const int ic_group_collapse_04 = 2131165290;
 			
 			// aapt resource value: 0x7F07006B
-			public const int ic_group_collapse_06 = 2131165291;
+			public const int ic_group_collapse_05 = 2131165291;
 			
 			// aapt resource value: 0x7F07006C
-			public const int ic_group_collapse_07 = 2131165292;
+			public const int ic_group_collapse_06 = 2131165292;
 			
 			// aapt resource value: 0x7F07006D
-			public const int ic_group_collapse_08 = 2131165293;
+			public const int ic_group_collapse_07 = 2131165293;
 			
 			// aapt resource value: 0x7F07006E
-			public const int ic_group_collapse_09 = 2131165294;
+			public const int ic_group_collapse_08 = 2131165294;
 			
 			// aapt resource value: 0x7F07006F
-			public const int ic_group_collapse_10 = 2131165295;
+			public const int ic_group_collapse_09 = 2131165295;
 			
 			// aapt resource value: 0x7F070070
-			public const int ic_group_collapse_11 = 2131165296;
+			public const int ic_group_collapse_10 = 2131165296;
 			
 			// aapt resource value: 0x7F070071
-			public const int ic_group_collapse_12 = 2131165297;
+			public const int ic_group_collapse_11 = 2131165297;
 			
 			// aapt resource value: 0x7F070072
-			public const int ic_group_collapse_13 = 2131165298;
+			public const int ic_group_collapse_12 = 2131165298;
 			
 			// aapt resource value: 0x7F070073
-			public const int ic_group_collapse_14 = 2131165299;
+			public const int ic_group_collapse_13 = 2131165299;
 			
 			// aapt resource value: 0x7F070074
-			public const int ic_group_collapse_15 = 2131165300;
+			public const int ic_group_collapse_14 = 2131165300;
 			
 			// aapt resource value: 0x7F070075
-			public const int ic_group_expand_00 = 2131165301;
+			public const int ic_group_collapse_15 = 2131165301;
 			
 			// aapt resource value: 0x7F070076
-			public const int ic_group_expand_01 = 2131165302;
+			public const int ic_group_expand_00 = 2131165302;
 			
 			// aapt resource value: 0x7F070077
-			public const int ic_group_expand_02 = 2131165303;
+			public const int ic_group_expand_01 = 2131165303;
 			
 			// aapt resource value: 0x7F070078
-			public const int ic_group_expand_03 = 2131165304;
+			public const int ic_group_expand_02 = 2131165304;
 			
 			// aapt resource value: 0x7F070079
-			public const int ic_group_expand_04 = 2131165305;
+			public const int ic_group_expand_03 = 2131165305;
 			
 			// aapt resource value: 0x7F07007A
-			public const int ic_group_expand_05 = 2131165306;
+			public const int ic_group_expand_04 = 2131165306;
 			
 			// aapt resource value: 0x7F07007B
-			public const int ic_group_expand_06 = 2131165307;
+			public const int ic_group_expand_05 = 2131165307;
 			
 			// aapt resource value: 0x7F07007C
-			public const int ic_group_expand_07 = 2131165308;
+			public const int ic_group_expand_06 = 2131165308;
 			
 			// aapt resource value: 0x7F07007D
-			public const int ic_group_expand_08 = 2131165309;
+			public const int ic_group_expand_07 = 2131165309;
 			
 			// aapt resource value: 0x7F07007E
-			public const int ic_group_expand_09 = 2131165310;
+			public const int ic_group_expand_08 = 2131165310;
 			
 			// aapt resource value: 0x7F07007F
-			public const int ic_group_expand_10 = 2131165311;
+			public const int ic_group_expand_09 = 2131165311;
 			
 			// aapt resource value: 0x7F070080
-			public const int ic_group_expand_11 = 2131165312;
+			public const int ic_group_expand_10 = 2131165312;
 			
 			// aapt resource value: 0x7F070081
-			public const int ic_group_expand_12 = 2131165313;
+			public const int ic_group_expand_11 = 2131165313;
 			
 			// aapt resource value: 0x7F070082
-			public const int ic_group_expand_13 = 2131165314;
+			public const int ic_group_expand_12 = 2131165314;
 			
 			// aapt resource value: 0x7F070083
-			public const int ic_group_expand_14 = 2131165315;
+			public const int ic_group_expand_13 = 2131165315;
 			
 			// aapt resource value: 0x7F070084
-			public const int ic_group_expand_15 = 2131165316;
+			public const int ic_group_expand_14 = 2131165316;
 			
 			// aapt resource value: 0x7F070085
-			public const int ic_media_pause_dark = 2131165317;
+			public const int ic_group_expand_15 = 2131165317;
 			
 			// aapt resource value: 0x7F070086
-			public const int ic_media_pause_light = 2131165318;
+			public const int ic_media_pause_dark = 2131165318;
 			
 			// aapt resource value: 0x7F070087
-			public const int ic_media_play_dark = 2131165319;
+			public const int ic_media_pause_light = 2131165319;
 			
 			// aapt resource value: 0x7F070088
-			public const int ic_media_play_light = 2131165320;
+			public const int ic_media_play_dark = 2131165320;
 			
 			// aapt resource value: 0x7F070089
-			public const int ic_media_stop_dark = 2131165321;
+			public const int ic_media_play_light = 2131165321;
 			
 			// aapt resource value: 0x7F07008A
-			public const int ic_media_stop_light = 2131165322;
+			public const int ic_media_stop_dark = 2131165322;
 			
 			// aapt resource value: 0x7F07008B
-			public const int ic_mr_button_connected_00_dark = 2131165323;
+			public const int ic_media_stop_light = 2131165323;
 			
 			// aapt resource value: 0x7F07008C
-			public const int ic_mr_button_connected_00_light = 2131165324;
+			public const int ic_mr_button_connected_00_dark = 2131165324;
 			
 			// aapt resource value: 0x7F07008D
-			public const int ic_mr_button_connected_01_dark = 2131165325;
+			public const int ic_mr_button_connected_00_light = 2131165325;
 			
 			// aapt resource value: 0x7F07008E
-			public const int ic_mr_button_connected_01_light = 2131165326;
+			public const int ic_mr_button_connected_01_dark = 2131165326;
 			
 			// aapt resource value: 0x7F07008F
-			public const int ic_mr_button_connected_02_dark = 2131165327;
+			public const int ic_mr_button_connected_01_light = 2131165327;
 			
 			// aapt resource value: 0x7F070090
-			public const int ic_mr_button_connected_02_light = 2131165328;
+			public const int ic_mr_button_connected_02_dark = 2131165328;
 			
 			// aapt resource value: 0x7F070091
-			public const int ic_mr_button_connected_03_dark = 2131165329;
+			public const int ic_mr_button_connected_02_light = 2131165329;
 			
 			// aapt resource value: 0x7F070092
-			public const int ic_mr_button_connected_03_light = 2131165330;
+			public const int ic_mr_button_connected_03_dark = 2131165330;
 			
 			// aapt resource value: 0x7F070093
-			public const int ic_mr_button_connected_04_dark = 2131165331;
+			public const int ic_mr_button_connected_03_light = 2131165331;
 			
 			// aapt resource value: 0x7F070094
-			public const int ic_mr_button_connected_04_light = 2131165332;
+			public const int ic_mr_button_connected_04_dark = 2131165332;
 			
 			// aapt resource value: 0x7F070095
-			public const int ic_mr_button_connected_05_dark = 2131165333;
+			public const int ic_mr_button_connected_04_light = 2131165333;
 			
 			// aapt resource value: 0x7F070096
-			public const int ic_mr_button_connected_05_light = 2131165334;
+			public const int ic_mr_button_connected_05_dark = 2131165334;
 			
 			// aapt resource value: 0x7F070097
-			public const int ic_mr_button_connected_06_dark = 2131165335;
+			public const int ic_mr_button_connected_05_light = 2131165335;
 			
 			// aapt resource value: 0x7F070098
-			public const int ic_mr_button_connected_06_light = 2131165336;
+			public const int ic_mr_button_connected_06_dark = 2131165336;
 			
 			// aapt resource value: 0x7F070099
-			public const int ic_mr_button_connected_07_dark = 2131165337;
+			public const int ic_mr_button_connected_06_light = 2131165337;
 			
 			// aapt resource value: 0x7F07009A
-			public const int ic_mr_button_connected_07_light = 2131165338;
+			public const int ic_mr_button_connected_07_dark = 2131165338;
 			
 			// aapt resource value: 0x7F07009B
-			public const int ic_mr_button_connected_08_dark = 2131165339;
+			public const int ic_mr_button_connected_07_light = 2131165339;
 			
 			// aapt resource value: 0x7F07009C
-			public const int ic_mr_button_connected_08_light = 2131165340;
+			public const int ic_mr_button_connected_08_dark = 2131165340;
 			
 			// aapt resource value: 0x7F07009D
-			public const int ic_mr_button_connected_09_dark = 2131165341;
+			public const int ic_mr_button_connected_08_light = 2131165341;
 			
 			// aapt resource value: 0x7F07009E
-			public const int ic_mr_button_connected_09_light = 2131165342;
+			public const int ic_mr_button_connected_09_dark = 2131165342;
 			
 			// aapt resource value: 0x7F07009F
-			public const int ic_mr_button_connected_10_dark = 2131165343;
+			public const int ic_mr_button_connected_09_light = 2131165343;
 			
 			// aapt resource value: 0x7F0700A0
-			public const int ic_mr_button_connected_10_light = 2131165344;
+			public const int ic_mr_button_connected_10_dark = 2131165344;
 			
 			// aapt resource value: 0x7F0700A1
-			public const int ic_mr_button_connected_11_dark = 2131165345;
+			public const int ic_mr_button_connected_10_light = 2131165345;
 			
 			// aapt resource value: 0x7F0700A2
-			public const int ic_mr_button_connected_11_light = 2131165346;
+			public const int ic_mr_button_connected_11_dark = 2131165346;
 			
 			// aapt resource value: 0x7F0700A3
-			public const int ic_mr_button_connected_12_dark = 2131165347;
+			public const int ic_mr_button_connected_11_light = 2131165347;
 			
 			// aapt resource value: 0x7F0700A4
-			public const int ic_mr_button_connected_12_light = 2131165348;
+			public const int ic_mr_button_connected_12_dark = 2131165348;
 			
 			// aapt resource value: 0x7F0700A5
-			public const int ic_mr_button_connected_13_dark = 2131165349;
+			public const int ic_mr_button_connected_12_light = 2131165349;
 			
 			// aapt resource value: 0x7F0700A6
-			public const int ic_mr_button_connected_13_light = 2131165350;
+			public const int ic_mr_button_connected_13_dark = 2131165350;
 			
 			// aapt resource value: 0x7F0700A7
-			public const int ic_mr_button_connected_14_dark = 2131165351;
+			public const int ic_mr_button_connected_13_light = 2131165351;
 			
 			// aapt resource value: 0x7F0700A8
-			public const int ic_mr_button_connected_14_light = 2131165352;
+			public const int ic_mr_button_connected_14_dark = 2131165352;
 			
 			// aapt resource value: 0x7F0700A9
-			public const int ic_mr_button_connected_15_dark = 2131165353;
+			public const int ic_mr_button_connected_14_light = 2131165353;
 			
 			// aapt resource value: 0x7F0700AA
-			public const int ic_mr_button_connected_15_light = 2131165354;
+			public const int ic_mr_button_connected_15_dark = 2131165354;
 			
 			// aapt resource value: 0x7F0700AB
-			public const int ic_mr_button_connected_16_dark = 2131165355;
+			public const int ic_mr_button_connected_15_light = 2131165355;
 			
 			// aapt resource value: 0x7F0700AC
-			public const int ic_mr_button_connected_16_light = 2131165356;
+			public const int ic_mr_button_connected_16_dark = 2131165356;
 			
 			// aapt resource value: 0x7F0700AD
-			public const int ic_mr_button_connected_17_dark = 2131165357;
+			public const int ic_mr_button_connected_16_light = 2131165357;
 			
 			// aapt resource value: 0x7F0700AE
-			public const int ic_mr_button_connected_17_light = 2131165358;
+			public const int ic_mr_button_connected_17_dark = 2131165358;
 			
 			// aapt resource value: 0x7F0700AF
-			public const int ic_mr_button_connected_18_dark = 2131165359;
+			public const int ic_mr_button_connected_17_light = 2131165359;
 			
 			// aapt resource value: 0x7F0700B0
-			public const int ic_mr_button_connected_18_light = 2131165360;
+			public const int ic_mr_button_connected_18_dark = 2131165360;
 			
 			// aapt resource value: 0x7F0700B1
-			public const int ic_mr_button_connected_19_dark = 2131165361;
+			public const int ic_mr_button_connected_18_light = 2131165361;
 			
 			// aapt resource value: 0x7F0700B2
-			public const int ic_mr_button_connected_19_light = 2131165362;
+			public const int ic_mr_button_connected_19_dark = 2131165362;
 			
 			// aapt resource value: 0x7F0700B3
-			public const int ic_mr_button_connected_20_dark = 2131165363;
+			public const int ic_mr_button_connected_19_light = 2131165363;
 			
 			// aapt resource value: 0x7F0700B4
-			public const int ic_mr_button_connected_20_light = 2131165364;
+			public const int ic_mr_button_connected_20_dark = 2131165364;
 			
 			// aapt resource value: 0x7F0700B5
-			public const int ic_mr_button_connected_21_dark = 2131165365;
+			public const int ic_mr_button_connected_20_light = 2131165365;
 			
 			// aapt resource value: 0x7F0700B6
-			public const int ic_mr_button_connected_21_light = 2131165366;
+			public const int ic_mr_button_connected_21_dark = 2131165366;
 			
 			// aapt resource value: 0x7F0700B7
-			public const int ic_mr_button_connected_22_dark = 2131165367;
+			public const int ic_mr_button_connected_21_light = 2131165367;
 			
 			// aapt resource value: 0x7F0700B8
-			public const int ic_mr_button_connected_22_light = 2131165368;
+			public const int ic_mr_button_connected_22_dark = 2131165368;
 			
 			// aapt resource value: 0x7F0700B9
-			public const int ic_mr_button_connected_23_dark = 2131165369;
+			public const int ic_mr_button_connected_22_light = 2131165369;
 			
 			// aapt resource value: 0x7F0700BA
-			public const int ic_mr_button_connected_23_light = 2131165370;
+			public const int ic_mr_button_connected_23_dark = 2131165370;
 			
 			// aapt resource value: 0x7F0700BB
-			public const int ic_mr_button_connected_24_dark = 2131165371;
+			public const int ic_mr_button_connected_23_light = 2131165371;
 			
 			// aapt resource value: 0x7F0700BC
-			public const int ic_mr_button_connected_24_light = 2131165372;
+			public const int ic_mr_button_connected_24_dark = 2131165372;
 			
 			// aapt resource value: 0x7F0700BD
-			public const int ic_mr_button_connected_25_dark = 2131165373;
+			public const int ic_mr_button_connected_24_light = 2131165373;
 			
 			// aapt resource value: 0x7F0700BE
-			public const int ic_mr_button_connected_25_light = 2131165374;
+			public const int ic_mr_button_connected_25_dark = 2131165374;
 			
 			// aapt resource value: 0x7F0700BF
-			public const int ic_mr_button_connected_26_dark = 2131165375;
+			public const int ic_mr_button_connected_25_light = 2131165375;
 			
 			// aapt resource value: 0x7F0700C0
-			public const int ic_mr_button_connected_26_light = 2131165376;
+			public const int ic_mr_button_connected_26_dark = 2131165376;
 			
 			// aapt resource value: 0x7F0700C1
-			public const int ic_mr_button_connected_27_dark = 2131165377;
+			public const int ic_mr_button_connected_26_light = 2131165377;
 			
 			// aapt resource value: 0x7F0700C2
-			public const int ic_mr_button_connected_27_light = 2131165378;
+			public const int ic_mr_button_connected_27_dark = 2131165378;
 			
 			// aapt resource value: 0x7F0700C3
-			public const int ic_mr_button_connected_28_dark = 2131165379;
+			public const int ic_mr_button_connected_27_light = 2131165379;
 			
 			// aapt resource value: 0x7F0700C4
-			public const int ic_mr_button_connected_28_light = 2131165380;
+			public const int ic_mr_button_connected_28_dark = 2131165380;
 			
 			// aapt resource value: 0x7F0700C5
-			public const int ic_mr_button_connected_29_dark = 2131165381;
+			public const int ic_mr_button_connected_28_light = 2131165381;
 			
 			// aapt resource value: 0x7F0700C6
-			public const int ic_mr_button_connected_29_light = 2131165382;
+			public const int ic_mr_button_connected_29_dark = 2131165382;
 			
 			// aapt resource value: 0x7F0700C7
-			public const int ic_mr_button_connected_30_dark = 2131165383;
+			public const int ic_mr_button_connected_29_light = 2131165383;
 			
 			// aapt resource value: 0x7F0700C8
-			public const int ic_mr_button_connected_30_light = 2131165384;
+			public const int ic_mr_button_connected_30_dark = 2131165384;
 			
 			// aapt resource value: 0x7F0700C9
-			public const int ic_mr_button_connecting_00_dark = 2131165385;
+			public const int ic_mr_button_connected_30_light = 2131165385;
 			
 			// aapt resource value: 0x7F0700CA
-			public const int ic_mr_button_connecting_00_light = 2131165386;
+			public const int ic_mr_button_connecting_00_dark = 2131165386;
 			
 			// aapt resource value: 0x7F0700CB
-			public const int ic_mr_button_connecting_01_dark = 2131165387;
+			public const int ic_mr_button_connecting_00_light = 2131165387;
 			
 			// aapt resource value: 0x7F0700CC
-			public const int ic_mr_button_connecting_01_light = 2131165388;
+			public const int ic_mr_button_connecting_01_dark = 2131165388;
 			
 			// aapt resource value: 0x7F0700CD
-			public const int ic_mr_button_connecting_02_dark = 2131165389;
+			public const int ic_mr_button_connecting_01_light = 2131165389;
 			
 			// aapt resource value: 0x7F0700CE
-			public const int ic_mr_button_connecting_02_light = 2131165390;
+			public const int ic_mr_button_connecting_02_dark = 2131165390;
 			
 			// aapt resource value: 0x7F0700CF
-			public const int ic_mr_button_connecting_03_dark = 2131165391;
+			public const int ic_mr_button_connecting_02_light = 2131165391;
 			
 			// aapt resource value: 0x7F0700D0
-			public const int ic_mr_button_connecting_03_light = 2131165392;
+			public const int ic_mr_button_connecting_03_dark = 2131165392;
 			
 			// aapt resource value: 0x7F0700D1
-			public const int ic_mr_button_connecting_04_dark = 2131165393;
+			public const int ic_mr_button_connecting_03_light = 2131165393;
 			
 			// aapt resource value: 0x7F0700D2
-			public const int ic_mr_button_connecting_04_light = 2131165394;
+			public const int ic_mr_button_connecting_04_dark = 2131165394;
 			
 			// aapt resource value: 0x7F0700D3
-			public const int ic_mr_button_connecting_05_dark = 2131165395;
+			public const int ic_mr_button_connecting_04_light = 2131165395;
 			
 			// aapt resource value: 0x7F0700D4
-			public const int ic_mr_button_connecting_05_light = 2131165396;
+			public const int ic_mr_button_connecting_05_dark = 2131165396;
 			
 			// aapt resource value: 0x7F0700D5
-			public const int ic_mr_button_connecting_06_dark = 2131165397;
+			public const int ic_mr_button_connecting_05_light = 2131165397;
 			
 			// aapt resource value: 0x7F0700D6
-			public const int ic_mr_button_connecting_06_light = 2131165398;
+			public const int ic_mr_button_connecting_06_dark = 2131165398;
 			
 			// aapt resource value: 0x7F0700D7
-			public const int ic_mr_button_connecting_07_dark = 2131165399;
+			public const int ic_mr_button_connecting_06_light = 2131165399;
 			
 			// aapt resource value: 0x7F0700D8
-			public const int ic_mr_button_connecting_07_light = 2131165400;
+			public const int ic_mr_button_connecting_07_dark = 2131165400;
 			
 			// aapt resource value: 0x7F0700D9
-			public const int ic_mr_button_connecting_08_dark = 2131165401;
+			public const int ic_mr_button_connecting_07_light = 2131165401;
 			
 			// aapt resource value: 0x7F0700DA
-			public const int ic_mr_button_connecting_08_light = 2131165402;
+			public const int ic_mr_button_connecting_08_dark = 2131165402;
 			
 			// aapt resource value: 0x7F0700DB
-			public const int ic_mr_button_connecting_09_dark = 2131165403;
+			public const int ic_mr_button_connecting_08_light = 2131165403;
 			
 			// aapt resource value: 0x7F0700DC
-			public const int ic_mr_button_connecting_09_light = 2131165404;
+			public const int ic_mr_button_connecting_09_dark = 2131165404;
 			
 			// aapt resource value: 0x7F0700DD
-			public const int ic_mr_button_connecting_10_dark = 2131165405;
+			public const int ic_mr_button_connecting_09_light = 2131165405;
 			
 			// aapt resource value: 0x7F0700DE
-			public const int ic_mr_button_connecting_10_light = 2131165406;
+			public const int ic_mr_button_connecting_10_dark = 2131165406;
 			
 			// aapt resource value: 0x7F0700DF
-			public const int ic_mr_button_connecting_11_dark = 2131165407;
+			public const int ic_mr_button_connecting_10_light = 2131165407;
 			
 			// aapt resource value: 0x7F0700E0
-			public const int ic_mr_button_connecting_11_light = 2131165408;
+			public const int ic_mr_button_connecting_11_dark = 2131165408;
 			
 			// aapt resource value: 0x7F0700E1
-			public const int ic_mr_button_connecting_12_dark = 2131165409;
+			public const int ic_mr_button_connecting_11_light = 2131165409;
 			
 			// aapt resource value: 0x7F0700E2
-			public const int ic_mr_button_connecting_12_light = 2131165410;
+			public const int ic_mr_button_connecting_12_dark = 2131165410;
 			
 			// aapt resource value: 0x7F0700E3
-			public const int ic_mr_button_connecting_13_dark = 2131165411;
+			public const int ic_mr_button_connecting_12_light = 2131165411;
 			
 			// aapt resource value: 0x7F0700E4
-			public const int ic_mr_button_connecting_13_light = 2131165412;
+			public const int ic_mr_button_connecting_13_dark = 2131165412;
 			
 			// aapt resource value: 0x7F0700E5
-			public const int ic_mr_button_connecting_14_dark = 2131165413;
+			public const int ic_mr_button_connecting_13_light = 2131165413;
 			
 			// aapt resource value: 0x7F0700E6
-			public const int ic_mr_button_connecting_14_light = 2131165414;
+			public const int ic_mr_button_connecting_14_dark = 2131165414;
 			
 			// aapt resource value: 0x7F0700E7
-			public const int ic_mr_button_connecting_15_dark = 2131165415;
+			public const int ic_mr_button_connecting_14_light = 2131165415;
 			
 			// aapt resource value: 0x7F0700E8
-			public const int ic_mr_button_connecting_15_light = 2131165416;
+			public const int ic_mr_button_connecting_15_dark = 2131165416;
 			
 			// aapt resource value: 0x7F0700E9
-			public const int ic_mr_button_connecting_16_dark = 2131165417;
+			public const int ic_mr_button_connecting_15_light = 2131165417;
 			
 			// aapt resource value: 0x7F0700EA
-			public const int ic_mr_button_connecting_16_light = 2131165418;
+			public const int ic_mr_button_connecting_16_dark = 2131165418;
 			
 			// aapt resource value: 0x7F0700EB
-			public const int ic_mr_button_connecting_17_dark = 2131165419;
+			public const int ic_mr_button_connecting_16_light = 2131165419;
 			
 			// aapt resource value: 0x7F0700EC
-			public const int ic_mr_button_connecting_17_light = 2131165420;
+			public const int ic_mr_button_connecting_17_dark = 2131165420;
 			
 			// aapt resource value: 0x7F0700ED
-			public const int ic_mr_button_connecting_18_dark = 2131165421;
+			public const int ic_mr_button_connecting_17_light = 2131165421;
 			
 			// aapt resource value: 0x7F0700EE
-			public const int ic_mr_button_connecting_18_light = 2131165422;
+			public const int ic_mr_button_connecting_18_dark = 2131165422;
 			
 			// aapt resource value: 0x7F0700EF
-			public const int ic_mr_button_connecting_19_dark = 2131165423;
+			public const int ic_mr_button_connecting_18_light = 2131165423;
 			
 			// aapt resource value: 0x7F0700F0
-			public const int ic_mr_button_connecting_19_light = 2131165424;
+			public const int ic_mr_button_connecting_19_dark = 2131165424;
 			
 			// aapt resource value: 0x7F0700F1
-			public const int ic_mr_button_connecting_20_dark = 2131165425;
+			public const int ic_mr_button_connecting_19_light = 2131165425;
 			
 			// aapt resource value: 0x7F0700F2
-			public const int ic_mr_button_connecting_20_light = 2131165426;
+			public const int ic_mr_button_connecting_20_dark = 2131165426;
 			
 			// aapt resource value: 0x7F0700F3
-			public const int ic_mr_button_connecting_21_dark = 2131165427;
+			public const int ic_mr_button_connecting_20_light = 2131165427;
 			
 			// aapt resource value: 0x7F0700F4
-			public const int ic_mr_button_connecting_21_light = 2131165428;
+			public const int ic_mr_button_connecting_21_dark = 2131165428;
 			
 			// aapt resource value: 0x7F0700F5
-			public const int ic_mr_button_connecting_22_dark = 2131165429;
+			public const int ic_mr_button_connecting_21_light = 2131165429;
 			
 			// aapt resource value: 0x7F0700F6
-			public const int ic_mr_button_connecting_22_light = 2131165430;
+			public const int ic_mr_button_connecting_22_dark = 2131165430;
 			
 			// aapt resource value: 0x7F0700F7
-			public const int ic_mr_button_connecting_23_dark = 2131165431;
+			public const int ic_mr_button_connecting_22_light = 2131165431;
 			
 			// aapt resource value: 0x7F0700F8
-			public const int ic_mr_button_connecting_23_light = 2131165432;
+			public const int ic_mr_button_connecting_23_dark = 2131165432;
 			
 			// aapt resource value: 0x7F0700F9
-			public const int ic_mr_button_connecting_24_dark = 2131165433;
+			public const int ic_mr_button_connecting_23_light = 2131165433;
 			
 			// aapt resource value: 0x7F0700FA
-			public const int ic_mr_button_connecting_24_light = 2131165434;
+			public const int ic_mr_button_connecting_24_dark = 2131165434;
 			
 			// aapt resource value: 0x7F0700FB
-			public const int ic_mr_button_connecting_25_dark = 2131165435;
+			public const int ic_mr_button_connecting_24_light = 2131165435;
 			
 			// aapt resource value: 0x7F0700FC
-			public const int ic_mr_button_connecting_25_light = 2131165436;
+			public const int ic_mr_button_connecting_25_dark = 2131165436;
 			
 			// aapt resource value: 0x7F0700FD
-			public const int ic_mr_button_connecting_26_dark = 2131165437;
+			public const int ic_mr_button_connecting_25_light = 2131165437;
 			
 			// aapt resource value: 0x7F0700FE
-			public const int ic_mr_button_connecting_26_light = 2131165438;
+			public const int ic_mr_button_connecting_26_dark = 2131165438;
 			
 			// aapt resource value: 0x7F0700FF
-			public const int ic_mr_button_connecting_27_dark = 2131165439;
+			public const int ic_mr_button_connecting_26_light = 2131165439;
 			
 			// aapt resource value: 0x7F070100
-			public const int ic_mr_button_connecting_27_light = 2131165440;
+			public const int ic_mr_button_connecting_27_dark = 2131165440;
 			
 			// aapt resource value: 0x7F070101
-			public const int ic_mr_button_connecting_28_dark = 2131165441;
+			public const int ic_mr_button_connecting_27_light = 2131165441;
 			
 			// aapt resource value: 0x7F070102
-			public const int ic_mr_button_connecting_28_light = 2131165442;
+			public const int ic_mr_button_connecting_28_dark = 2131165442;
 			
 			// aapt resource value: 0x7F070103
-			public const int ic_mr_button_connecting_29_dark = 2131165443;
+			public const int ic_mr_button_connecting_28_light = 2131165443;
 			
 			// aapt resource value: 0x7F070104
-			public const int ic_mr_button_connecting_29_light = 2131165444;
+			public const int ic_mr_button_connecting_29_dark = 2131165444;
 			
 			// aapt resource value: 0x7F070105
-			public const int ic_mr_button_connecting_30_dark = 2131165445;
+			public const int ic_mr_button_connecting_29_light = 2131165445;
 			
 			// aapt resource value: 0x7F070106
-			public const int ic_mr_button_connecting_30_light = 2131165446;
+			public const int ic_mr_button_connecting_30_dark = 2131165446;
 			
 			// aapt resource value: 0x7F070107
-			public const int ic_mr_button_disabled_dark = 2131165447;
+			public const int ic_mr_button_connecting_30_light = 2131165447;
 			
 			// aapt resource value: 0x7F070108
-			public const int ic_mr_button_disabled_light = 2131165448;
+			public const int ic_mr_button_disabled_dark = 2131165448;
 			
 			// aapt resource value: 0x7F070109
-			public const int ic_mr_button_disconnected_dark = 2131165449;
+			public const int ic_mr_button_disabled_light = 2131165449;
 			
 			// aapt resource value: 0x7F07010A
-			public const int ic_mr_button_disconnected_light = 2131165450;
+			public const int ic_mr_button_disconnected_dark = 2131165450;
 			
 			// aapt resource value: 0x7F07010B
-			public const int ic_mr_button_grey = 2131165451;
+			public const int ic_mr_button_disconnected_light = 2131165451;
 			
 			// aapt resource value: 0x7F07010C
-			public const int ic_vol_type_speaker_dark = 2131165452;
+			public const int ic_mr_button_grey = 2131165452;
 			
 			// aapt resource value: 0x7F07010D
-			public const int ic_vol_type_speaker_group_dark = 2131165453;
+			public const int ic_mtrl_chip_checked_black = 2131165453;
 			
 			// aapt resource value: 0x7F07010E
-			public const int ic_vol_type_speaker_group_light = 2131165454;
+			public const int ic_mtrl_chip_checked_circle = 2131165454;
 			
 			// aapt resource value: 0x7F07010F
-			public const int ic_vol_type_speaker_light = 2131165455;
+			public const int ic_mtrl_chip_close_circle = 2131165455;
 			
 			// aapt resource value: 0x7F070110
-			public const int ic_vol_type_tv_dark = 2131165456;
+			public const int ic_vol_type_speaker_dark = 2131165456;
 			
 			// aapt resource value: 0x7F070111
-			public const int ic_vol_type_tv_light = 2131165457;
+			public const int ic_vol_type_speaker_group_dark = 2131165457;
 			
 			// aapt resource value: 0x7F070112
-			public const int mr_button_connected_dark = 2131165458;
+			public const int ic_vol_type_speaker_group_light = 2131165458;
 			
 			// aapt resource value: 0x7F070113
-			public const int mr_button_connected_light = 2131165459;
+			public const int ic_vol_type_speaker_light = 2131165459;
 			
 			// aapt resource value: 0x7F070114
-			public const int mr_button_connecting_dark = 2131165460;
+			public const int ic_vol_type_tv_dark = 2131165460;
 			
 			// aapt resource value: 0x7F070115
-			public const int mr_button_connecting_light = 2131165461;
+			public const int ic_vol_type_tv_light = 2131165461;
 			
 			// aapt resource value: 0x7F070116
-			public const int mr_button_dark = 2131165462;
+			public const int mr_button_connected_dark = 2131165462;
 			
 			// aapt resource value: 0x7F070117
-			public const int mr_button_light = 2131165463;
+			public const int mr_button_connected_light = 2131165463;
 			
 			// aapt resource value: 0x7F070118
-			public const int mr_dialog_close_dark = 2131165464;
+			public const int mr_button_connecting_dark = 2131165464;
 			
 			// aapt resource value: 0x7F070119
-			public const int mr_dialog_close_light = 2131165465;
+			public const int mr_button_connecting_light = 2131165465;
 			
 			// aapt resource value: 0x7F07011A
-			public const int mr_dialog_material_background_dark = 2131165466;
+			public const int mr_button_dark = 2131165466;
 			
 			// aapt resource value: 0x7F07011B
-			public const int mr_dialog_material_background_light = 2131165467;
+			public const int mr_button_light = 2131165467;
 			
 			// aapt resource value: 0x7F07011C
-			public const int mr_group_collapse = 2131165468;
+			public const int mr_dialog_close_dark = 2131165468;
 			
 			// aapt resource value: 0x7F07011D
-			public const int mr_group_expand = 2131165469;
+			public const int mr_dialog_close_light = 2131165469;
 			
 			// aapt resource value: 0x7F07011E
-			public const int mr_media_pause_dark = 2131165470;
+			public const int mr_dialog_material_background_dark = 2131165470;
 			
 			// aapt resource value: 0x7F07011F
-			public const int mr_media_pause_light = 2131165471;
+			public const int mr_dialog_material_background_light = 2131165471;
 			
 			// aapt resource value: 0x7F070120
-			public const int mr_media_play_dark = 2131165472;
+			public const int mr_group_collapse = 2131165472;
 			
 			// aapt resource value: 0x7F070121
-			public const int mr_media_play_light = 2131165473;
+			public const int mr_group_expand = 2131165473;
 			
 			// aapt resource value: 0x7F070122
-			public const int mr_media_stop_dark = 2131165474;
+			public const int mr_media_pause_dark = 2131165474;
 			
 			// aapt resource value: 0x7F070123
-			public const int mr_media_stop_light = 2131165475;
+			public const int mr_media_pause_light = 2131165475;
 			
 			// aapt resource value: 0x7F070124
-			public const int mr_vol_type_audiotrack_dark = 2131165476;
+			public const int mr_media_play_dark = 2131165476;
 			
 			// aapt resource value: 0x7F070125
-			public const int mr_vol_type_audiotrack_light = 2131165477;
+			public const int mr_media_play_light = 2131165477;
 			
 			// aapt resource value: 0x7F070126
-			public const int navigation_empty_icon = 2131165478;
+			public const int mr_media_stop_dark = 2131165478;
 			
 			// aapt resource value: 0x7F070127
-			public const int notification_action_background = 2131165479;
+			public const int mr_media_stop_light = 2131165479;
 			
 			// aapt resource value: 0x7F070128
-			public const int notification_bg = 2131165480;
+			public const int mr_vol_type_audiotrack_dark = 2131165480;
 			
 			// aapt resource value: 0x7F070129
-			public const int notification_bg_low = 2131165481;
+			public const int mr_vol_type_audiotrack_light = 2131165481;
 			
 			// aapt resource value: 0x7F07012A
-			public const int notification_bg_low_normal = 2131165482;
+			public const int mtrl_snackbar_background = 2131165482;
 			
 			// aapt resource value: 0x7F07012B
-			public const int notification_bg_low_pressed = 2131165483;
+			public const int mtrl_tabs_default_indicator = 2131165483;
 			
 			// aapt resource value: 0x7F07012C
-			public const int notification_bg_normal = 2131165484;
+			public const int navigation_empty_icon = 2131165484;
 			
 			// aapt resource value: 0x7F07012D
-			public const int notification_bg_normal_pressed = 2131165485;
+			public const int notification_action_background = 2131165485;
 			
 			// aapt resource value: 0x7F07012E
-			public const int notification_icon_background = 2131165486;
+			public const int notification_bg = 2131165486;
 			
 			// aapt resource value: 0x7F07012F
-			public const int notification_template_icon_bg = 2131165487;
+			public const int notification_bg_low = 2131165487;
 			
 			// aapt resource value: 0x7F070130
-			public const int notification_template_icon_low_bg = 2131165488;
+			public const int notification_bg_low_normal = 2131165488;
 			
 			// aapt resource value: 0x7F070131
-			public const int notification_tile_bg = 2131165489;
+			public const int notification_bg_low_pressed = 2131165489;
 			
 			// aapt resource value: 0x7F070132
-			public const int notify_panel_notification_icon_bg = 2131165490;
+			public const int notification_bg_normal = 2131165490;
 			
 			// aapt resource value: 0x7F070133
-			public const int tooltip_frame_dark = 2131165491;
+			public const int notification_bg_normal_pressed = 2131165491;
 			
 			// aapt resource value: 0x7F070134
-			public const int tooltip_frame_light = 2131165492;
+			public const int notification_icon_background = 2131165492;
+			
+			// aapt resource value: 0x7F070135
+			public const int notification_template_icon_bg = 2131165493;
+			
+			// aapt resource value: 0x7F070136
+			public const int notification_template_icon_low_bg = 2131165494;
+			
+			// aapt resource value: 0x7F070137
+			public const int notification_tile_bg = 2131165495;
+			
+			// aapt resource value: 0x7F070138
+			public const int notify_panel_notification_icon_bg = 2131165496;
+			
+			// aapt resource value: 0x7F070139
+			public const int tooltip_frame_dark = 2131165497;
+			
+			// aapt resource value: 0x7F07013A
+			public const int tooltip_frame_light = 2131165498;
 			
 			static Drawable()
 			{
@@ -5106,547 +6372,670 @@ namespace NFCSample.Droid
 			public const int bottomtab_tabbar = 2131230756;
 			
 			// aapt resource value: 0x7F080025
-			public const int buttonPanel = 2131230757;
-			
-			// aapt resource value: 0x7F080026
-			public const int cancel_action = 2131230758;
-			
-			// aapt resource value: 0x7F080027
-			public const int center = 2131230759;
+			public const int browser_actions_header_text = 2131230757;
 			
 			// aapt resource value: 0x7F080028
-			public const int center_horizontal = 2131230760;
+			public const int browser_actions_menu_items = 2131230760;
+			
+			// aapt resource value: 0x7F080026
+			public const int browser_actions_menu_item_icon = 2131230758;
+			
+			// aapt resource value: 0x7F080027
+			public const int browser_actions_menu_item_text = 2131230759;
 			
 			// aapt resource value: 0x7F080029
-			public const int center_vertical = 2131230761;
+			public const int browser_actions_menu_view = 2131230761;
 			
 			// aapt resource value: 0x7F08002A
-			public const int checkbox = 2131230762;
+			public const int buttonPanel = 2131230762;
 			
 			// aapt resource value: 0x7F08002B
-			public const int chronometer = 2131230763;
+			public const int cancel_action = 2131230763;
 			
 			// aapt resource value: 0x7F08002C
-			public const int clip_horizontal = 2131230764;
+			public const int center = 2131230764;
 			
 			// aapt resource value: 0x7F08002D
-			public const int clip_vertical = 2131230765;
+			public const int center_horizontal = 2131230765;
 			
 			// aapt resource value: 0x7F08002E
-			public const int collapseActionView = 2131230766;
+			public const int center_vertical = 2131230766;
 			
 			// aapt resource value: 0x7F08002F
-			public const int container = 2131230767;
+			public const int checkbox = 2131230767;
 			
 			// aapt resource value: 0x7F080030
-			public const int contentPanel = 2131230768;
+			public const int chronometer = 2131230768;
 			
 			// aapt resource value: 0x7F080031
-			public const int coordinator = 2131230769;
+			public const int clip_horizontal = 2131230769;
+			
+			// aapt resource value: 0x7F080032
+			public const int clip_vertical = 2131230770;
+			
+			// aapt resource value: 0x7F080033
+			public const int collapseActionView = 2131230771;
+			
+			// aapt resource value: 0x7F080034
+			public const int container = 2131230772;
+			
+			// aapt resource value: 0x7F080035
+			public const int content = 2131230773;
+			
+			// aapt resource value: 0x7F080036
+			public const int contentPanel = 2131230774;
+			
+			// aapt resource value: 0x7F080037
+			public const int coordinator = 2131230775;
 			
 			// aapt resource value: 0x7F080001
 			public const int CTRL = 2131230721;
 			
-			// aapt resource value: 0x7F080032
-			public const int custom = 2131230770;
-			
-			// aapt resource value: 0x7F080033
-			public const int customPanel = 2131230771;
-			
-			// aapt resource value: 0x7F080034
-			public const int decor_content_parent = 2131230772;
-			
-			// aapt resource value: 0x7F080035
-			public const int default_activity_button = 2131230773;
-			
-			// aapt resource value: 0x7F080036
-			public const int design_bottom_sheet = 2131230774;
-			
-			// aapt resource value: 0x7F080037
-			public const int design_menu_item_action_area = 2131230775;
-			
 			// aapt resource value: 0x7F080038
-			public const int design_menu_item_action_area_stub = 2131230776;
+			public const int custom = 2131230776;
 			
 			// aapt resource value: 0x7F080039
-			public const int design_menu_item_text = 2131230777;
+			public const int customPanel = 2131230777;
 			
 			// aapt resource value: 0x7F08003A
-			public const int design_navigation_view = 2131230778;
+			public const int decor_content_parent = 2131230778;
 			
 			// aapt resource value: 0x7F08003B
-			public const int disableHome = 2131230779;
+			public const int default_activity_button = 2131230779;
 			
 			// aapt resource value: 0x7F08003C
-			public const int edit_query = 2131230780;
+			public const int design_bottom_sheet = 2131230780;
 			
 			// aapt resource value: 0x7F08003D
-			public const int end = 2131230781;
+			public const int design_menu_item_action_area = 2131230781;
 			
 			// aapt resource value: 0x7F08003E
-			public const int end_padder = 2131230782;
+			public const int design_menu_item_action_area_stub = 2131230782;
 			
 			// aapt resource value: 0x7F08003F
-			public const int enterAlways = 2131230783;
+			public const int design_menu_item_text = 2131230783;
 			
 			// aapt resource value: 0x7F080040
-			public const int enterAlwaysCollapsed = 2131230784;
+			public const int design_navigation_view = 2131230784;
 			
 			// aapt resource value: 0x7F080041
-			public const int exitUntilCollapsed = 2131230785;
-			
-			// aapt resource value: 0x7F080043
-			public const int expanded_menu = 2131230787;
+			public const int disableHome = 2131230785;
 			
 			// aapt resource value: 0x7F080042
-			public const int expand_activities_button = 2131230786;
+			public const int edit_query = 2131230786;
+			
+			// aapt resource value: 0x7F080043
+			public const int end = 2131230787;
 			
 			// aapt resource value: 0x7F080044
-			public const int fill = 2131230788;
+			public const int end_padder = 2131230788;
 			
 			// aapt resource value: 0x7F080045
-			public const int fill_horizontal = 2131230789;
+			public const int enterAlways = 2131230789;
 			
 			// aapt resource value: 0x7F080046
-			public const int fill_vertical = 2131230790;
+			public const int enterAlwaysCollapsed = 2131230790;
 			
 			// aapt resource value: 0x7F080047
-			public const int @fixed = 2131230791;
-			
-			// aapt resource value: 0x7F080048
-			public const int flyoutcontent_appbar = 2131230792;
+			public const int exitUntilCollapsed = 2131230791;
 			
 			// aapt resource value: 0x7F080049
-			public const int flyoutcontent_recycler = 2131230793;
+			public const int expanded_menu = 2131230793;
+			
+			// aapt resource value: 0x7F080048
+			public const int expand_activities_button = 2131230792;
 			
 			// aapt resource value: 0x7F08004A
-			public const int forever = 2131230794;
+			public const int fill = 2131230794;
+			
+			// aapt resource value: 0x7F08004D
+			public const int filled = 2131230797;
+			
+			// aapt resource value: 0x7F08004B
+			public const int fill_horizontal = 2131230795;
+			
+			// aapt resource value: 0x7F08004C
+			public const int fill_vertical = 2131230796;
+			
+			// aapt resource value: 0x7F08004E
+			public const int @fixed = 2131230798;
+			
+			// aapt resource value: 0x7F08004F
+			public const int flyoutcontent_appbar = 2131230799;
+			
+			// aapt resource value: 0x7F080050
+			public const int flyoutcontent_recycler = 2131230800;
+			
+			// aapt resource value: 0x7F080051
+			public const int forever = 2131230801;
 			
 			// aapt resource value: 0x7F080002
 			public const int FUNCTION = 2131230722;
 			
-			// aapt resource value: 0x7F08004B
-			public const int ghost_view = 2131230795;
-			
-			// aapt resource value: 0x7F08004C
-			public const int home = 2131230796;
-			
-			// aapt resource value: 0x7F08004D
-			public const int homeAsUp = 2131230797;
-			
-			// aapt resource value: 0x7F08004E
-			public const int icon = 2131230798;
-			
-			// aapt resource value: 0x7F08004F
-			public const int icon_group = 2131230799;
-			
-			// aapt resource value: 0x7F080050
-			public const int ifRoom = 2131230800;
-			
-			// aapt resource value: 0x7F080051
-			public const int image = 2131230801;
-			
 			// aapt resource value: 0x7F080052
-			public const int info = 2131230802;
+			public const int ghost_view = 2131230802;
 			
 			// aapt resource value: 0x7F080053
-			public const int italic = 2131230803;
+			public const int group_divider = 2131230803;
 			
 			// aapt resource value: 0x7F080054
-			public const int item_touch_helper_previous_elevation = 2131230804;
+			public const int home = 2131230804;
 			
 			// aapt resource value: 0x7F080055
-			public const int largeLabel = 2131230805;
+			public const int homeAsUp = 2131230805;
 			
 			// aapt resource value: 0x7F080056
-			public const int left = 2131230806;
+			public const int icon = 2131230806;
 			
 			// aapt resource value: 0x7F080057
-			public const int line1 = 2131230807;
+			public const int icon_group = 2131230807;
 			
 			// aapt resource value: 0x7F080058
-			public const int line3 = 2131230808;
+			public const int ifRoom = 2131230808;
 			
 			// aapt resource value: 0x7F080059
-			public const int listMode = 2131230809;
+			public const int image = 2131230809;
 			
 			// aapt resource value: 0x7F08005A
-			public const int list_item = 2131230810;
+			public const int info = 2131230810;
 			
 			// aapt resource value: 0x7F08005B
-			public const int main_appbar = 2131230811;
+			public const int italic = 2131230811;
 			
 			// aapt resource value: 0x7F08005C
-			public const int main_tablayout = 2131230812;
+			public const int item_touch_helper_previous_elevation = 2131230812;
 			
 			// aapt resource value: 0x7F08005D
-			public const int main_toolbar = 2131230813;
+			public const int labeled = 2131230813;
 			
 			// aapt resource value: 0x7F08005E
-			public const int main_viewpager = 2131230814;
+			public const int largeLabel = 2131230814;
 			
 			// aapt resource value: 0x7F08005F
-			public const int masked = 2131230815;
+			public const int left = 2131230815;
 			
 			// aapt resource value: 0x7F080060
-			public const int media_actions = 2131230816;
+			public const int line1 = 2131230816;
 			
 			// aapt resource value: 0x7F080061
-			public const int message = 2131230817;
+			public const int line3 = 2131230817;
+			
+			// aapt resource value: 0x7F080062
+			public const int listMode = 2131230818;
+			
+			// aapt resource value: 0x7F080063
+			public const int list_item = 2131230819;
+			
+			// aapt resource value: 0x7F080064
+			public const int main_appbar = 2131230820;
+			
+			// aapt resource value: 0x7F080065
+			public const int main_tablayout = 2131230821;
+			
+			// aapt resource value: 0x7F080066
+			public const int main_toolbar = 2131230822;
+			
+			// aapt resource value: 0x7F080067
+			public const int main_viewpager = 2131230823;
+			
+			// aapt resource value: 0x7F080068
+			public const int masked = 2131230824;
+			
+			// aapt resource value: 0x7F080069
+			public const int media_actions = 2131230825;
+			
+			// aapt resource value: 0x7F08006A
+			public const int message = 2131230826;
 			
 			// aapt resource value: 0x7F080003
 			public const int META = 2131230723;
 			
-			// aapt resource value: 0x7F080062
-			public const int middle = 2131230818;
-			
-			// aapt resource value: 0x7F080063
-			public const int mini = 2131230819;
-			
-			// aapt resource value: 0x7F080064
-			public const int mr_art = 2131230820;
-			
-			// aapt resource value: 0x7F080065
-			public const int mr_chooser_list = 2131230821;
-			
-			// aapt resource value: 0x7F080066
-			public const int mr_chooser_route_desc = 2131230822;
-			
-			// aapt resource value: 0x7F080067
-			public const int mr_chooser_route_icon = 2131230823;
-			
-			// aapt resource value: 0x7F080068
-			public const int mr_chooser_route_name = 2131230824;
-			
-			// aapt resource value: 0x7F080069
-			public const int mr_chooser_title = 2131230825;
-			
-			// aapt resource value: 0x7F08006A
-			public const int mr_close = 2131230826;
-			
 			// aapt resource value: 0x7F08006B
-			public const int mr_control_divider = 2131230827;
+			public const int middle = 2131230827;
 			
 			// aapt resource value: 0x7F08006C
-			public const int mr_control_playback_ctrl = 2131230828;
+			public const int mini = 2131230828;
 			
 			// aapt resource value: 0x7F08006D
-			public const int mr_control_subtitle = 2131230829;
+			public const int mr_art = 2131230829;
 			
 			// aapt resource value: 0x7F08006E
-			public const int mr_control_title = 2131230830;
+			public const int mr_cast_checkbox = 2131230830;
 			
 			// aapt resource value: 0x7F08006F
-			public const int mr_control_title_container = 2131230831;
+			public const int mr_cast_close_button = 2131230831;
 			
 			// aapt resource value: 0x7F080070
-			public const int mr_custom_control = 2131230832;
+			public const int mr_cast_group_icon = 2131230832;
 			
 			// aapt resource value: 0x7F080071
-			public const int mr_default_control = 2131230833;
+			public const int mr_cast_group_name = 2131230833;
 			
 			// aapt resource value: 0x7F080072
-			public const int mr_dialog_area = 2131230834;
+			public const int mr_cast_list = 2131230834;
 			
 			// aapt resource value: 0x7F080073
-			public const int mr_expandable_area = 2131230835;
+			public const int mr_cast_meta = 2131230835;
 			
 			// aapt resource value: 0x7F080074
-			public const int mr_group_expand_collapse = 2131230836;
+			public const int mr_cast_meta_art = 2131230836;
 			
 			// aapt resource value: 0x7F080075
-			public const int mr_media_main_control = 2131230837;
+			public const int mr_cast_meta_subtitle = 2131230837;
 			
 			// aapt resource value: 0x7F080076
-			public const int mr_name = 2131230838;
+			public const int mr_cast_meta_title = 2131230838;
 			
 			// aapt resource value: 0x7F080077
-			public const int mr_playback_control = 2131230839;
+			public const int mr_cast_route_icon = 2131230839;
 			
 			// aapt resource value: 0x7F080078
-			public const int mr_title_bar = 2131230840;
+			public const int mr_cast_route_name = 2131230840;
 			
 			// aapt resource value: 0x7F080079
-			public const int mr_volume_control = 2131230841;
+			public const int mr_cast_stop_button = 2131230841;
 			
 			// aapt resource value: 0x7F08007A
-			public const int mr_volume_group_list = 2131230842;
+			public const int mr_cast_volume_layout = 2131230842;
 			
 			// aapt resource value: 0x7F08007B
-			public const int mr_volume_item_icon = 2131230843;
+			public const int mr_cast_volume_slider = 2131230843;
 			
 			// aapt resource value: 0x7F08007C
-			public const int mr_volume_slider = 2131230844;
+			public const int mr_chooser_list = 2131230844;
 			
 			// aapt resource value: 0x7F08007D
-			public const int multiply = 2131230845;
+			public const int mr_chooser_route_desc = 2131230845;
 			
 			// aapt resource value: 0x7F08007E
-			public const int navigation_header_container = 2131230846;
+			public const int mr_chooser_route_icon = 2131230846;
 			
 			// aapt resource value: 0x7F08007F
-			public const int never = 2131230847;
+			public const int mr_chooser_route_name = 2131230847;
 			
 			// aapt resource value: 0x7F080080
-			public const int none = 2131230848;
+			public const int mr_chooser_title = 2131230848;
 			
 			// aapt resource value: 0x7F080081
-			public const int normal = 2131230849;
+			public const int mr_close = 2131230849;
 			
 			// aapt resource value: 0x7F080082
-			public const int notification_background = 2131230850;
+			public const int mr_control_divider = 2131230850;
 			
 			// aapt resource value: 0x7F080083
-			public const int notification_main_column = 2131230851;
+			public const int mr_control_playback_ctrl = 2131230851;
 			
 			// aapt resource value: 0x7F080084
-			public const int notification_main_column_container = 2131230852;
+			public const int mr_control_subtitle = 2131230852;
 			
 			// aapt resource value: 0x7F080085
-			public const int parallax = 2131230853;
+			public const int mr_control_title = 2131230853;
 			
 			// aapt resource value: 0x7F080086
-			public const int parentPanel = 2131230854;
+			public const int mr_control_title_container = 2131230854;
 			
 			// aapt resource value: 0x7F080087
-			public const int parent_matrix = 2131230855;
+			public const int mr_custom_control = 2131230855;
 			
 			// aapt resource value: 0x7F080088
-			public const int pin = 2131230856;
+			public const int mr_default_control = 2131230856;
 			
 			// aapt resource value: 0x7F080089
-			public const int progress_circular = 2131230857;
+			public const int mr_dialog_area = 2131230857;
 			
 			// aapt resource value: 0x7F08008A
-			public const int progress_horizontal = 2131230858;
+			public const int mr_dialog_header_name = 2131230858;
 			
 			// aapt resource value: 0x7F08008B
-			public const int radio = 2131230859;
+			public const int mr_expandable_area = 2131230859;
 			
 			// aapt resource value: 0x7F08008C
-			public const int right = 2131230860;
+			public const int mr_group_expand_collapse = 2131230860;
 			
 			// aapt resource value: 0x7F08008D
-			public const int right_icon = 2131230861;
+			public const int mr_group_volume_route_name = 2131230861;
 			
 			// aapt resource value: 0x7F08008E
-			public const int right_side = 2131230862;
+			public const int mr_group_volume_slider = 2131230862;
 			
 			// aapt resource value: 0x7F08008F
-			public const int save_image_matrix = 2131230863;
+			public const int mr_media_main_control = 2131230863;
 			
 			// aapt resource value: 0x7F080090
-			public const int save_non_transition_alpha = 2131230864;
+			public const int mr_name = 2131230864;
 			
 			// aapt resource value: 0x7F080091
-			public const int save_scale_type = 2131230865;
+			public const int mr_picker_close_button = 2131230865;
 			
 			// aapt resource value: 0x7F080092
-			public const int screen = 2131230866;
+			public const int mr_picker_list = 2131230866;
 			
 			// aapt resource value: 0x7F080093
-			public const int scroll = 2131230867;
-			
-			// aapt resource value: 0x7F080097
-			public const int scrollable = 2131230871;
+			public const int mr_picker_route_icon = 2131230867;
 			
 			// aapt resource value: 0x7F080094
-			public const int scrollIndicatorDown = 2131230868;
+			public const int mr_picker_route_name = 2131230868;
 			
 			// aapt resource value: 0x7F080095
-			public const int scrollIndicatorUp = 2131230869;
+			public const int mr_playback_control = 2131230869;
 			
 			// aapt resource value: 0x7F080096
-			public const int scrollView = 2131230870;
+			public const int mr_title_bar = 2131230870;
+			
+			// aapt resource value: 0x7F080097
+			public const int mr_volume_control = 2131230871;
 			
 			// aapt resource value: 0x7F080098
-			public const int search_badge = 2131230872;
+			public const int mr_volume_group_list = 2131230872;
 			
 			// aapt resource value: 0x7F080099
-			public const int search_bar = 2131230873;
+			public const int mr_volume_item_icon = 2131230873;
 			
 			// aapt resource value: 0x7F08009A
-			public const int search_button = 2131230874;
+			public const int mr_volume_slider = 2131230874;
 			
 			// aapt resource value: 0x7F08009B
-			public const int search_close_btn = 2131230875;
+			public const int mtrl_child_content_container = 2131230875;
 			
 			// aapt resource value: 0x7F08009C
-			public const int search_edit_frame = 2131230876;
+			public const int mtrl_internal_children_alpha_tag = 2131230876;
 			
 			// aapt resource value: 0x7F08009D
-			public const int search_go_btn = 2131230877;
+			public const int multiply = 2131230877;
 			
 			// aapt resource value: 0x7F08009E
-			public const int search_mag_icon = 2131230878;
+			public const int navigation_header_container = 2131230878;
 			
 			// aapt resource value: 0x7F08009F
-			public const int search_plate = 2131230879;
+			public const int never = 2131230879;
 			
 			// aapt resource value: 0x7F0800A0
-			public const int search_src_text = 2131230880;
+			public const int none = 2131230880;
 			
 			// aapt resource value: 0x7F0800A1
-			public const int search_voice_btn = 2131230881;
+			public const int normal = 2131230881;
 			
 			// aapt resource value: 0x7F0800A2
-			public const int select_dialog_listview = 2131230882;
+			public const int notification_background = 2131230882;
 			
 			// aapt resource value: 0x7F0800A3
-			public const int shellcontent_appbar = 2131230883;
+			public const int notification_main_column = 2131230883;
 			
 			// aapt resource value: 0x7F0800A4
-			public const int shellcontent_toolbar = 2131230884;
+			public const int notification_main_column_container = 2131230884;
+			
+			// aapt resource value: 0x7F0800A5
+			public const int outline = 2131230885;
+			
+			// aapt resource value: 0x7F0800A6
+			public const int parallax = 2131230886;
+			
+			// aapt resource value: 0x7F0800A7
+			public const int parentPanel = 2131230887;
+			
+			// aapt resource value: 0x7F0800A8
+			public const int parent_matrix = 2131230888;
+			
+			// aapt resource value: 0x7F0800A9
+			public const int pin = 2131230889;
+			
+			// aapt resource value: 0x7F0800AA
+			public const int progress_circular = 2131230890;
+			
+			// aapt resource value: 0x7F0800AB
+			public const int progress_horizontal = 2131230891;
+			
+			// aapt resource value: 0x7F0800AC
+			public const int radio = 2131230892;
+			
+			// aapt resource value: 0x7F0800AD
+			public const int right = 2131230893;
+			
+			// aapt resource value: 0x7F0800AE
+			public const int right_icon = 2131230894;
+			
+			// aapt resource value: 0x7F0800AF
+			public const int right_side = 2131230895;
+			
+			// aapt resource value: 0x7F0800B0
+			public const int save_image_matrix = 2131230896;
+			
+			// aapt resource value: 0x7F0800B1
+			public const int save_non_transition_alpha = 2131230897;
+			
+			// aapt resource value: 0x7F0800B2
+			public const int save_scale_type = 2131230898;
+			
+			// aapt resource value: 0x7F0800B3
+			public const int screen = 2131230899;
+			
+			// aapt resource value: 0x7F0800B4
+			public const int scroll = 2131230900;
+			
+			// aapt resource value: 0x7F0800B8
+			public const int scrollable = 2131230904;
+			
+			// aapt resource value: 0x7F0800B5
+			public const int scrollIndicatorDown = 2131230901;
+			
+			// aapt resource value: 0x7F0800B6
+			public const int scrollIndicatorUp = 2131230902;
+			
+			// aapt resource value: 0x7F0800B7
+			public const int scrollView = 2131230903;
+			
+			// aapt resource value: 0x7F0800B9
+			public const int search_badge = 2131230905;
+			
+			// aapt resource value: 0x7F0800BA
+			public const int search_bar = 2131230906;
+			
+			// aapt resource value: 0x7F0800BB
+			public const int search_button = 2131230907;
+			
+			// aapt resource value: 0x7F0800BC
+			public const int search_close_btn = 2131230908;
+			
+			// aapt resource value: 0x7F0800BD
+			public const int search_edit_frame = 2131230909;
+			
+			// aapt resource value: 0x7F0800BE
+			public const int search_go_btn = 2131230910;
+			
+			// aapt resource value: 0x7F0800BF
+			public const int search_mag_icon = 2131230911;
+			
+			// aapt resource value: 0x7F0800C0
+			public const int search_plate = 2131230912;
+			
+			// aapt resource value: 0x7F0800C1
+			public const int search_src_text = 2131230913;
+			
+			// aapt resource value: 0x7F0800C2
+			public const int search_voice_btn = 2131230914;
+			
+			// aapt resource value: 0x7F0800C4
+			public const int selected = 2131230916;
+			
+			// aapt resource value: 0x7F0800C3
+			public const int select_dialog_listview = 2131230915;
+			
+			// aapt resource value: 0x7F0800C5
+			public const int shellcontent_appbar = 2131230917;
+			
+			// aapt resource value: 0x7F0800C6
+			public const int shellcontent_toolbar = 2131230918;
 			
 			// aapt resource value: 0x7F080004
 			public const int SHIFT = 2131230724;
 			
-			// aapt resource value: 0x7F0800A5
-			public const int shortcut = 2131230885;
+			// aapt resource value: 0x7F0800C7
+			public const int shortcut = 2131230919;
 			
-			// aapt resource value: 0x7F0800A6
-			public const int showCustom = 2131230886;
+			// aapt resource value: 0x7F0800C8
+			public const int showCustom = 2131230920;
 			
-			// aapt resource value: 0x7F0800A7
-			public const int showHome = 2131230887;
+			// aapt resource value: 0x7F0800C9
+			public const int showHome = 2131230921;
 			
-			// aapt resource value: 0x7F0800A8
-			public const int showTitle = 2131230888;
+			// aapt resource value: 0x7F0800CA
+			public const int showTitle = 2131230922;
 			
-			// aapt resource value: 0x7F0800A9
-			public const int sliding_tabs = 2131230889;
+			// aapt resource value: 0x7F0800CB
+			public const int sliding_tabs = 2131230923;
 			
-			// aapt resource value: 0x7F0800AA
-			public const int smallLabel = 2131230890;
+			// aapt resource value: 0x7F0800CC
+			public const int smallLabel = 2131230924;
 			
-			// aapt resource value: 0x7F0800AB
-			public const int snackbar_action = 2131230891;
+			// aapt resource value: 0x7F0800CD
+			public const int snackbar_action = 2131230925;
 			
-			// aapt resource value: 0x7F0800AC
-			public const int snackbar_text = 2131230892;
+			// aapt resource value: 0x7F0800CE
+			public const int snackbar_text = 2131230926;
 			
-			// aapt resource value: 0x7F0800AD
-			public const int snap = 2131230893;
+			// aapt resource value: 0x7F0800CF
+			public const int snap = 2131230927;
 			
-			// aapt resource value: 0x7F0800AE
-			public const int spacer = 2131230894;
+			// aapt resource value: 0x7F0800D0
+			public const int snapMargins = 2131230928;
 			
-			// aapt resource value: 0x7F0800AF
-			public const int split_action_bar = 2131230895;
+			// aapt resource value: 0x7F0800D1
+			public const int spacer = 2131230929;
 			
-			// aapt resource value: 0x7F0800B0
-			public const int src_atop = 2131230896;
+			// aapt resource value: 0x7F0800D2
+			public const int split_action_bar = 2131230930;
 			
-			// aapt resource value: 0x7F0800B1
-			public const int src_in = 2131230897;
+			// aapt resource value: 0x7F0800D3
+			public const int src_atop = 2131230931;
 			
-			// aapt resource value: 0x7F0800B2
-			public const int src_over = 2131230898;
+			// aapt resource value: 0x7F0800D4
+			public const int src_in = 2131230932;
 			
-			// aapt resource value: 0x7F0800B3
-			public const int start = 2131230899;
+			// aapt resource value: 0x7F0800D5
+			public const int src_over = 2131230933;
 			
-			// aapt resource value: 0x7F0800B4
-			public const int status_bar_latest_event_content = 2131230900;
+			// aapt resource value: 0x7F0800D6
+			public const int start = 2131230934;
 			
-			// aapt resource value: 0x7F0800B5
-			public const int submenuarrow = 2131230901;
+			// aapt resource value: 0x7F0800D7
+			public const int status_bar_latest_event_content = 2131230935;
 			
-			// aapt resource value: 0x7F0800B6
-			public const int submit_area = 2131230902;
+			// aapt resource value: 0x7F0800D8
+			public const int stretch = 2131230936;
+			
+			// aapt resource value: 0x7F0800D9
+			public const int submenuarrow = 2131230937;
+			
+			// aapt resource value: 0x7F0800DA
+			public const int submit_area = 2131230938;
 			
 			// aapt resource value: 0x7F080005
 			public const int SYM = 2131230725;
 			
-			// aapt resource value: 0x7F0800B7
-			public const int tabMode = 2131230903;
+			// aapt resource value: 0x7F0800DB
+			public const int tabMode = 2131230939;
 			
-			// aapt resource value: 0x7F0800B8
-			public const int tag_transition_group = 2131230904;
+			// aapt resource value: 0x7F0800DC
+			public const int tag_transition_group = 2131230940;
 			
-			// aapt resource value: 0x7F0800B9
-			public const int text = 2131230905;
+			// aapt resource value: 0x7F0800DD
+			public const int tag_unhandled_key_event_manager = 2131230941;
 			
-			// aapt resource value: 0x7F0800BA
-			public const int text2 = 2131230906;
+			// aapt resource value: 0x7F0800DE
+			public const int tag_unhandled_key_listeners = 2131230942;
 			
-			// aapt resource value: 0x7F0800BE
-			public const int textinput_counter = 2131230910;
+			// aapt resource value: 0x7F0800DF
+			public const int text = 2131230943;
 			
-			// aapt resource value: 0x7F0800BF
-			public const int textinput_error = 2131230911;
+			// aapt resource value: 0x7F0800E0
+			public const int text2 = 2131230944;
 			
-			// aapt resource value: 0x7F0800BB
-			public const int textSpacerNoButtons = 2131230907;
+			// aapt resource value: 0x7F0800E5
+			public const int textinput_counter = 2131230949;
 			
-			// aapt resource value: 0x7F0800BC
-			public const int textSpacerNoTitle = 2131230908;
+			// aapt resource value: 0x7F0800E6
+			public const int textinput_error = 2131230950;
 			
-			// aapt resource value: 0x7F0800BD
-			public const int text_input_password_toggle = 2131230909;
+			// aapt resource value: 0x7F0800E7
+			public const int textinput_helper_text = 2131230951;
 			
-			// aapt resource value: 0x7F0800C0
-			public const int time = 2131230912;
+			// aapt resource value: 0x7F0800E1
+			public const int textSpacerNoButtons = 2131230945;
 			
-			// aapt resource value: 0x7F0800C1
-			public const int title = 2131230913;
+			// aapt resource value: 0x7F0800E2
+			public const int textSpacerNoTitle = 2131230946;
 			
-			// aapt resource value: 0x7F0800C2
-			public const int titleDividerNoCustom = 2131230914;
+			// aapt resource value: 0x7F0800E3
+			public const int textStart = 2131230947;
 			
-			// aapt resource value: 0x7F0800C3
-			public const int title_template = 2131230915;
+			// aapt resource value: 0x7F0800E4
+			public const int text_input_password_toggle = 2131230948;
 			
-			// aapt resource value: 0x7F0800C4
-			public const int toolbar = 2131230916;
+			// aapt resource value: 0x7F0800E8
+			public const int time = 2131230952;
 			
-			// aapt resource value: 0x7F0800C5
-			public const int top = 2131230917;
+			// aapt resource value: 0x7F0800E9
+			public const int title = 2131230953;
 			
-			// aapt resource value: 0x7F0800C6
-			public const int topPanel = 2131230918;
+			// aapt resource value: 0x7F0800EA
+			public const int titleDividerNoCustom = 2131230954;
 			
-			// aapt resource value: 0x7F0800C7
-			public const int touch_outside = 2131230919;
+			// aapt resource value: 0x7F0800EB
+			public const int title_template = 2131230955;
 			
-			// aapt resource value: 0x7F0800C8
-			public const int transition_current_scene = 2131230920;
+			// aapt resource value: 0x7F0800EC
+			public const int toolbar = 2131230956;
 			
-			// aapt resource value: 0x7F0800C9
-			public const int transition_layout_save = 2131230921;
+			// aapt resource value: 0x7F0800ED
+			public const int top = 2131230957;
 			
-			// aapt resource value: 0x7F0800CA
-			public const int transition_position = 2131230922;
+			// aapt resource value: 0x7F0800EE
+			public const int topPanel = 2131230958;
 			
-			// aapt resource value: 0x7F0800CB
-			public const int transition_scene_layoutid_cache = 2131230923;
+			// aapt resource value: 0x7F0800EF
+			public const int touch_outside = 2131230959;
 			
-			// aapt resource value: 0x7F0800CC
-			public const int transition_transform = 2131230924;
+			// aapt resource value: 0x7F0800F0
+			public const int transition_current_scene = 2131230960;
 			
-			// aapt resource value: 0x7F0800CD
-			public const int uniform = 2131230925;
+			// aapt resource value: 0x7F0800F1
+			public const int transition_layout_save = 2131230961;
 			
-			// aapt resource value: 0x7F0800CE
-			public const int up = 2131230926;
+			// aapt resource value: 0x7F0800F2
+			public const int transition_position = 2131230962;
 			
-			// aapt resource value: 0x7F0800CF
-			public const int useLogo = 2131230927;
+			// aapt resource value: 0x7F0800F3
+			public const int transition_scene_layoutid_cache = 2131230963;
 			
-			// aapt resource value: 0x7F0800D0
-			public const int view_offset_helper = 2131230928;
+			// aapt resource value: 0x7F0800F4
+			public const int transition_transform = 2131230964;
 			
-			// aapt resource value: 0x7F0800D1
-			public const int visible = 2131230929;
+			// aapt resource value: 0x7F0800F5
+			public const int uniform = 2131230965;
 			
-			// aapt resource value: 0x7F0800D2
-			public const int volume_item_container = 2131230930;
+			// aapt resource value: 0x7F0800F6
+			public const int unlabeled = 2131230966;
 			
-			// aapt resource value: 0x7F0800D3
-			public const int withText = 2131230931;
+			// aapt resource value: 0x7F0800F7
+			public const int up = 2131230967;
 			
-			// aapt resource value: 0x7F0800D4
-			public const int wrap_content = 2131230932;
+			// aapt resource value: 0x7F0800F8
+			public const int useLogo = 2131230968;
+			
+			// aapt resource value: 0x7F0800F9
+			public const int view_offset_helper = 2131230969;
+			
+			// aapt resource value: 0x7F0800FA
+			public const int visible = 2131230970;
+			
+			// aapt resource value: 0x7F0800FB
+			public const int volume_item_container = 2131230971;
+			
+			// aapt resource value: 0x7F0800FC
+			public const int withText = 2131230972;
+			
+			// aapt resource value: 0x7F0800FD
+			public const int wrap_content = 2131230973;
 			
 			static Id()
 			{
@@ -5683,22 +7072,40 @@ namespace NFCSample.Droid
 			public const int design_snackbar_text_max_lines = 2131296262;
 			
 			// aapt resource value: 0x7F090007
-			public const int hide_password_duration = 2131296263;
+			public const int design_tab_indicator_anim_duration_ms = 2131296263;
 			
 			// aapt resource value: 0x7F090008
-			public const int mr_controller_volume_group_list_animation_duration_ms = 2131296264;
+			public const int hide_password_duration = 2131296264;
 			
 			// aapt resource value: 0x7F090009
-			public const int mr_controller_volume_group_list_fade_in_duration_ms = 2131296265;
+			public const int mr_controller_volume_group_list_animation_duration_ms = 2131296265;
 			
 			// aapt resource value: 0x7F09000A
-			public const int mr_controller_volume_group_list_fade_out_duration_ms = 2131296266;
+			public const int mr_controller_volume_group_list_fade_in_duration_ms = 2131296266;
 			
 			// aapt resource value: 0x7F09000B
-			public const int show_password_duration = 2131296267;
+			public const int mr_controller_volume_group_list_fade_out_duration_ms = 2131296267;
 			
 			// aapt resource value: 0x7F09000C
-			public const int status_bar_notification_info_maxnum = 2131296268;
+			public const int mr_update_routes_delay_ms = 2131296268;
+			
+			// aapt resource value: 0x7F09000D
+			public const int mtrl_btn_anim_delay_ms = 2131296269;
+			
+			// aapt resource value: 0x7F09000E
+			public const int mtrl_btn_anim_duration_ms = 2131296270;
+			
+			// aapt resource value: 0x7F09000F
+			public const int mtrl_chip_anim_duration = 2131296271;
+			
+			// aapt resource value: 0x7F090010
+			public const int mtrl_tab_indicator_anim_duration_ms = 2131296272;
+			
+			// aapt resource value: 0x7F090011
+			public const int show_password_duration = 2131296273;
+			
+			// aapt resource value: 0x7F090012
+			public const int status_bar_notification_info_maxnum = 2131296274;
 			
 			static Integer()
 			{
@@ -5718,6 +7125,18 @@ namespace NFCSample.Droid
 			
 			// aapt resource value: 0x7F0A0001
 			public const int mr_linear_out_slow_in = 2131361793;
+			
+			// aapt resource value: 0x7F0A0002
+			public const int mtrl_fast_out_linear_in = 2131361794;
+			
+			// aapt resource value: 0x7F0A0003
+			public const int mtrl_fast_out_slow_in = 2131361795;
+			
+			// aapt resource value: 0x7F0A0004
+			public const int mtrl_linear = 2131361796;
+			
+			// aapt resource value: 0x7F0A0005
+			public const int mtrl_linear_out_slow_in = 2131361797;
 			
 			static Interpolator()
 			{
@@ -5766,187 +7185,226 @@ namespace NFCSample.Droid
 			public const int abc_alert_dialog_title_material = 2131427338;
 			
 			// aapt resource value: 0x7F0B000B
-			public const int abc_dialog_title_material = 2131427339;
+			public const int abc_cascading_menu_item_layout = 2131427339;
 			
 			// aapt resource value: 0x7F0B000C
-			public const int abc_expanded_menu_layout = 2131427340;
+			public const int abc_dialog_title_material = 2131427340;
 			
 			// aapt resource value: 0x7F0B000D
-			public const int abc_list_menu_item_checkbox = 2131427341;
+			public const int abc_expanded_menu_layout = 2131427341;
 			
 			// aapt resource value: 0x7F0B000E
-			public const int abc_list_menu_item_icon = 2131427342;
+			public const int abc_list_menu_item_checkbox = 2131427342;
 			
 			// aapt resource value: 0x7F0B000F
-			public const int abc_list_menu_item_layout = 2131427343;
+			public const int abc_list_menu_item_icon = 2131427343;
 			
 			// aapt resource value: 0x7F0B0010
-			public const int abc_list_menu_item_radio = 2131427344;
+			public const int abc_list_menu_item_layout = 2131427344;
 			
 			// aapt resource value: 0x7F0B0011
-			public const int abc_popup_menu_header_item_layout = 2131427345;
+			public const int abc_list_menu_item_radio = 2131427345;
 			
 			// aapt resource value: 0x7F0B0012
-			public const int abc_popup_menu_item_layout = 2131427346;
+			public const int abc_popup_menu_header_item_layout = 2131427346;
 			
 			// aapt resource value: 0x7F0B0013
-			public const int abc_screen_content_include = 2131427347;
+			public const int abc_popup_menu_item_layout = 2131427347;
 			
 			// aapt resource value: 0x7F0B0014
-			public const int abc_screen_simple = 2131427348;
+			public const int abc_screen_content_include = 2131427348;
 			
 			// aapt resource value: 0x7F0B0015
-			public const int abc_screen_simple_overlay_action_mode = 2131427349;
+			public const int abc_screen_simple = 2131427349;
 			
 			// aapt resource value: 0x7F0B0016
-			public const int abc_screen_toolbar = 2131427350;
+			public const int abc_screen_simple_overlay_action_mode = 2131427350;
 			
 			// aapt resource value: 0x7F0B0017
-			public const int abc_search_dropdown_item_icons_2line = 2131427351;
+			public const int abc_screen_toolbar = 2131427351;
 			
 			// aapt resource value: 0x7F0B0018
-			public const int abc_search_view = 2131427352;
+			public const int abc_search_dropdown_item_icons_2line = 2131427352;
 			
 			// aapt resource value: 0x7F0B0019
-			public const int abc_select_dialog_material = 2131427353;
+			public const int abc_search_view = 2131427353;
 			
 			// aapt resource value: 0x7F0B001A
-			public const int BottomTabLayout = 2131427354;
+			public const int abc_select_dialog_material = 2131427354;
 			
 			// aapt resource value: 0x7F0B001B
-			public const int design_bottom_navigation_item = 2131427355;
+			public const int abc_tooltip = 2131427355;
 			
 			// aapt resource value: 0x7F0B001C
-			public const int design_bottom_sheet_dialog = 2131427356;
+			public const int BottomTabLayout = 2131427356;
 			
 			// aapt resource value: 0x7F0B001D
-			public const int design_layout_snackbar = 2131427357;
+			public const int browser_actions_context_menu_page = 2131427357;
 			
 			// aapt resource value: 0x7F0B001E
-			public const int design_layout_snackbar_include = 2131427358;
+			public const int browser_actions_context_menu_row = 2131427358;
 			
 			// aapt resource value: 0x7F0B001F
-			public const int design_layout_tab_icon = 2131427359;
+			public const int design_bottom_navigation_item = 2131427359;
 			
 			// aapt resource value: 0x7F0B0020
-			public const int design_layout_tab_text = 2131427360;
+			public const int design_bottom_sheet_dialog = 2131427360;
 			
 			// aapt resource value: 0x7F0B0021
-			public const int design_menu_item_action_area = 2131427361;
+			public const int design_layout_snackbar = 2131427361;
 			
 			// aapt resource value: 0x7F0B0022
-			public const int design_navigation_item = 2131427362;
+			public const int design_layout_snackbar_include = 2131427362;
 			
 			// aapt resource value: 0x7F0B0023
-			public const int design_navigation_item_header = 2131427363;
+			public const int design_layout_tab_icon = 2131427363;
 			
 			// aapt resource value: 0x7F0B0024
-			public const int design_navigation_item_separator = 2131427364;
+			public const int design_layout_tab_text = 2131427364;
 			
 			// aapt resource value: 0x7F0B0025
-			public const int design_navigation_item_subheader = 2131427365;
+			public const int design_menu_item_action_area = 2131427365;
 			
 			// aapt resource value: 0x7F0B0026
-			public const int design_navigation_menu = 2131427366;
+			public const int design_navigation_item = 2131427366;
 			
 			// aapt resource value: 0x7F0B0027
-			public const int design_navigation_menu_item = 2131427367;
+			public const int design_navigation_item_header = 2131427367;
 			
 			// aapt resource value: 0x7F0B0028
-			public const int design_text_input_password_icon = 2131427368;
+			public const int design_navigation_item_separator = 2131427368;
 			
 			// aapt resource value: 0x7F0B0029
-			public const int FlyoutContent = 2131427369;
+			public const int design_navigation_item_subheader = 2131427369;
 			
 			// aapt resource value: 0x7F0B002A
-			public const int mr_chooser_dialog = 2131427370;
+			public const int design_navigation_menu = 2131427370;
 			
 			// aapt resource value: 0x7F0B002B
-			public const int mr_chooser_list_item = 2131427371;
+			public const int design_navigation_menu_item = 2131427371;
 			
 			// aapt resource value: 0x7F0B002C
-			public const int mr_controller_material_dialog_b = 2131427372;
+			public const int design_text_input_password_icon = 2131427372;
 			
 			// aapt resource value: 0x7F0B002D
-			public const int mr_controller_volume_item = 2131427373;
+			public const int FlyoutContent = 2131427373;
 			
 			// aapt resource value: 0x7F0B002E
-			public const int mr_playback_control = 2131427374;
+			public const int mr_cast_dialog = 2131427374;
 			
 			// aapt resource value: 0x7F0B002F
-			public const int mr_volume_control = 2131427375;
+			public const int mr_cast_group_item = 2131427375;
 			
 			// aapt resource value: 0x7F0B0030
-			public const int notification_action = 2131427376;
+			public const int mr_cast_group_volume_item = 2131427376;
 			
 			// aapt resource value: 0x7F0B0031
-			public const int notification_action_tombstone = 2131427377;
+			public const int mr_cast_media_metadata = 2131427377;
 			
 			// aapt resource value: 0x7F0B0032
-			public const int notification_media_action = 2131427378;
+			public const int mr_cast_route_item = 2131427378;
 			
 			// aapt resource value: 0x7F0B0033
-			public const int notification_media_cancel_action = 2131427379;
+			public const int mr_chooser_dialog = 2131427379;
 			
 			// aapt resource value: 0x7F0B0034
-			public const int notification_template_big_media = 2131427380;
+			public const int mr_chooser_list_item = 2131427380;
 			
 			// aapt resource value: 0x7F0B0035
-			public const int notification_template_big_media_custom = 2131427381;
+			public const int mr_controller_material_dialog_b = 2131427381;
 			
 			// aapt resource value: 0x7F0B0036
-			public const int notification_template_big_media_narrow = 2131427382;
+			public const int mr_controller_volume_item = 2131427382;
 			
 			// aapt resource value: 0x7F0B0037
-			public const int notification_template_big_media_narrow_custom = 2131427383;
+			public const int mr_dialog_header_item = 2131427383;
 			
 			// aapt resource value: 0x7F0B0038
-			public const int notification_template_custom_big = 2131427384;
+			public const int mr_picker_dialog = 2131427384;
 			
 			// aapt resource value: 0x7F0B0039
-			public const int notification_template_icon_group = 2131427385;
+			public const int mr_picker_route_item = 2131427385;
 			
 			// aapt resource value: 0x7F0B003A
-			public const int notification_template_lines_media = 2131427386;
+			public const int mr_playback_control = 2131427386;
 			
 			// aapt resource value: 0x7F0B003B
-			public const int notification_template_media = 2131427387;
+			public const int mr_volume_control = 2131427387;
 			
 			// aapt resource value: 0x7F0B003C
-			public const int notification_template_media_custom = 2131427388;
+			public const int mtrl_layout_snackbar = 2131427388;
 			
 			// aapt resource value: 0x7F0B003D
-			public const int notification_template_part_chronometer = 2131427389;
+			public const int mtrl_layout_snackbar_include = 2131427389;
 			
 			// aapt resource value: 0x7F0B003E
-			public const int notification_template_part_time = 2131427390;
+			public const int notification_action = 2131427390;
 			
 			// aapt resource value: 0x7F0B003F
-			public const int RootLayout = 2131427391;
+			public const int notification_action_tombstone = 2131427391;
 			
 			// aapt resource value: 0x7F0B0040
-			public const int select_dialog_item_material = 2131427392;
+			public const int notification_media_action = 2131427392;
 			
 			// aapt resource value: 0x7F0B0041
-			public const int select_dialog_multichoice_material = 2131427393;
+			public const int notification_media_cancel_action = 2131427393;
 			
 			// aapt resource value: 0x7F0B0042
-			public const int select_dialog_singlechoice_material = 2131427394;
+			public const int notification_template_big_media = 2131427394;
 			
 			// aapt resource value: 0x7F0B0043
-			public const int ShellContent = 2131427395;
+			public const int notification_template_big_media_custom = 2131427395;
 			
 			// aapt resource value: 0x7F0B0044
-			public const int support_simple_spinner_dropdown_item = 2131427396;
+			public const int notification_template_big_media_narrow = 2131427396;
 			
 			// aapt resource value: 0x7F0B0045
-			public const int Tabbar = 2131427397;
+			public const int notification_template_big_media_narrow_custom = 2131427397;
 			
 			// aapt resource value: 0x7F0B0046
-			public const int Toolbar = 2131427398;
+			public const int notification_template_custom_big = 2131427398;
 			
 			// aapt resource value: 0x7F0B0047
-			public const int tooltip = 2131427399;
+			public const int notification_template_icon_group = 2131427399;
+			
+			// aapt resource value: 0x7F0B0048
+			public const int notification_template_lines_media = 2131427400;
+			
+			// aapt resource value: 0x7F0B0049
+			public const int notification_template_media = 2131427401;
+			
+			// aapt resource value: 0x7F0B004A
+			public const int notification_template_media_custom = 2131427402;
+			
+			// aapt resource value: 0x7F0B004B
+			public const int notification_template_part_chronometer = 2131427403;
+			
+			// aapt resource value: 0x7F0B004C
+			public const int notification_template_part_time = 2131427404;
+			
+			// aapt resource value: 0x7F0B004D
+			public const int RootLayout = 2131427405;
+			
+			// aapt resource value: 0x7F0B004E
+			public const int select_dialog_item_material = 2131427406;
+			
+			// aapt resource value: 0x7F0B004F
+			public const int select_dialog_multichoice_material = 2131427407;
+			
+			// aapt resource value: 0x7F0B0050
+			public const int select_dialog_singlechoice_material = 2131427408;
+			
+			// aapt resource value: 0x7F0B0051
+			public const int ShellContent = 2131427409;
+			
+			// aapt resource value: 0x7F0B0052
+			public const int support_simple_spinner_dropdown_item = 2131427410;
+			
+			// aapt resource value: 0x7F0B0053
+			public const int Tabbar = 2131427411;
+			
+			// aapt resource value: 0x7F0B0054
+			public const int Toolbar = 2131427412;
 			
 			static Layout()
 			{
@@ -6043,125 +7501,179 @@ namespace NFCSample.Droid
 			// aapt resource value: 0x7F0D0013
 			public const int abc_font_family_title_material = 2131558419;
 			
+			// aapt resource value: 0x7F0D0014
+			public const int abc_menu_alt_shortcut_label = 2131558420;
+			
 			// aapt resource value: 0x7F0D0015
-			public const int abc_searchview_description_clear = 2131558421;
+			public const int abc_menu_ctrl_shortcut_label = 2131558421;
 			
 			// aapt resource value: 0x7F0D0016
-			public const int abc_searchview_description_query = 2131558422;
+			public const int abc_menu_delete_shortcut_label = 2131558422;
 			
 			// aapt resource value: 0x7F0D0017
-			public const int abc_searchview_description_search = 2131558423;
+			public const int abc_menu_enter_shortcut_label = 2131558423;
 			
 			// aapt resource value: 0x7F0D0018
-			public const int abc_searchview_description_submit = 2131558424;
+			public const int abc_menu_function_shortcut_label = 2131558424;
 			
 			// aapt resource value: 0x7F0D0019
-			public const int abc_searchview_description_voice = 2131558425;
-			
-			// aapt resource value: 0x7F0D0014
-			public const int abc_search_hint = 2131558420;
+			public const int abc_menu_meta_shortcut_label = 2131558425;
 			
 			// aapt resource value: 0x7F0D001A
-			public const int abc_shareactionprovider_share_with = 2131558426;
+			public const int abc_menu_shift_shortcut_label = 2131558426;
 			
 			// aapt resource value: 0x7F0D001B
-			public const int abc_shareactionprovider_share_with_application = 2131558427;
+			public const int abc_menu_space_shortcut_label = 2131558427;
 			
 			// aapt resource value: 0x7F0D001C
-			public const int abc_toolbar_collapse_description = 2131558428;
+			public const int abc_menu_sym_shortcut_label = 2131558428;
 			
 			// aapt resource value: 0x7F0D001D
-			public const int appbar_scrolling_view_behavior = 2131558429;
-			
-			// aapt resource value: 0x7F0D001E
-			public const int bottom_sheet_behavior = 2131558430;
+			public const int abc_prepend_shortcut_label = 2131558429;
 			
 			// aapt resource value: 0x7F0D001F
-			public const int character_counter_pattern = 2131558431;
+			public const int abc_searchview_description_clear = 2131558431;
 			
 			// aapt resource value: 0x7F0D0020
-			public const int mr_button_content_description = 2131558432;
+			public const int abc_searchview_description_query = 2131558432;
 			
 			// aapt resource value: 0x7F0D0021
-			public const int mr_cast_button_connected = 2131558433;
+			public const int abc_searchview_description_search = 2131558433;
 			
 			// aapt resource value: 0x7F0D0022
-			public const int mr_cast_button_connecting = 2131558434;
+			public const int abc_searchview_description_submit = 2131558434;
 			
 			// aapt resource value: 0x7F0D0023
-			public const int mr_cast_button_disconnected = 2131558435;
+			public const int abc_searchview_description_voice = 2131558435;
+			
+			// aapt resource value: 0x7F0D001E
+			public const int abc_search_hint = 2131558430;
 			
 			// aapt resource value: 0x7F0D0024
-			public const int mr_chooser_searching = 2131558436;
+			public const int abc_shareactionprovider_share_with = 2131558436;
 			
 			// aapt resource value: 0x7F0D0025
-			public const int mr_chooser_title = 2131558437;
+			public const int abc_shareactionprovider_share_with_application = 2131558437;
 			
 			// aapt resource value: 0x7F0D0026
-			public const int mr_controller_album_art = 2131558438;
+			public const int abc_toolbar_collapse_description = 2131558438;
 			
 			// aapt resource value: 0x7F0D0027
-			public const int mr_controller_casting_screen = 2131558439;
+			public const int appbar_scrolling_view_behavior = 2131558439;
 			
 			// aapt resource value: 0x7F0D0028
-			public const int mr_controller_close_description = 2131558440;
+			public const int bottom_sheet_behavior = 2131558440;
 			
 			// aapt resource value: 0x7F0D0029
-			public const int mr_controller_collapse_group = 2131558441;
+			public const int character_counter_content_description = 2131558441;
 			
 			// aapt resource value: 0x7F0D002A
-			public const int mr_controller_disconnect = 2131558442;
+			public const int character_counter_pattern = 2131558442;
 			
 			// aapt resource value: 0x7F0D002B
-			public const int mr_controller_expand_group = 2131558443;
+			public const int fab_transformation_scrim_behavior = 2131558443;
 			
 			// aapt resource value: 0x7F0D002C
-			public const int mr_controller_no_info_available = 2131558444;
+			public const int fab_transformation_sheet_behavior = 2131558444;
 			
 			// aapt resource value: 0x7F0D002D
-			public const int mr_controller_no_media_selected = 2131558445;
+			public const int hide_bottom_view_on_scroll_behavior = 2131558445;
 			
 			// aapt resource value: 0x7F0D002E
-			public const int mr_controller_pause = 2131558446;
+			public const int mr_button_content_description = 2131558446;
 			
 			// aapt resource value: 0x7F0D002F
-			public const int mr_controller_play = 2131558447;
+			public const int mr_cast_button_connected = 2131558447;
 			
 			// aapt resource value: 0x7F0D0030
-			public const int mr_controller_stop = 2131558448;
+			public const int mr_cast_button_connecting = 2131558448;
 			
 			// aapt resource value: 0x7F0D0031
-			public const int mr_controller_stop_casting = 2131558449;
+			public const int mr_cast_button_disconnected = 2131558449;
 			
 			// aapt resource value: 0x7F0D0032
-			public const int mr_controller_volume_slider = 2131558450;
+			public const int mr_cast_dialog_title_view_placeholder = 2131558450;
 			
 			// aapt resource value: 0x7F0D0033
-			public const int mr_system_route_name = 2131558451;
+			public const int mr_chooser_searching = 2131558451;
 			
 			// aapt resource value: 0x7F0D0034
-			public const int mr_user_route_category_name = 2131558452;
+			public const int mr_chooser_title = 2131558452;
 			
 			// aapt resource value: 0x7F0D0035
-			public const int password_toggle_content_description = 2131558453;
+			public const int mr_controller_album_art = 2131558453;
 			
 			// aapt resource value: 0x7F0D0036
-			public const int path_password_eye = 2131558454;
+			public const int mr_controller_casting_screen = 2131558454;
 			
 			// aapt resource value: 0x7F0D0037
-			public const int path_password_eye_mask_strike_through = 2131558455;
+			public const int mr_controller_close_description = 2131558455;
 			
 			// aapt resource value: 0x7F0D0038
-			public const int path_password_eye_mask_visible = 2131558456;
+			public const int mr_controller_collapse_group = 2131558456;
 			
 			// aapt resource value: 0x7F0D0039
-			public const int path_password_strike_through = 2131558457;
+			public const int mr_controller_disconnect = 2131558457;
 			
 			// aapt resource value: 0x7F0D003A
-			public const int search_menu_title = 2131558458;
+			public const int mr_controller_expand_group = 2131558458;
 			
 			// aapt resource value: 0x7F0D003B
-			public const int status_bar_notification_info_overflow = 2131558459;
+			public const int mr_controller_no_info_available = 2131558459;
+			
+			// aapt resource value: 0x7F0D003C
+			public const int mr_controller_no_media_selected = 2131558460;
+			
+			// aapt resource value: 0x7F0D003D
+			public const int mr_controller_pause = 2131558461;
+			
+			// aapt resource value: 0x7F0D003E
+			public const int mr_controller_play = 2131558462;
+			
+			// aapt resource value: 0x7F0D003F
+			public const int mr_controller_stop = 2131558463;
+			
+			// aapt resource value: 0x7F0D0040
+			public const int mr_controller_stop_casting = 2131558464;
+			
+			// aapt resource value: 0x7F0D0041
+			public const int mr_controller_volume_slider = 2131558465;
+			
+			// aapt resource value: 0x7F0D0042
+			public const int mr_dialog_device_header = 2131558466;
+			
+			// aapt resource value: 0x7F0D0043
+			public const int mr_dialog_route_header = 2131558467;
+			
+			// aapt resource value: 0x7F0D0044
+			public const int mr_system_route_name = 2131558468;
+			
+			// aapt resource value: 0x7F0D0045
+			public const int mr_user_route_category_name = 2131558469;
+			
+			// aapt resource value: 0x7F0D0046
+			public const int mtrl_chip_close_icon_content_description = 2131558470;
+			
+			// aapt resource value: 0x7F0D0047
+			public const int password_toggle_content_description = 2131558471;
+			
+			// aapt resource value: 0x7F0D0048
+			public const int path_password_eye = 2131558472;
+			
+			// aapt resource value: 0x7F0D0049
+			public const int path_password_eye_mask_strike_through = 2131558473;
+			
+			// aapt resource value: 0x7F0D004A
+			public const int path_password_eye_mask_visible = 2131558474;
+			
+			// aapt resource value: 0x7F0D004B
+			public const int path_password_strike_through = 2131558475;
+			
+			// aapt resource value: 0x7F0D004C
+			public const int search_menu_title = 2131558476;
+			
+			// aapt resource value: 0x7F0D004D
+			public const int status_bar_notification_info_overflow = 2131558477;
 			
 			static String()
 			{
@@ -6365,26 +7877,32 @@ namespace NFCSample.Droid
 			// aapt resource value: 0x7F0E003E
 			public const int Base_TextAppearance_Widget_AppCompat_Toolbar_Title = 2131623998;
 			
-			// aapt resource value: 0x7F0E004D
-			public const int Base_ThemeOverlay_AppCompat = 2131624013;
+			// aapt resource value: 0x7F0E005E
+			public const int Base_ThemeOverlay_AppCompat = 2131624030;
 			
-			// aapt resource value: 0x7F0E004E
-			public const int Base_ThemeOverlay_AppCompat_ActionBar = 2131624014;
+			// aapt resource value: 0x7F0E005F
+			public const int Base_ThemeOverlay_AppCompat_ActionBar = 2131624031;
 			
-			// aapt resource value: 0x7F0E004F
-			public const int Base_ThemeOverlay_AppCompat_Dark = 2131624015;
+			// aapt resource value: 0x7F0E0060
+			public const int Base_ThemeOverlay_AppCompat_Dark = 2131624032;
 			
-			// aapt resource value: 0x7F0E0050
-			public const int Base_ThemeOverlay_AppCompat_Dark_ActionBar = 2131624016;
+			// aapt resource value: 0x7F0E0061
+			public const int Base_ThemeOverlay_AppCompat_Dark_ActionBar = 2131624033;
 			
-			// aapt resource value: 0x7F0E0051
-			public const int Base_ThemeOverlay_AppCompat_Dialog = 2131624017;
+			// aapt resource value: 0x7F0E0062
+			public const int Base_ThemeOverlay_AppCompat_Dialog = 2131624034;
 			
-			// aapt resource value: 0x7F0E0052
-			public const int Base_ThemeOverlay_AppCompat_Dialog_Alert = 2131624018;
+			// aapt resource value: 0x7F0E0063
+			public const int Base_ThemeOverlay_AppCompat_Dialog_Alert = 2131624035;
 			
-			// aapt resource value: 0x7F0E0053
-			public const int Base_ThemeOverlay_AppCompat_Light = 2131624019;
+			// aapt resource value: 0x7F0E0064
+			public const int Base_ThemeOverlay_AppCompat_Light = 2131624036;
+			
+			// aapt resource value: 0x7F0E0065
+			public const int Base_ThemeOverlay_MaterialComponents_Dialog = 2131624037;
+			
+			// aapt resource value: 0x7F0E0066
+			public const int Base_ThemeOverlay_MaterialComponents_Dialog_Alert = 2131624038;
 			
 			// aapt resource value: 0x7F0E003F
 			public const int Base_Theme_AppCompat = 2131623999;
@@ -6428,965 +7946,1295 @@ namespace NFCSample.Droid
 			// aapt resource value: 0x7F0E004B
 			public const int Base_Theme_AppCompat_Light_Dialog_MinWidth = 2131624011;
 			
-			// aapt resource value: 0x7F0E0056
-			public const int Base_V11_ThemeOverlay_AppCompat_Dialog = 2131624022;
+			// aapt resource value: 0x7F0E004D
+			public const int Base_Theme_MaterialComponents = 2131624013;
+			
+			// aapt resource value: 0x7F0E004E
+			public const int Base_Theme_MaterialComponents_Bridge = 2131624014;
+			
+			// aapt resource value: 0x7F0E004F
+			public const int Base_Theme_MaterialComponents_CompactMenu = 2131624015;
+			
+			// aapt resource value: 0x7F0E0050
+			public const int Base_Theme_MaterialComponents_Dialog = 2131624016;
 			
 			// aapt resource value: 0x7F0E0054
-			public const int Base_V11_Theme_AppCompat_Dialog = 2131624020;
+			public const int Base_Theme_MaterialComponents_DialogWhenLarge = 2131624020;
+			
+			// aapt resource value: 0x7F0E0051
+			public const int Base_Theme_MaterialComponents_Dialog_Alert = 2131624017;
+			
+			// aapt resource value: 0x7F0E0052
+			public const int Base_Theme_MaterialComponents_Dialog_FixedSize = 2131624018;
+			
+			// aapt resource value: 0x7F0E0053
+			public const int Base_Theme_MaterialComponents_Dialog_MinWidth = 2131624019;
 			
 			// aapt resource value: 0x7F0E0055
-			public const int Base_V11_Theme_AppCompat_Light_Dialog = 2131624021;
+			public const int Base_Theme_MaterialComponents_Light = 2131624021;
+			
+			// aapt resource value: 0x7F0E0056
+			public const int Base_Theme_MaterialComponents_Light_Bridge = 2131624022;
 			
 			// aapt resource value: 0x7F0E0057
-			public const int Base_V12_Widget_AppCompat_AutoCompleteTextView = 2131624023;
+			public const int Base_Theme_MaterialComponents_Light_DarkActionBar = 2131624023;
 			
 			// aapt resource value: 0x7F0E0058
-			public const int Base_V12_Widget_AppCompat_EditText = 2131624024;
+			public const int Base_Theme_MaterialComponents_Light_DarkActionBar_Bridge = 2131624024;
 			
 			// aapt resource value: 0x7F0E0059
-			public const int Base_V14_Widget_Design_AppBarLayout = 2131624025;
-			
-			// aapt resource value: 0x7F0E005E
-			public const int Base_V21_ThemeOverlay_AppCompat_Dialog = 2131624030;
-			
-			// aapt resource value: 0x7F0E005A
-			public const int Base_V21_Theme_AppCompat = 2131624026;
-			
-			// aapt resource value: 0x7F0E005B
-			public const int Base_V21_Theme_AppCompat_Dialog = 2131624027;
-			
-			// aapt resource value: 0x7F0E005C
-			public const int Base_V21_Theme_AppCompat_Light = 2131624028;
+			public const int Base_Theme_MaterialComponents_Light_Dialog = 2131624025;
 			
 			// aapt resource value: 0x7F0E005D
-			public const int Base_V21_Theme_AppCompat_Light_Dialog = 2131624029;
+			public const int Base_Theme_MaterialComponents_Light_DialogWhenLarge = 2131624029;
 			
-			// aapt resource value: 0x7F0E005F
-			public const int Base_V21_Widget_Design_AppBarLayout = 2131624031;
+			// aapt resource value: 0x7F0E005A
+			public const int Base_Theme_MaterialComponents_Light_Dialog_Alert = 2131624026;
 			
-			// aapt resource value: 0x7F0E0060
-			public const int Base_V22_Theme_AppCompat = 2131624032;
+			// aapt resource value: 0x7F0E005B
+			public const int Base_Theme_MaterialComponents_Light_Dialog_FixedSize = 2131624027;
 			
-			// aapt resource value: 0x7F0E0061
-			public const int Base_V22_Theme_AppCompat_Light = 2131624033;
-			
-			// aapt resource value: 0x7F0E0062
-			public const int Base_V23_Theme_AppCompat = 2131624034;
-			
-			// aapt resource value: 0x7F0E0063
-			public const int Base_V23_Theme_AppCompat_Light = 2131624035;
-			
-			// aapt resource value: 0x7F0E0064
-			public const int Base_V26_Theme_AppCompat = 2131624036;
-			
-			// aapt resource value: 0x7F0E0065
-			public const int Base_V26_Theme_AppCompat_Light = 2131624037;
-			
-			// aapt resource value: 0x7F0E0066
-			public const int Base_V26_Widget_AppCompat_Toolbar = 2131624038;
-			
-			// aapt resource value: 0x7F0E0067
-			public const int Base_V26_Widget_Design_AppBarLayout = 2131624039;
-			
-			// aapt resource value: 0x7F0E006C
-			public const int Base_V7_ThemeOverlay_AppCompat_Dialog = 2131624044;
-			
-			// aapt resource value: 0x7F0E0068
-			public const int Base_V7_Theme_AppCompat = 2131624040;
-			
-			// aapt resource value: 0x7F0E0069
-			public const int Base_V7_Theme_AppCompat_Dialog = 2131624041;
-			
-			// aapt resource value: 0x7F0E006A
-			public const int Base_V7_Theme_AppCompat_Light = 2131624042;
-			
-			// aapt resource value: 0x7F0E006B
-			public const int Base_V7_Theme_AppCompat_Light_Dialog = 2131624043;
-			
-			// aapt resource value: 0x7F0E006D
-			public const int Base_V7_Widget_AppCompat_AutoCompleteTextView = 2131624045;
+			// aapt resource value: 0x7F0E005C
+			public const int Base_Theme_MaterialComponents_Light_Dialog_MinWidth = 2131624028;
 			
 			// aapt resource value: 0x7F0E006E
-			public const int Base_V7_Widget_AppCompat_EditText = 2131624046;
+			public const int Base_V14_ThemeOverlay_MaterialComponents_Dialog = 2131624046;
 			
 			// aapt resource value: 0x7F0E006F
-			public const int Base_V7_Widget_AppCompat_Toolbar = 2131624047;
+			public const int Base_V14_ThemeOverlay_MaterialComponents_Dialog_Alert = 2131624047;
 			
-			// aapt resource value: 0x7F0E0070
-			public const int Base_Widget_AppCompat_ActionBar = 2131624048;
+			// aapt resource value: 0x7F0E0067
+			public const int Base_V14_Theme_MaterialComponents = 2131624039;
 			
-			// aapt resource value: 0x7F0E0071
-			public const int Base_Widget_AppCompat_ActionBar_Solid = 2131624049;
+			// aapt resource value: 0x7F0E0068
+			public const int Base_V14_Theme_MaterialComponents_Bridge = 2131624040;
 			
-			// aapt resource value: 0x7F0E0072
-			public const int Base_Widget_AppCompat_ActionBar_TabBar = 2131624050;
+			// aapt resource value: 0x7F0E0069
+			public const int Base_V14_Theme_MaterialComponents_Dialog = 2131624041;
 			
-			// aapt resource value: 0x7F0E0073
-			public const int Base_Widget_AppCompat_ActionBar_TabText = 2131624051;
+			// aapt resource value: 0x7F0E006A
+			public const int Base_V14_Theme_MaterialComponents_Light = 2131624042;
+			
+			// aapt resource value: 0x7F0E006B
+			public const int Base_V14_Theme_MaterialComponents_Light_Bridge = 2131624043;
+			
+			// aapt resource value: 0x7F0E006C
+			public const int Base_V14_Theme_MaterialComponents_Light_DarkActionBar_Bridge = 2131624044;
+			
+			// aapt resource value: 0x7F0E006D
+			public const int Base_V14_Theme_MaterialComponents_Light_Dialog = 2131624045;
 			
 			// aapt resource value: 0x7F0E0074
-			public const int Base_Widget_AppCompat_ActionBar_TabView = 2131624052;
+			public const int Base_V21_ThemeOverlay_AppCompat_Dialog = 2131624052;
+			
+			// aapt resource value: 0x7F0E0070
+			public const int Base_V21_Theme_AppCompat = 2131624048;
+			
+			// aapt resource value: 0x7F0E0071
+			public const int Base_V21_Theme_AppCompat_Dialog = 2131624049;
+			
+			// aapt resource value: 0x7F0E0072
+			public const int Base_V21_Theme_AppCompat_Light = 2131624050;
+			
+			// aapt resource value: 0x7F0E0073
+			public const int Base_V21_Theme_AppCompat_Light_Dialog = 2131624051;
 			
 			// aapt resource value: 0x7F0E0075
-			public const int Base_Widget_AppCompat_ActionButton = 2131624053;
+			public const int Base_V22_Theme_AppCompat = 2131624053;
 			
 			// aapt resource value: 0x7F0E0076
-			public const int Base_Widget_AppCompat_ActionButton_CloseMode = 2131624054;
+			public const int Base_V22_Theme_AppCompat_Light = 2131624054;
 			
 			// aapt resource value: 0x7F0E0077
-			public const int Base_Widget_AppCompat_ActionButton_Overflow = 2131624055;
+			public const int Base_V23_Theme_AppCompat = 2131624055;
 			
 			// aapt resource value: 0x7F0E0078
-			public const int Base_Widget_AppCompat_ActionMode = 2131624056;
+			public const int Base_V23_Theme_AppCompat_Light = 2131624056;
 			
 			// aapt resource value: 0x7F0E0079
-			public const int Base_Widget_AppCompat_ActivityChooserView = 2131624057;
+			public const int Base_V26_Theme_AppCompat = 2131624057;
 			
 			// aapt resource value: 0x7F0E007A
-			public const int Base_Widget_AppCompat_AutoCompleteTextView = 2131624058;
+			public const int Base_V26_Theme_AppCompat_Light = 2131624058;
 			
 			// aapt resource value: 0x7F0E007B
-			public const int Base_Widget_AppCompat_Button = 2131624059;
-			
-			// aapt resource value: 0x7F0E0081
-			public const int Base_Widget_AppCompat_ButtonBar = 2131624065;
-			
-			// aapt resource value: 0x7F0E0082
-			public const int Base_Widget_AppCompat_ButtonBar_AlertDialog = 2131624066;
+			public const int Base_V26_Widget_AppCompat_Toolbar = 2131624059;
 			
 			// aapt resource value: 0x7F0E007C
-			public const int Base_Widget_AppCompat_Button_Borderless = 2131624060;
+			public const int Base_V28_Theme_AppCompat = 2131624060;
 			
 			// aapt resource value: 0x7F0E007D
-			public const int Base_Widget_AppCompat_Button_Borderless_Colored = 2131624061;
+			public const int Base_V28_Theme_AppCompat_Light = 2131624061;
+			
+			// aapt resource value: 0x7F0E0082
+			public const int Base_V7_ThemeOverlay_AppCompat_Dialog = 2131624066;
 			
 			// aapt resource value: 0x7F0E007E
-			public const int Base_Widget_AppCompat_Button_ButtonBar_AlertDialog = 2131624062;
+			public const int Base_V7_Theme_AppCompat = 2131624062;
 			
 			// aapt resource value: 0x7F0E007F
-			public const int Base_Widget_AppCompat_Button_Colored = 2131624063;
+			public const int Base_V7_Theme_AppCompat_Dialog = 2131624063;
 			
 			// aapt resource value: 0x7F0E0080
-			public const int Base_Widget_AppCompat_Button_Small = 2131624064;
+			public const int Base_V7_Theme_AppCompat_Light = 2131624064;
+			
+			// aapt resource value: 0x7F0E0081
+			public const int Base_V7_Theme_AppCompat_Light_Dialog = 2131624065;
 			
 			// aapt resource value: 0x7F0E0083
-			public const int Base_Widget_AppCompat_CompoundButton_CheckBox = 2131624067;
+			public const int Base_V7_Widget_AppCompat_AutoCompleteTextView = 2131624067;
 			
 			// aapt resource value: 0x7F0E0084
-			public const int Base_Widget_AppCompat_CompoundButton_RadioButton = 2131624068;
+			public const int Base_V7_Widget_AppCompat_EditText = 2131624068;
 			
 			// aapt resource value: 0x7F0E0085
-			public const int Base_Widget_AppCompat_CompoundButton_Switch = 2131624069;
+			public const int Base_V7_Widget_AppCompat_Toolbar = 2131624069;
 			
 			// aapt resource value: 0x7F0E0086
-			public const int Base_Widget_AppCompat_DrawerArrowToggle = 2131624070;
+			public const int Base_Widget_AppCompat_ActionBar = 2131624070;
 			
 			// aapt resource value: 0x7F0E0087
-			public const int Base_Widget_AppCompat_DrawerArrowToggle_Common = 2131624071;
+			public const int Base_Widget_AppCompat_ActionBar_Solid = 2131624071;
 			
 			// aapt resource value: 0x7F0E0088
-			public const int Base_Widget_AppCompat_DropDownItem_Spinner = 2131624072;
+			public const int Base_Widget_AppCompat_ActionBar_TabBar = 2131624072;
 			
 			// aapt resource value: 0x7F0E0089
-			public const int Base_Widget_AppCompat_EditText = 2131624073;
+			public const int Base_Widget_AppCompat_ActionBar_TabText = 2131624073;
 			
 			// aapt resource value: 0x7F0E008A
-			public const int Base_Widget_AppCompat_ImageButton = 2131624074;
+			public const int Base_Widget_AppCompat_ActionBar_TabView = 2131624074;
 			
 			// aapt resource value: 0x7F0E008B
-			public const int Base_Widget_AppCompat_Light_ActionBar = 2131624075;
+			public const int Base_Widget_AppCompat_ActionButton = 2131624075;
 			
 			// aapt resource value: 0x7F0E008C
-			public const int Base_Widget_AppCompat_Light_ActionBar_Solid = 2131624076;
+			public const int Base_Widget_AppCompat_ActionButton_CloseMode = 2131624076;
 			
 			// aapt resource value: 0x7F0E008D
-			public const int Base_Widget_AppCompat_Light_ActionBar_TabBar = 2131624077;
+			public const int Base_Widget_AppCompat_ActionButton_Overflow = 2131624077;
 			
 			// aapt resource value: 0x7F0E008E
-			public const int Base_Widget_AppCompat_Light_ActionBar_TabText = 2131624078;
+			public const int Base_Widget_AppCompat_ActionMode = 2131624078;
 			
 			// aapt resource value: 0x7F0E008F
-			public const int Base_Widget_AppCompat_Light_ActionBar_TabText_Inverse = 2131624079;
+			public const int Base_Widget_AppCompat_ActivityChooserView = 2131624079;
 			
 			// aapt resource value: 0x7F0E0090
-			public const int Base_Widget_AppCompat_Light_ActionBar_TabView = 2131624080;
+			public const int Base_Widget_AppCompat_AutoCompleteTextView = 2131624080;
 			
 			// aapt resource value: 0x7F0E0091
-			public const int Base_Widget_AppCompat_Light_PopupMenu = 2131624081;
-			
-			// aapt resource value: 0x7F0E0092
-			public const int Base_Widget_AppCompat_Light_PopupMenu_Overflow = 2131624082;
-			
-			// aapt resource value: 0x7F0E0093
-			public const int Base_Widget_AppCompat_ListMenuView = 2131624083;
-			
-			// aapt resource value: 0x7F0E0094
-			public const int Base_Widget_AppCompat_ListPopupWindow = 2131624084;
-			
-			// aapt resource value: 0x7F0E0095
-			public const int Base_Widget_AppCompat_ListView = 2131624085;
-			
-			// aapt resource value: 0x7F0E0096
-			public const int Base_Widget_AppCompat_ListView_DropDown = 2131624086;
+			public const int Base_Widget_AppCompat_Button = 2131624081;
 			
 			// aapt resource value: 0x7F0E0097
-			public const int Base_Widget_AppCompat_ListView_Menu = 2131624087;
+			public const int Base_Widget_AppCompat_ButtonBar = 2131624087;
 			
 			// aapt resource value: 0x7F0E0098
-			public const int Base_Widget_AppCompat_PopupMenu = 2131624088;
+			public const int Base_Widget_AppCompat_ButtonBar_AlertDialog = 2131624088;
+			
+			// aapt resource value: 0x7F0E0092
+			public const int Base_Widget_AppCompat_Button_Borderless = 2131624082;
+			
+			// aapt resource value: 0x7F0E0093
+			public const int Base_Widget_AppCompat_Button_Borderless_Colored = 2131624083;
+			
+			// aapt resource value: 0x7F0E0094
+			public const int Base_Widget_AppCompat_Button_ButtonBar_AlertDialog = 2131624084;
+			
+			// aapt resource value: 0x7F0E0095
+			public const int Base_Widget_AppCompat_Button_Colored = 2131624085;
+			
+			// aapt resource value: 0x7F0E0096
+			public const int Base_Widget_AppCompat_Button_Small = 2131624086;
 			
 			// aapt resource value: 0x7F0E0099
-			public const int Base_Widget_AppCompat_PopupMenu_Overflow = 2131624089;
+			public const int Base_Widget_AppCompat_CompoundButton_CheckBox = 2131624089;
 			
 			// aapt resource value: 0x7F0E009A
-			public const int Base_Widget_AppCompat_PopupWindow = 2131624090;
+			public const int Base_Widget_AppCompat_CompoundButton_RadioButton = 2131624090;
 			
 			// aapt resource value: 0x7F0E009B
-			public const int Base_Widget_AppCompat_ProgressBar = 2131624091;
+			public const int Base_Widget_AppCompat_CompoundButton_Switch = 2131624091;
 			
 			// aapt resource value: 0x7F0E009C
-			public const int Base_Widget_AppCompat_ProgressBar_Horizontal = 2131624092;
+			public const int Base_Widget_AppCompat_DrawerArrowToggle = 2131624092;
 			
 			// aapt resource value: 0x7F0E009D
-			public const int Base_Widget_AppCompat_RatingBar = 2131624093;
+			public const int Base_Widget_AppCompat_DrawerArrowToggle_Common = 2131624093;
 			
 			// aapt resource value: 0x7F0E009E
-			public const int Base_Widget_AppCompat_RatingBar_Indicator = 2131624094;
+			public const int Base_Widget_AppCompat_DropDownItem_Spinner = 2131624094;
 			
 			// aapt resource value: 0x7F0E009F
-			public const int Base_Widget_AppCompat_RatingBar_Small = 2131624095;
+			public const int Base_Widget_AppCompat_EditText = 2131624095;
 			
 			// aapt resource value: 0x7F0E00A0
-			public const int Base_Widget_AppCompat_SearchView = 2131624096;
+			public const int Base_Widget_AppCompat_ImageButton = 2131624096;
 			
 			// aapt resource value: 0x7F0E00A1
-			public const int Base_Widget_AppCompat_SearchView_ActionBar = 2131624097;
+			public const int Base_Widget_AppCompat_Light_ActionBar = 2131624097;
 			
 			// aapt resource value: 0x7F0E00A2
-			public const int Base_Widget_AppCompat_SeekBar = 2131624098;
+			public const int Base_Widget_AppCompat_Light_ActionBar_Solid = 2131624098;
 			
 			// aapt resource value: 0x7F0E00A3
-			public const int Base_Widget_AppCompat_SeekBar_Discrete = 2131624099;
+			public const int Base_Widget_AppCompat_Light_ActionBar_TabBar = 2131624099;
 			
 			// aapt resource value: 0x7F0E00A4
-			public const int Base_Widget_AppCompat_Spinner = 2131624100;
+			public const int Base_Widget_AppCompat_Light_ActionBar_TabText = 2131624100;
 			
 			// aapt resource value: 0x7F0E00A5
-			public const int Base_Widget_AppCompat_Spinner_Underlined = 2131624101;
+			public const int Base_Widget_AppCompat_Light_ActionBar_TabText_Inverse = 2131624101;
 			
 			// aapt resource value: 0x7F0E00A6
-			public const int Base_Widget_AppCompat_TextView_SpinnerItem = 2131624102;
+			public const int Base_Widget_AppCompat_Light_ActionBar_TabView = 2131624102;
 			
 			// aapt resource value: 0x7F0E00A7
-			public const int Base_Widget_AppCompat_Toolbar = 2131624103;
+			public const int Base_Widget_AppCompat_Light_PopupMenu = 2131624103;
 			
 			// aapt resource value: 0x7F0E00A8
-			public const int Base_Widget_AppCompat_Toolbar_Button_Navigation = 2131624104;
+			public const int Base_Widget_AppCompat_Light_PopupMenu_Overflow = 2131624104;
 			
 			// aapt resource value: 0x7F0E00A9
-			public const int Base_Widget_Design_AppBarLayout = 2131624105;
+			public const int Base_Widget_AppCompat_ListMenuView = 2131624105;
 			
 			// aapt resource value: 0x7F0E00AA
-			public const int Base_Widget_Design_TabLayout = 2131624106;
+			public const int Base_Widget_AppCompat_ListPopupWindow = 2131624106;
 			
 			// aapt resource value: 0x7F0E00AB
-			public const int CardView = 2131624107;
+			public const int Base_Widget_AppCompat_ListView = 2131624107;
 			
 			// aapt resource value: 0x7F0E00AC
-			public const int CardView_Dark = 2131624108;
+			public const int Base_Widget_AppCompat_ListView_DropDown = 2131624108;
 			
 			// aapt resource value: 0x7F0E00AD
-			public const int CardView_Light = 2131624109;
-			
-			// aapt resource value: 0x7F0E0193
-			public const int collectionViewStyle = 2131624339;
+			public const int Base_Widget_AppCompat_ListView_Menu = 2131624109;
 			
 			// aapt resource value: 0x7F0E00AE
-			public const int MainTheme = 2131624110;
+			public const int Base_Widget_AppCompat_PopupMenu = 2131624110;
 			
 			// aapt resource value: 0x7F0E00AF
-			public const int MainTheme_Base = 2131624111;
+			public const int Base_Widget_AppCompat_PopupMenu_Overflow = 2131624111;
 			
 			// aapt resource value: 0x7F0E00B0
-			public const int NestedScrollBarStyle = 2131624112;
+			public const int Base_Widget_AppCompat_PopupWindow = 2131624112;
 			
 			// aapt resource value: 0x7F0E00B1
-			public const int Platform_AppCompat = 2131624113;
+			public const int Base_Widget_AppCompat_ProgressBar = 2131624113;
 			
 			// aapt resource value: 0x7F0E00B2
-			public const int Platform_AppCompat_Light = 2131624114;
+			public const int Base_Widget_AppCompat_ProgressBar_Horizontal = 2131624114;
 			
 			// aapt resource value: 0x7F0E00B3
-			public const int Platform_ThemeOverlay_AppCompat = 2131624115;
+			public const int Base_Widget_AppCompat_RatingBar = 2131624115;
 			
 			// aapt resource value: 0x7F0E00B4
-			public const int Platform_ThemeOverlay_AppCompat_Dark = 2131624116;
+			public const int Base_Widget_AppCompat_RatingBar_Indicator = 2131624116;
 			
 			// aapt resource value: 0x7F0E00B5
-			public const int Platform_ThemeOverlay_AppCompat_Light = 2131624117;
+			public const int Base_Widget_AppCompat_RatingBar_Small = 2131624117;
 			
 			// aapt resource value: 0x7F0E00B6
-			public const int Platform_V11_AppCompat = 2131624118;
+			public const int Base_Widget_AppCompat_SearchView = 2131624118;
 			
 			// aapt resource value: 0x7F0E00B7
-			public const int Platform_V11_AppCompat_Light = 2131624119;
+			public const int Base_Widget_AppCompat_SearchView_ActionBar = 2131624119;
 			
 			// aapt resource value: 0x7F0E00B8
-			public const int Platform_V14_AppCompat = 2131624120;
+			public const int Base_Widget_AppCompat_SeekBar = 2131624120;
 			
 			// aapt resource value: 0x7F0E00B9
-			public const int Platform_V14_AppCompat_Light = 2131624121;
+			public const int Base_Widget_AppCompat_SeekBar_Discrete = 2131624121;
 			
 			// aapt resource value: 0x7F0E00BA
-			public const int Platform_V21_AppCompat = 2131624122;
+			public const int Base_Widget_AppCompat_Spinner = 2131624122;
 			
 			// aapt resource value: 0x7F0E00BB
-			public const int Platform_V21_AppCompat_Light = 2131624123;
+			public const int Base_Widget_AppCompat_Spinner_Underlined = 2131624123;
 			
 			// aapt resource value: 0x7F0E00BC
-			public const int Platform_V25_AppCompat = 2131624124;
+			public const int Base_Widget_AppCompat_TextView_SpinnerItem = 2131624124;
 			
 			// aapt resource value: 0x7F0E00BD
-			public const int Platform_V25_AppCompat_Light = 2131624125;
+			public const int Base_Widget_AppCompat_Toolbar = 2131624125;
 			
 			// aapt resource value: 0x7F0E00BE
-			public const int Platform_Widget_AppCompat_Spinner = 2131624126;
+			public const int Base_Widget_AppCompat_Toolbar_Button_Navigation = 2131624126;
 			
 			// aapt resource value: 0x7F0E00BF
-			public const int RtlOverlay_DialogWindowTitle_AppCompat = 2131624127;
+			public const int Base_Widget_Design_TabLayout = 2131624127;
 			
 			// aapt resource value: 0x7F0E00C0
-			public const int RtlOverlay_Widget_AppCompat_ActionBar_TitleItem = 2131624128;
+			public const int Base_Widget_MaterialComponents_Chip = 2131624128;
 			
 			// aapt resource value: 0x7F0E00C1
-			public const int RtlOverlay_Widget_AppCompat_DialogTitle_Icon = 2131624129;
+			public const int Base_Widget_MaterialComponents_TextInputEditText = 2131624129;
 			
 			// aapt resource value: 0x7F0E00C2
-			public const int RtlOverlay_Widget_AppCompat_PopupMenuItem = 2131624130;
+			public const int Base_Widget_MaterialComponents_TextInputLayout = 2131624130;
 			
 			// aapt resource value: 0x7F0E00C3
-			public const int RtlOverlay_Widget_AppCompat_PopupMenuItem_InternalGroup = 2131624131;
+			public const int CardView = 2131624131;
 			
 			// aapt resource value: 0x7F0E00C4
-			public const int RtlOverlay_Widget_AppCompat_PopupMenuItem_Text = 2131624132;
-			
-			// aapt resource value: 0x7F0E00CA
-			public const int RtlOverlay_Widget_AppCompat_SearchView_MagIcon = 2131624138;
+			public const int CardView_Dark = 2131624132;
 			
 			// aapt resource value: 0x7F0E00C5
-			public const int RtlOverlay_Widget_AppCompat_Search_DropDown = 2131624133;
+			public const int CardView_Light = 2131624133;
+			
+			// aapt resource value: 0x7F0E0203
+			public const int collectionViewStyle = 2131624451;
 			
 			// aapt resource value: 0x7F0E00C6
-			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Icon1 = 2131624134;
+			public const int MainTheme = 2131624134;
 			
 			// aapt resource value: 0x7F0E00C7
-			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Icon2 = 2131624135;
+			public const int MainTheme_Base = 2131624135;
 			
 			// aapt resource value: 0x7F0E00C8
-			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Query = 2131624136;
+			public const int NestedScrollBarStyle = 2131624136;
 			
 			// aapt resource value: 0x7F0E00C9
-			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Text = 2131624137;
+			public const int Platform_AppCompat = 2131624137;
+			
+			// aapt resource value: 0x7F0E00CA
+			public const int Platform_AppCompat_Light = 2131624138;
 			
 			// aapt resource value: 0x7F0E00CB
-			public const int RtlUnderlay_Widget_AppCompat_ActionButton = 2131624139;
+			public const int Platform_MaterialComponents = 2131624139;
 			
 			// aapt resource value: 0x7F0E00CC
-			public const int RtlUnderlay_Widget_AppCompat_ActionButton_Overflow = 2131624140;
+			public const int Platform_MaterialComponents_Dialog = 2131624140;
 			
 			// aapt resource value: 0x7F0E00CD
-			public const int TextAppearance_AppCompat = 2131624141;
+			public const int Platform_MaterialComponents_Light = 2131624141;
 			
 			// aapt resource value: 0x7F0E00CE
-			public const int TextAppearance_AppCompat_Body1 = 2131624142;
+			public const int Platform_MaterialComponents_Light_Dialog = 2131624142;
 			
 			// aapt resource value: 0x7F0E00CF
-			public const int TextAppearance_AppCompat_Body2 = 2131624143;
+			public const int Platform_ThemeOverlay_AppCompat = 2131624143;
 			
 			// aapt resource value: 0x7F0E00D0
-			public const int TextAppearance_AppCompat_Button = 2131624144;
+			public const int Platform_ThemeOverlay_AppCompat_Dark = 2131624144;
 			
 			// aapt resource value: 0x7F0E00D1
-			public const int TextAppearance_AppCompat_Caption = 2131624145;
+			public const int Platform_ThemeOverlay_AppCompat_Light = 2131624145;
 			
 			// aapt resource value: 0x7F0E00D2
-			public const int TextAppearance_AppCompat_Display1 = 2131624146;
+			public const int Platform_V21_AppCompat = 2131624146;
 			
 			// aapt resource value: 0x7F0E00D3
-			public const int TextAppearance_AppCompat_Display2 = 2131624147;
+			public const int Platform_V21_AppCompat_Light = 2131624147;
 			
 			// aapt resource value: 0x7F0E00D4
-			public const int TextAppearance_AppCompat_Display3 = 2131624148;
+			public const int Platform_V25_AppCompat = 2131624148;
 			
 			// aapt resource value: 0x7F0E00D5
-			public const int TextAppearance_AppCompat_Display4 = 2131624149;
+			public const int Platform_V25_AppCompat_Light = 2131624149;
 			
 			// aapt resource value: 0x7F0E00D6
-			public const int TextAppearance_AppCompat_Headline = 2131624150;
+			public const int Platform_Widget_AppCompat_Spinner = 2131624150;
 			
 			// aapt resource value: 0x7F0E00D7
-			public const int TextAppearance_AppCompat_Inverse = 2131624151;
+			public const int RtlOverlay_DialogWindowTitle_AppCompat = 2131624151;
 			
 			// aapt resource value: 0x7F0E00D8
-			public const int TextAppearance_AppCompat_Large = 2131624152;
+			public const int RtlOverlay_Widget_AppCompat_ActionBar_TitleItem = 2131624152;
 			
 			// aapt resource value: 0x7F0E00D9
-			public const int TextAppearance_AppCompat_Large_Inverse = 2131624153;
+			public const int RtlOverlay_Widget_AppCompat_DialogTitle_Icon = 2131624153;
 			
 			// aapt resource value: 0x7F0E00DA
-			public const int TextAppearance_AppCompat_Light_SearchResult_Subtitle = 2131624154;
+			public const int RtlOverlay_Widget_AppCompat_PopupMenuItem = 2131624154;
 			
 			// aapt resource value: 0x7F0E00DB
-			public const int TextAppearance_AppCompat_Light_SearchResult_Title = 2131624155;
+			public const int RtlOverlay_Widget_AppCompat_PopupMenuItem_InternalGroup = 2131624155;
 			
 			// aapt resource value: 0x7F0E00DC
-			public const int TextAppearance_AppCompat_Light_Widget_PopupMenu_Large = 2131624156;
+			public const int RtlOverlay_Widget_AppCompat_PopupMenuItem_Shortcut = 2131624156;
 			
 			// aapt resource value: 0x7F0E00DD
-			public const int TextAppearance_AppCompat_Light_Widget_PopupMenu_Small = 2131624157;
+			public const int RtlOverlay_Widget_AppCompat_PopupMenuItem_SubmenuArrow = 2131624157;
 			
 			// aapt resource value: 0x7F0E00DE
-			public const int TextAppearance_AppCompat_Medium = 2131624158;
+			public const int RtlOverlay_Widget_AppCompat_PopupMenuItem_Text = 2131624158;
 			
 			// aapt resource value: 0x7F0E00DF
-			public const int TextAppearance_AppCompat_Medium_Inverse = 2131624159;
-			
-			// aapt resource value: 0x7F0E00E0
-			public const int TextAppearance_AppCompat_Menu = 2131624160;
-			
-			// aapt resource value: 0x7F0E00E1
-			public const int TextAppearance_AppCompat_SearchResult_Subtitle = 2131624161;
-			
-			// aapt resource value: 0x7F0E00E2
-			public const int TextAppearance_AppCompat_SearchResult_Title = 2131624162;
-			
-			// aapt resource value: 0x7F0E00E3
-			public const int TextAppearance_AppCompat_Small = 2131624163;
-			
-			// aapt resource value: 0x7F0E00E4
-			public const int TextAppearance_AppCompat_Small_Inverse = 2131624164;
+			public const int RtlOverlay_Widget_AppCompat_PopupMenuItem_Title = 2131624159;
 			
 			// aapt resource value: 0x7F0E00E5
-			public const int TextAppearance_AppCompat_Subhead = 2131624165;
+			public const int RtlOverlay_Widget_AppCompat_SearchView_MagIcon = 2131624165;
+			
+			// aapt resource value: 0x7F0E00E0
+			public const int RtlOverlay_Widget_AppCompat_Search_DropDown = 2131624160;
+			
+			// aapt resource value: 0x7F0E00E1
+			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Icon1 = 2131624161;
+			
+			// aapt resource value: 0x7F0E00E2
+			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Icon2 = 2131624162;
+			
+			// aapt resource value: 0x7F0E00E3
+			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Query = 2131624163;
+			
+			// aapt resource value: 0x7F0E00E4
+			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Text = 2131624164;
 			
 			// aapt resource value: 0x7F0E00E6
-			public const int TextAppearance_AppCompat_Subhead_Inverse = 2131624166;
+			public const int RtlUnderlay_Widget_AppCompat_ActionButton = 2131624166;
 			
 			// aapt resource value: 0x7F0E00E7
-			public const int TextAppearance_AppCompat_Title = 2131624167;
+			public const int RtlUnderlay_Widget_AppCompat_ActionButton_Overflow = 2131624167;
 			
 			// aapt resource value: 0x7F0E00E8
-			public const int TextAppearance_AppCompat_Title_Inverse = 2131624168;
+			public const int TextAppearance_AppCompat = 2131624168;
 			
 			// aapt resource value: 0x7F0E00E9
-			public const int TextAppearance_AppCompat_Tooltip = 2131624169;
+			public const int TextAppearance_AppCompat_Body1 = 2131624169;
 			
 			// aapt resource value: 0x7F0E00EA
-			public const int TextAppearance_AppCompat_Widget_ActionBar_Menu = 2131624170;
+			public const int TextAppearance_AppCompat_Body2 = 2131624170;
 			
 			// aapt resource value: 0x7F0E00EB
-			public const int TextAppearance_AppCompat_Widget_ActionBar_Subtitle = 2131624171;
+			public const int TextAppearance_AppCompat_Button = 2131624171;
 			
 			// aapt resource value: 0x7F0E00EC
-			public const int TextAppearance_AppCompat_Widget_ActionBar_Subtitle_Inverse = 2131624172;
+			public const int TextAppearance_AppCompat_Caption = 2131624172;
 			
 			// aapt resource value: 0x7F0E00ED
-			public const int TextAppearance_AppCompat_Widget_ActionBar_Title = 2131624173;
+			public const int TextAppearance_AppCompat_Display1 = 2131624173;
 			
 			// aapt resource value: 0x7F0E00EE
-			public const int TextAppearance_AppCompat_Widget_ActionBar_Title_Inverse = 2131624174;
+			public const int TextAppearance_AppCompat_Display2 = 2131624174;
 			
 			// aapt resource value: 0x7F0E00EF
-			public const int TextAppearance_AppCompat_Widget_ActionMode_Subtitle = 2131624175;
+			public const int TextAppearance_AppCompat_Display3 = 2131624175;
 			
 			// aapt resource value: 0x7F0E00F0
-			public const int TextAppearance_AppCompat_Widget_ActionMode_Subtitle_Inverse = 2131624176;
+			public const int TextAppearance_AppCompat_Display4 = 2131624176;
 			
 			// aapt resource value: 0x7F0E00F1
-			public const int TextAppearance_AppCompat_Widget_ActionMode_Title = 2131624177;
+			public const int TextAppearance_AppCompat_Headline = 2131624177;
 			
 			// aapt resource value: 0x7F0E00F2
-			public const int TextAppearance_AppCompat_Widget_ActionMode_Title_Inverse = 2131624178;
+			public const int TextAppearance_AppCompat_Inverse = 2131624178;
 			
 			// aapt resource value: 0x7F0E00F3
-			public const int TextAppearance_AppCompat_Widget_Button = 2131624179;
+			public const int TextAppearance_AppCompat_Large = 2131624179;
 			
 			// aapt resource value: 0x7F0E00F4
-			public const int TextAppearance_AppCompat_Widget_Button_Borderless_Colored = 2131624180;
+			public const int TextAppearance_AppCompat_Large_Inverse = 2131624180;
 			
 			// aapt resource value: 0x7F0E00F5
-			public const int TextAppearance_AppCompat_Widget_Button_Colored = 2131624181;
+			public const int TextAppearance_AppCompat_Light_SearchResult_Subtitle = 2131624181;
 			
 			// aapt resource value: 0x7F0E00F6
-			public const int TextAppearance_AppCompat_Widget_Button_Inverse = 2131624182;
+			public const int TextAppearance_AppCompat_Light_SearchResult_Title = 2131624182;
 			
 			// aapt resource value: 0x7F0E00F7
-			public const int TextAppearance_AppCompat_Widget_DropDownItem = 2131624183;
+			public const int TextAppearance_AppCompat_Light_Widget_PopupMenu_Large = 2131624183;
 			
 			// aapt resource value: 0x7F0E00F8
-			public const int TextAppearance_AppCompat_Widget_PopupMenu_Header = 2131624184;
+			public const int TextAppearance_AppCompat_Light_Widget_PopupMenu_Small = 2131624184;
 			
 			// aapt resource value: 0x7F0E00F9
-			public const int TextAppearance_AppCompat_Widget_PopupMenu_Large = 2131624185;
+			public const int TextAppearance_AppCompat_Medium = 2131624185;
 			
 			// aapt resource value: 0x7F0E00FA
-			public const int TextAppearance_AppCompat_Widget_PopupMenu_Small = 2131624186;
+			public const int TextAppearance_AppCompat_Medium_Inverse = 2131624186;
 			
 			// aapt resource value: 0x7F0E00FB
-			public const int TextAppearance_AppCompat_Widget_Switch = 2131624187;
+			public const int TextAppearance_AppCompat_Menu = 2131624187;
 			
 			// aapt resource value: 0x7F0E00FC
-			public const int TextAppearance_AppCompat_Widget_TextView_SpinnerItem = 2131624188;
+			public const int TextAppearance_AppCompat_SearchResult_Subtitle = 2131624188;
 			
 			// aapt resource value: 0x7F0E00FD
-			public const int TextAppearance_Compat_Notification = 2131624189;
+			public const int TextAppearance_AppCompat_SearchResult_Title = 2131624189;
 			
 			// aapt resource value: 0x7F0E00FE
-			public const int TextAppearance_Compat_Notification_Info = 2131624190;
+			public const int TextAppearance_AppCompat_Small = 2131624190;
 			
 			// aapt resource value: 0x7F0E00FF
-			public const int TextAppearance_Compat_Notification_Info_Media = 2131624191;
+			public const int TextAppearance_AppCompat_Small_Inverse = 2131624191;
 			
 			// aapt resource value: 0x7F0E0100
-			public const int TextAppearance_Compat_Notification_Line2 = 2131624192;
+			public const int TextAppearance_AppCompat_Subhead = 2131624192;
 			
 			// aapt resource value: 0x7F0E0101
-			public const int TextAppearance_Compat_Notification_Line2_Media = 2131624193;
+			public const int TextAppearance_AppCompat_Subhead_Inverse = 2131624193;
 			
 			// aapt resource value: 0x7F0E0102
-			public const int TextAppearance_Compat_Notification_Media = 2131624194;
+			public const int TextAppearance_AppCompat_Title = 2131624194;
 			
 			// aapt resource value: 0x7F0E0103
-			public const int TextAppearance_Compat_Notification_Time = 2131624195;
+			public const int TextAppearance_AppCompat_Title_Inverse = 2131624195;
 			
 			// aapt resource value: 0x7F0E0104
-			public const int TextAppearance_Compat_Notification_Time_Media = 2131624196;
+			public const int TextAppearance_AppCompat_Tooltip = 2131624196;
 			
 			// aapt resource value: 0x7F0E0105
-			public const int TextAppearance_Compat_Notification_Title = 2131624197;
+			public const int TextAppearance_AppCompat_Widget_ActionBar_Menu = 2131624197;
 			
 			// aapt resource value: 0x7F0E0106
-			public const int TextAppearance_Compat_Notification_Title_Media = 2131624198;
+			public const int TextAppearance_AppCompat_Widget_ActionBar_Subtitle = 2131624198;
 			
 			// aapt resource value: 0x7F0E0107
-			public const int TextAppearance_Design_CollapsingToolbar_Expanded = 2131624199;
+			public const int TextAppearance_AppCompat_Widget_ActionBar_Subtitle_Inverse = 2131624199;
 			
 			// aapt resource value: 0x7F0E0108
-			public const int TextAppearance_Design_Counter = 2131624200;
+			public const int TextAppearance_AppCompat_Widget_ActionBar_Title = 2131624200;
 			
 			// aapt resource value: 0x7F0E0109
-			public const int TextAppearance_Design_Counter_Overflow = 2131624201;
+			public const int TextAppearance_AppCompat_Widget_ActionBar_Title_Inverse = 2131624201;
 			
 			// aapt resource value: 0x7F0E010A
-			public const int TextAppearance_Design_Error = 2131624202;
+			public const int TextAppearance_AppCompat_Widget_ActionMode_Subtitle = 2131624202;
 			
 			// aapt resource value: 0x7F0E010B
-			public const int TextAppearance_Design_Hint = 2131624203;
+			public const int TextAppearance_AppCompat_Widget_ActionMode_Subtitle_Inverse = 2131624203;
 			
 			// aapt resource value: 0x7F0E010C
-			public const int TextAppearance_Design_Snackbar_Message = 2131624204;
+			public const int TextAppearance_AppCompat_Widget_ActionMode_Title = 2131624204;
 			
 			// aapt resource value: 0x7F0E010D
-			public const int TextAppearance_Design_Tab = 2131624205;
+			public const int TextAppearance_AppCompat_Widget_ActionMode_Title_Inverse = 2131624205;
 			
 			// aapt resource value: 0x7F0E010E
-			public const int TextAppearance_MediaRouter_PrimaryText = 2131624206;
+			public const int TextAppearance_AppCompat_Widget_Button = 2131624206;
 			
 			// aapt resource value: 0x7F0E010F
-			public const int TextAppearance_MediaRouter_SecondaryText = 2131624207;
+			public const int TextAppearance_AppCompat_Widget_Button_Borderless_Colored = 2131624207;
 			
 			// aapt resource value: 0x7F0E0110
-			public const int TextAppearance_MediaRouter_Title = 2131624208;
+			public const int TextAppearance_AppCompat_Widget_Button_Colored = 2131624208;
 			
 			// aapt resource value: 0x7F0E0111
-			public const int TextAppearance_Widget_AppCompat_ExpandedMenu_Item = 2131624209;
+			public const int TextAppearance_AppCompat_Widget_Button_Inverse = 2131624209;
 			
 			// aapt resource value: 0x7F0E0112
-			public const int TextAppearance_Widget_AppCompat_Toolbar_Subtitle = 2131624210;
+			public const int TextAppearance_AppCompat_Widget_DropDownItem = 2131624210;
 			
 			// aapt resource value: 0x7F0E0113
-			public const int TextAppearance_Widget_AppCompat_Toolbar_Title = 2131624211;
-			
-			// aapt resource value: 0x7F0E0133
-			public const int ThemeOverlay_AppCompat = 2131624243;
-			
-			// aapt resource value: 0x7F0E0134
-			public const int ThemeOverlay_AppCompat_ActionBar = 2131624244;
-			
-			// aapt resource value: 0x7F0E0135
-			public const int ThemeOverlay_AppCompat_Dark = 2131624245;
-			
-			// aapt resource value: 0x7F0E0136
-			public const int ThemeOverlay_AppCompat_Dark_ActionBar = 2131624246;
-			
-			// aapt resource value: 0x7F0E0137
-			public const int ThemeOverlay_AppCompat_Dialog = 2131624247;
-			
-			// aapt resource value: 0x7F0E0138
-			public const int ThemeOverlay_AppCompat_Dialog_Alert = 2131624248;
-			
-			// aapt resource value: 0x7F0E0139
-			public const int ThemeOverlay_AppCompat_Light = 2131624249;
-			
-			// aapt resource value: 0x7F0E013A
-			public const int ThemeOverlay_MediaRouter_Dark = 2131624250;
-			
-			// aapt resource value: 0x7F0E013B
-			public const int ThemeOverlay_MediaRouter_Light = 2131624251;
+			public const int TextAppearance_AppCompat_Widget_PopupMenu_Header = 2131624211;
 			
 			// aapt resource value: 0x7F0E0114
-			public const int Theme_AppCompat = 2131624212;
+			public const int TextAppearance_AppCompat_Widget_PopupMenu_Large = 2131624212;
 			
 			// aapt resource value: 0x7F0E0115
-			public const int Theme_AppCompat_CompactMenu = 2131624213;
+			public const int TextAppearance_AppCompat_Widget_PopupMenu_Small = 2131624213;
 			
 			// aapt resource value: 0x7F0E0116
-			public const int Theme_AppCompat_DayNight = 2131624214;
+			public const int TextAppearance_AppCompat_Widget_Switch = 2131624214;
 			
 			// aapt resource value: 0x7F0E0117
-			public const int Theme_AppCompat_DayNight_DarkActionBar = 2131624215;
+			public const int TextAppearance_AppCompat_Widget_TextView_SpinnerItem = 2131624215;
 			
 			// aapt resource value: 0x7F0E0118
-			public const int Theme_AppCompat_DayNight_Dialog = 2131624216;
-			
-			// aapt resource value: 0x7F0E011B
-			public const int Theme_AppCompat_DayNight_DialogWhenLarge = 2131624219;
+			public const int TextAppearance_Compat_Notification = 2131624216;
 			
 			// aapt resource value: 0x7F0E0119
-			public const int Theme_AppCompat_DayNight_Dialog_Alert = 2131624217;
+			public const int TextAppearance_Compat_Notification_Info = 2131624217;
 			
 			// aapt resource value: 0x7F0E011A
-			public const int Theme_AppCompat_DayNight_Dialog_MinWidth = 2131624218;
+			public const int TextAppearance_Compat_Notification_Info_Media = 2131624218;
+			
+			// aapt resource value: 0x7F0E011B
+			public const int TextAppearance_Compat_Notification_Line2 = 2131624219;
 			
 			// aapt resource value: 0x7F0E011C
-			public const int Theme_AppCompat_DayNight_NoActionBar = 2131624220;
+			public const int TextAppearance_Compat_Notification_Line2_Media = 2131624220;
 			
 			// aapt resource value: 0x7F0E011D
-			public const int Theme_AppCompat_Dialog = 2131624221;
-			
-			// aapt resource value: 0x7F0E0120
-			public const int Theme_AppCompat_DialogWhenLarge = 2131624224;
+			public const int TextAppearance_Compat_Notification_Media = 2131624221;
 			
 			// aapt resource value: 0x7F0E011E
-			public const int Theme_AppCompat_Dialog_Alert = 2131624222;
+			public const int TextAppearance_Compat_Notification_Time = 2131624222;
 			
 			// aapt resource value: 0x7F0E011F
-			public const int Theme_AppCompat_Dialog_MinWidth = 2131624223;
+			public const int TextAppearance_Compat_Notification_Time_Media = 2131624223;
+			
+			// aapt resource value: 0x7F0E0120
+			public const int TextAppearance_Compat_Notification_Title = 2131624224;
 			
 			// aapt resource value: 0x7F0E0121
-			public const int Theme_AppCompat_Light = 2131624225;
+			public const int TextAppearance_Compat_Notification_Title_Media = 2131624225;
 			
 			// aapt resource value: 0x7F0E0122
-			public const int Theme_AppCompat_Light_DarkActionBar = 2131624226;
+			public const int TextAppearance_Design_CollapsingToolbar_Expanded = 2131624226;
 			
 			// aapt resource value: 0x7F0E0123
-			public const int Theme_AppCompat_Light_Dialog = 2131624227;
-			
-			// aapt resource value: 0x7F0E0126
-			public const int Theme_AppCompat_Light_DialogWhenLarge = 2131624230;
+			public const int TextAppearance_Design_Counter = 2131624227;
 			
 			// aapt resource value: 0x7F0E0124
-			public const int Theme_AppCompat_Light_Dialog_Alert = 2131624228;
+			public const int TextAppearance_Design_Counter_Overflow = 2131624228;
 			
 			// aapt resource value: 0x7F0E0125
-			public const int Theme_AppCompat_Light_Dialog_MinWidth = 2131624229;
+			public const int TextAppearance_Design_Error = 2131624229;
+			
+			// aapt resource value: 0x7F0E0126
+			public const int TextAppearance_Design_HelperText = 2131624230;
 			
 			// aapt resource value: 0x7F0E0127
-			public const int Theme_AppCompat_Light_NoActionBar = 2131624231;
+			public const int TextAppearance_Design_Hint = 2131624231;
 			
 			// aapt resource value: 0x7F0E0128
-			public const int Theme_AppCompat_NoActionBar = 2131624232;
+			public const int TextAppearance_Design_Snackbar_Message = 2131624232;
 			
 			// aapt resource value: 0x7F0E0129
-			public const int Theme_Design = 2131624233;
+			public const int TextAppearance_Design_Tab = 2131624233;
 			
 			// aapt resource value: 0x7F0E012A
-			public const int Theme_Design_BottomSheetDialog = 2131624234;
+			public const int TextAppearance_MaterialComponents_Body1 = 2131624234;
 			
 			// aapt resource value: 0x7F0E012B
-			public const int Theme_Design_Light = 2131624235;
+			public const int TextAppearance_MaterialComponents_Body2 = 2131624235;
 			
 			// aapt resource value: 0x7F0E012C
-			public const int Theme_Design_Light_BottomSheetDialog = 2131624236;
+			public const int TextAppearance_MaterialComponents_Button = 2131624236;
 			
 			// aapt resource value: 0x7F0E012D
-			public const int Theme_Design_Light_NoActionBar = 2131624237;
+			public const int TextAppearance_MaterialComponents_Caption = 2131624237;
 			
 			// aapt resource value: 0x7F0E012E
-			public const int Theme_Design_NoActionBar = 2131624238;
+			public const int TextAppearance_MaterialComponents_Chip = 2131624238;
 			
 			// aapt resource value: 0x7F0E012F
-			public const int Theme_MediaRouter = 2131624239;
+			public const int TextAppearance_MaterialComponents_Headline1 = 2131624239;
 			
 			// aapt resource value: 0x7F0E0130
-			public const int Theme_MediaRouter_Light = 2131624240;
-			
-			// aapt resource value: 0x7F0E0132
-			public const int Theme_MediaRouter_LightControlPanel = 2131624242;
+			public const int TextAppearance_MaterialComponents_Headline2 = 2131624240;
 			
 			// aapt resource value: 0x7F0E0131
-			public const int Theme_MediaRouter_Light_DarkControlPanel = 2131624241;
+			public const int TextAppearance_MaterialComponents_Headline3 = 2131624241;
+			
+			// aapt resource value: 0x7F0E0132
+			public const int TextAppearance_MaterialComponents_Headline4 = 2131624242;
+			
+			// aapt resource value: 0x7F0E0133
+			public const int TextAppearance_MaterialComponents_Headline5 = 2131624243;
+			
+			// aapt resource value: 0x7F0E0134
+			public const int TextAppearance_MaterialComponents_Headline6 = 2131624244;
+			
+			// aapt resource value: 0x7F0E0135
+			public const int TextAppearance_MaterialComponents_Overline = 2131624245;
+			
+			// aapt resource value: 0x7F0E0136
+			public const int TextAppearance_MaterialComponents_Subtitle1 = 2131624246;
+			
+			// aapt resource value: 0x7F0E0137
+			public const int TextAppearance_MaterialComponents_Subtitle2 = 2131624247;
+			
+			// aapt resource value: 0x7F0E0138
+			public const int TextAppearance_MaterialComponents_Tab = 2131624248;
+			
+			// aapt resource value: 0x7F0E0139
+			public const int TextAppearance_MediaRouter_PrimaryText = 2131624249;
+			
+			// aapt resource value: 0x7F0E013A
+			public const int TextAppearance_MediaRouter_SecondaryText = 2131624250;
+			
+			// aapt resource value: 0x7F0E013B
+			public const int TextAppearance_MediaRouter_Title = 2131624251;
 			
 			// aapt resource value: 0x7F0E013C
-			public const int Widget_AppCompat_ActionBar = 2131624252;
+			public const int TextAppearance_Widget_AppCompat_ExpandedMenu_Item = 2131624252;
 			
 			// aapt resource value: 0x7F0E013D
-			public const int Widget_AppCompat_ActionBar_Solid = 2131624253;
+			public const int TextAppearance_Widget_AppCompat_Toolbar_Subtitle = 2131624253;
 			
 			// aapt resource value: 0x7F0E013E
-			public const int Widget_AppCompat_ActionBar_TabBar = 2131624254;
-			
-			// aapt resource value: 0x7F0E013F
-			public const int Widget_AppCompat_ActionBar_TabText = 2131624255;
-			
-			// aapt resource value: 0x7F0E0140
-			public const int Widget_AppCompat_ActionBar_TabView = 2131624256;
-			
-			// aapt resource value: 0x7F0E0141
-			public const int Widget_AppCompat_ActionButton = 2131624257;
-			
-			// aapt resource value: 0x7F0E0142
-			public const int Widget_AppCompat_ActionButton_CloseMode = 2131624258;
-			
-			// aapt resource value: 0x7F0E0143
-			public const int Widget_AppCompat_ActionButton_Overflow = 2131624259;
-			
-			// aapt resource value: 0x7F0E0144
-			public const int Widget_AppCompat_ActionMode = 2131624260;
-			
-			// aapt resource value: 0x7F0E0145
-			public const int Widget_AppCompat_ActivityChooserView = 2131624261;
-			
-			// aapt resource value: 0x7F0E0146
-			public const int Widget_AppCompat_AutoCompleteTextView = 2131624262;
-			
-			// aapt resource value: 0x7F0E0147
-			public const int Widget_AppCompat_Button = 2131624263;
-			
-			// aapt resource value: 0x7F0E014D
-			public const int Widget_AppCompat_ButtonBar = 2131624269;
-			
-			// aapt resource value: 0x7F0E014E
-			public const int Widget_AppCompat_ButtonBar_AlertDialog = 2131624270;
-			
-			// aapt resource value: 0x7F0E0148
-			public const int Widget_AppCompat_Button_Borderless = 2131624264;
-			
-			// aapt resource value: 0x7F0E0149
-			public const int Widget_AppCompat_Button_Borderless_Colored = 2131624265;
-			
-			// aapt resource value: 0x7F0E014A
-			public const int Widget_AppCompat_Button_ButtonBar_AlertDialog = 2131624266;
-			
-			// aapt resource value: 0x7F0E014B
-			public const int Widget_AppCompat_Button_Colored = 2131624267;
-			
-			// aapt resource value: 0x7F0E014C
-			public const int Widget_AppCompat_Button_Small = 2131624268;
-			
-			// aapt resource value: 0x7F0E014F
-			public const int Widget_AppCompat_CompoundButton_CheckBox = 2131624271;
-			
-			// aapt resource value: 0x7F0E0150
-			public const int Widget_AppCompat_CompoundButton_RadioButton = 2131624272;
-			
-			// aapt resource value: 0x7F0E0151
-			public const int Widget_AppCompat_CompoundButton_Switch = 2131624273;
-			
-			// aapt resource value: 0x7F0E0152
-			public const int Widget_AppCompat_DrawerArrowToggle = 2131624274;
-			
-			// aapt resource value: 0x7F0E0153
-			public const int Widget_AppCompat_DropDownItem_Spinner = 2131624275;
-			
-			// aapt resource value: 0x7F0E0154
-			public const int Widget_AppCompat_EditText = 2131624276;
-			
-			// aapt resource value: 0x7F0E0155
-			public const int Widget_AppCompat_ImageButton = 2131624277;
-			
-			// aapt resource value: 0x7F0E0156
-			public const int Widget_AppCompat_Light_ActionBar = 2131624278;
-			
-			// aapt resource value: 0x7F0E0157
-			public const int Widget_AppCompat_Light_ActionBar_Solid = 2131624279;
-			
-			// aapt resource value: 0x7F0E0158
-			public const int Widget_AppCompat_Light_ActionBar_Solid_Inverse = 2131624280;
-			
-			// aapt resource value: 0x7F0E0159
-			public const int Widget_AppCompat_Light_ActionBar_TabBar = 2131624281;
-			
-			// aapt resource value: 0x7F0E015A
-			public const int Widget_AppCompat_Light_ActionBar_TabBar_Inverse = 2131624282;
-			
-			// aapt resource value: 0x7F0E015B
-			public const int Widget_AppCompat_Light_ActionBar_TabText = 2131624283;
-			
-			// aapt resource value: 0x7F0E015C
-			public const int Widget_AppCompat_Light_ActionBar_TabText_Inverse = 2131624284;
-			
-			// aapt resource value: 0x7F0E015D
-			public const int Widget_AppCompat_Light_ActionBar_TabView = 2131624285;
-			
-			// aapt resource value: 0x7F0E015E
-			public const int Widget_AppCompat_Light_ActionBar_TabView_Inverse = 2131624286;
-			
-			// aapt resource value: 0x7F0E015F
-			public const int Widget_AppCompat_Light_ActionButton = 2131624287;
-			
-			// aapt resource value: 0x7F0E0160
-			public const int Widget_AppCompat_Light_ActionButton_CloseMode = 2131624288;
-			
-			// aapt resource value: 0x7F0E0161
-			public const int Widget_AppCompat_Light_ActionButton_Overflow = 2131624289;
-			
-			// aapt resource value: 0x7F0E0162
-			public const int Widget_AppCompat_Light_ActionMode_Inverse = 2131624290;
-			
-			// aapt resource value: 0x7F0E0163
-			public const int Widget_AppCompat_Light_ActivityChooserView = 2131624291;
-			
-			// aapt resource value: 0x7F0E0164
-			public const int Widget_AppCompat_Light_AutoCompleteTextView = 2131624292;
-			
-			// aapt resource value: 0x7F0E0165
-			public const int Widget_AppCompat_Light_DropDownItem_Spinner = 2131624293;
-			
-			// aapt resource value: 0x7F0E0166
-			public const int Widget_AppCompat_Light_ListPopupWindow = 2131624294;
-			
-			// aapt resource value: 0x7F0E0167
-			public const int Widget_AppCompat_Light_ListView_DropDown = 2131624295;
-			
-			// aapt resource value: 0x7F0E0168
-			public const int Widget_AppCompat_Light_PopupMenu = 2131624296;
-			
-			// aapt resource value: 0x7F0E0169
-			public const int Widget_AppCompat_Light_PopupMenu_Overflow = 2131624297;
-			
-			// aapt resource value: 0x7F0E016A
-			public const int Widget_AppCompat_Light_SearchView = 2131624298;
-			
-			// aapt resource value: 0x7F0E016B
-			public const int Widget_AppCompat_Light_Spinner_DropDown_ActionBar = 2131624299;
-			
-			// aapt resource value: 0x7F0E016C
-			public const int Widget_AppCompat_ListMenuView = 2131624300;
-			
-			// aapt resource value: 0x7F0E016D
-			public const int Widget_AppCompat_ListPopupWindow = 2131624301;
-			
-			// aapt resource value: 0x7F0E016E
-			public const int Widget_AppCompat_ListView = 2131624302;
-			
-			// aapt resource value: 0x7F0E016F
-			public const int Widget_AppCompat_ListView_DropDown = 2131624303;
-			
-			// aapt resource value: 0x7F0E0170
-			public const int Widget_AppCompat_ListView_Menu = 2131624304;
-			
-			// aapt resource value: 0x7F0E0171
-			public const int Widget_AppCompat_PopupMenu = 2131624305;
-			
-			// aapt resource value: 0x7F0E0172
-			public const int Widget_AppCompat_PopupMenu_Overflow = 2131624306;
+			public const int TextAppearance_Widget_AppCompat_Toolbar_Title = 2131624254;
 			
 			// aapt resource value: 0x7F0E0173
-			public const int Widget_AppCompat_PopupWindow = 2131624307;
+			public const int ThemeOverlay_AppCompat = 2131624307;
 			
 			// aapt resource value: 0x7F0E0174
-			public const int Widget_AppCompat_ProgressBar = 2131624308;
+			public const int ThemeOverlay_AppCompat_ActionBar = 2131624308;
 			
 			// aapt resource value: 0x7F0E0175
-			public const int Widget_AppCompat_ProgressBar_Horizontal = 2131624309;
+			public const int ThemeOverlay_AppCompat_Dark = 2131624309;
 			
 			// aapt resource value: 0x7F0E0176
-			public const int Widget_AppCompat_RatingBar = 2131624310;
+			public const int ThemeOverlay_AppCompat_Dark_ActionBar = 2131624310;
 			
 			// aapt resource value: 0x7F0E0177
-			public const int Widget_AppCompat_RatingBar_Indicator = 2131624311;
+			public const int ThemeOverlay_AppCompat_Dialog = 2131624311;
 			
 			// aapt resource value: 0x7F0E0178
-			public const int Widget_AppCompat_RatingBar_Small = 2131624312;
+			public const int ThemeOverlay_AppCompat_Dialog_Alert = 2131624312;
 			
 			// aapt resource value: 0x7F0E0179
-			public const int Widget_AppCompat_SearchView = 2131624313;
+			public const int ThemeOverlay_AppCompat_Light = 2131624313;
 			
 			// aapt resource value: 0x7F0E017A
-			public const int Widget_AppCompat_SearchView_ActionBar = 2131624314;
+			public const int ThemeOverlay_MaterialComponents = 2131624314;
 			
 			// aapt resource value: 0x7F0E017B
-			public const int Widget_AppCompat_SeekBar = 2131624315;
+			public const int ThemeOverlay_MaterialComponents_ActionBar = 2131624315;
 			
 			// aapt resource value: 0x7F0E017C
-			public const int Widget_AppCompat_SeekBar_Discrete = 2131624316;
+			public const int ThemeOverlay_MaterialComponents_Dark = 2131624316;
 			
 			// aapt resource value: 0x7F0E017D
-			public const int Widget_AppCompat_Spinner = 2131624317;
+			public const int ThemeOverlay_MaterialComponents_Dark_ActionBar = 2131624317;
 			
 			// aapt resource value: 0x7F0E017E
-			public const int Widget_AppCompat_Spinner_DropDown = 2131624318;
+			public const int ThemeOverlay_MaterialComponents_Dialog = 2131624318;
 			
 			// aapt resource value: 0x7F0E017F
-			public const int Widget_AppCompat_Spinner_DropDown_ActionBar = 2131624319;
+			public const int ThemeOverlay_MaterialComponents_Dialog_Alert = 2131624319;
 			
 			// aapt resource value: 0x7F0E0180
-			public const int Widget_AppCompat_Spinner_Underlined = 2131624320;
+			public const int ThemeOverlay_MaterialComponents_Light = 2131624320;
 			
 			// aapt resource value: 0x7F0E0181
-			public const int Widget_AppCompat_TextView_SpinnerItem = 2131624321;
+			public const int ThemeOverlay_MaterialComponents_TextInputEditText = 2131624321;
 			
 			// aapt resource value: 0x7F0E0182
-			public const int Widget_AppCompat_Toolbar = 2131624322;
+			public const int ThemeOverlay_MaterialComponents_TextInputEditText_FilledBox = 2131624322;
 			
 			// aapt resource value: 0x7F0E0183
-			public const int Widget_AppCompat_Toolbar_Button_Navigation = 2131624323;
+			public const int ThemeOverlay_MaterialComponents_TextInputEditText_FilledBox_Dense = 2131624323;
 			
 			// aapt resource value: 0x7F0E0184
-			public const int Widget_Compat_NotificationActionContainer = 2131624324;
+			public const int ThemeOverlay_MaterialComponents_TextInputEditText_OutlinedBox = 2131624324;
 			
 			// aapt resource value: 0x7F0E0185
-			public const int Widget_Compat_NotificationActionText = 2131624325;
+			public const int ThemeOverlay_MaterialComponents_TextInputEditText_OutlinedBox_Dense = 2131624325;
 			
 			// aapt resource value: 0x7F0E0186
-			public const int Widget_Design_AppBarLayout = 2131624326;
+			public const int ThemeOverlay_MediaRouter_Dark = 2131624326;
 			
 			// aapt resource value: 0x7F0E0187
-			public const int Widget_Design_BottomNavigationView = 2131624327;
+			public const int ThemeOverlay_MediaRouter_Light = 2131624327;
+			
+			// aapt resource value: 0x7F0E013F
+			public const int Theme_AppCompat = 2131624255;
+			
+			// aapt resource value: 0x7F0E0140
+			public const int Theme_AppCompat_CompactMenu = 2131624256;
+			
+			// aapt resource value: 0x7F0E0141
+			public const int Theme_AppCompat_DayNight = 2131624257;
+			
+			// aapt resource value: 0x7F0E0142
+			public const int Theme_AppCompat_DayNight_DarkActionBar = 2131624258;
+			
+			// aapt resource value: 0x7F0E0143
+			public const int Theme_AppCompat_DayNight_Dialog = 2131624259;
+			
+			// aapt resource value: 0x7F0E0146
+			public const int Theme_AppCompat_DayNight_DialogWhenLarge = 2131624262;
+			
+			// aapt resource value: 0x7F0E0144
+			public const int Theme_AppCompat_DayNight_Dialog_Alert = 2131624260;
+			
+			// aapt resource value: 0x7F0E0145
+			public const int Theme_AppCompat_DayNight_Dialog_MinWidth = 2131624261;
+			
+			// aapt resource value: 0x7F0E0147
+			public const int Theme_AppCompat_DayNight_NoActionBar = 2131624263;
+			
+			// aapt resource value: 0x7F0E0148
+			public const int Theme_AppCompat_Dialog = 2131624264;
+			
+			// aapt resource value: 0x7F0E014B
+			public const int Theme_AppCompat_DialogWhenLarge = 2131624267;
+			
+			// aapt resource value: 0x7F0E0149
+			public const int Theme_AppCompat_Dialog_Alert = 2131624265;
+			
+			// aapt resource value: 0x7F0E014A
+			public const int Theme_AppCompat_Dialog_MinWidth = 2131624266;
+			
+			// aapt resource value: 0x7F0E014C
+			public const int Theme_AppCompat_Light = 2131624268;
+			
+			// aapt resource value: 0x7F0E014D
+			public const int Theme_AppCompat_Light_DarkActionBar = 2131624269;
+			
+			// aapt resource value: 0x7F0E014E
+			public const int Theme_AppCompat_Light_Dialog = 2131624270;
+			
+			// aapt resource value: 0x7F0E0151
+			public const int Theme_AppCompat_Light_DialogWhenLarge = 2131624273;
+			
+			// aapt resource value: 0x7F0E014F
+			public const int Theme_AppCompat_Light_Dialog_Alert = 2131624271;
+			
+			// aapt resource value: 0x7F0E0150
+			public const int Theme_AppCompat_Light_Dialog_MinWidth = 2131624272;
+			
+			// aapt resource value: 0x7F0E0152
+			public const int Theme_AppCompat_Light_NoActionBar = 2131624274;
+			
+			// aapt resource value: 0x7F0E0153
+			public const int Theme_AppCompat_NoActionBar = 2131624275;
+			
+			// aapt resource value: 0x7F0E0154
+			public const int Theme_Design = 2131624276;
+			
+			// aapt resource value: 0x7F0E0155
+			public const int Theme_Design_BottomSheetDialog = 2131624277;
+			
+			// aapt resource value: 0x7F0E0156
+			public const int Theme_Design_Light = 2131624278;
+			
+			// aapt resource value: 0x7F0E0157
+			public const int Theme_Design_Light_BottomSheetDialog = 2131624279;
+			
+			// aapt resource value: 0x7F0E0158
+			public const int Theme_Design_Light_NoActionBar = 2131624280;
+			
+			// aapt resource value: 0x7F0E0159
+			public const int Theme_Design_NoActionBar = 2131624281;
+			
+			// aapt resource value: 0x7F0E015A
+			public const int Theme_MaterialComponents = 2131624282;
+			
+			// aapt resource value: 0x7F0E015B
+			public const int Theme_MaterialComponents_BottomSheetDialog = 2131624283;
+			
+			// aapt resource value: 0x7F0E015C
+			public const int Theme_MaterialComponents_Bridge = 2131624284;
+			
+			// aapt resource value: 0x7F0E015D
+			public const int Theme_MaterialComponents_CompactMenu = 2131624285;
+			
+			// aapt resource value: 0x7F0E015E
+			public const int Theme_MaterialComponents_Dialog = 2131624286;
+			
+			// aapt resource value: 0x7F0E0161
+			public const int Theme_MaterialComponents_DialogWhenLarge = 2131624289;
+			
+			// aapt resource value: 0x7F0E015F
+			public const int Theme_MaterialComponents_Dialog_Alert = 2131624287;
+			
+			// aapt resource value: 0x7F0E0160
+			public const int Theme_MaterialComponents_Dialog_MinWidth = 2131624288;
+			
+			// aapt resource value: 0x7F0E0162
+			public const int Theme_MaterialComponents_Light = 2131624290;
+			
+			// aapt resource value: 0x7F0E0163
+			public const int Theme_MaterialComponents_Light_BottomSheetDialog = 2131624291;
+			
+			// aapt resource value: 0x7F0E0164
+			public const int Theme_MaterialComponents_Light_Bridge = 2131624292;
+			
+			// aapt resource value: 0x7F0E0165
+			public const int Theme_MaterialComponents_Light_DarkActionBar = 2131624293;
+			
+			// aapt resource value: 0x7F0E0166
+			public const int Theme_MaterialComponents_Light_DarkActionBar_Bridge = 2131624294;
+			
+			// aapt resource value: 0x7F0E0167
+			public const int Theme_MaterialComponents_Light_Dialog = 2131624295;
+			
+			// aapt resource value: 0x7F0E016A
+			public const int Theme_MaterialComponents_Light_DialogWhenLarge = 2131624298;
+			
+			// aapt resource value: 0x7F0E0168
+			public const int Theme_MaterialComponents_Light_Dialog_Alert = 2131624296;
+			
+			// aapt resource value: 0x7F0E0169
+			public const int Theme_MaterialComponents_Light_Dialog_MinWidth = 2131624297;
+			
+			// aapt resource value: 0x7F0E016B
+			public const int Theme_MaterialComponents_Light_NoActionBar = 2131624299;
+			
+			// aapt resource value: 0x7F0E016C
+			public const int Theme_MaterialComponents_Light_NoActionBar_Bridge = 2131624300;
+			
+			// aapt resource value: 0x7F0E016D
+			public const int Theme_MaterialComponents_NoActionBar = 2131624301;
+			
+			// aapt resource value: 0x7F0E016E
+			public const int Theme_MaterialComponents_NoActionBar_Bridge = 2131624302;
+			
+			// aapt resource value: 0x7F0E016F
+			public const int Theme_MediaRouter = 2131624303;
+			
+			// aapt resource value: 0x7F0E0170
+			public const int Theme_MediaRouter_Light = 2131624304;
+			
+			// aapt resource value: 0x7F0E0172
+			public const int Theme_MediaRouter_LightControlPanel = 2131624306;
+			
+			// aapt resource value: 0x7F0E0171
+			public const int Theme_MediaRouter_Light_DarkControlPanel = 2131624305;
 			
 			// aapt resource value: 0x7F0E0188
-			public const int Widget_Design_BottomSheet_Modal = 2131624328;
+			public const int Widget_AppCompat_ActionBar = 2131624328;
 			
 			// aapt resource value: 0x7F0E0189
-			public const int Widget_Design_CollapsingToolbar = 2131624329;
+			public const int Widget_AppCompat_ActionBar_Solid = 2131624329;
 			
 			// aapt resource value: 0x7F0E018A
-			public const int Widget_Design_CoordinatorLayout = 2131624330;
+			public const int Widget_AppCompat_ActionBar_TabBar = 2131624330;
 			
 			// aapt resource value: 0x7F0E018B
-			public const int Widget_Design_FloatingActionButton = 2131624331;
+			public const int Widget_AppCompat_ActionBar_TabText = 2131624331;
 			
 			// aapt resource value: 0x7F0E018C
-			public const int Widget_Design_NavigationView = 2131624332;
+			public const int Widget_AppCompat_ActionBar_TabView = 2131624332;
 			
 			// aapt resource value: 0x7F0E018D
-			public const int Widget_Design_ScrimInsetsFrameLayout = 2131624333;
+			public const int Widget_AppCompat_ActionButton = 2131624333;
 			
 			// aapt resource value: 0x7F0E018E
-			public const int Widget_Design_Snackbar = 2131624334;
+			public const int Widget_AppCompat_ActionButton_CloseMode = 2131624334;
 			
 			// aapt resource value: 0x7F0E018F
-			public const int Widget_Design_TabLayout = 2131624335;
+			public const int Widget_AppCompat_ActionButton_Overflow = 2131624335;
 			
 			// aapt resource value: 0x7F0E0190
-			public const int Widget_Design_TextInputLayout = 2131624336;
+			public const int Widget_AppCompat_ActionMode = 2131624336;
 			
 			// aapt resource value: 0x7F0E0191
-			public const int Widget_MediaRouter_Light_MediaRouteButton = 2131624337;
+			public const int Widget_AppCompat_ActivityChooserView = 2131624337;
 			
 			// aapt resource value: 0x7F0E0192
-			public const int Widget_MediaRouter_MediaRouteButton = 2131624338;
+			public const int Widget_AppCompat_AutoCompleteTextView = 2131624338;
+			
+			// aapt resource value: 0x7F0E0193
+			public const int Widget_AppCompat_Button = 2131624339;
+			
+			// aapt resource value: 0x7F0E0199
+			public const int Widget_AppCompat_ButtonBar = 2131624345;
+			
+			// aapt resource value: 0x7F0E019A
+			public const int Widget_AppCompat_ButtonBar_AlertDialog = 2131624346;
+			
+			// aapt resource value: 0x7F0E0194
+			public const int Widget_AppCompat_Button_Borderless = 2131624340;
+			
+			// aapt resource value: 0x7F0E0195
+			public const int Widget_AppCompat_Button_Borderless_Colored = 2131624341;
+			
+			// aapt resource value: 0x7F0E0196
+			public const int Widget_AppCompat_Button_ButtonBar_AlertDialog = 2131624342;
+			
+			// aapt resource value: 0x7F0E0197
+			public const int Widget_AppCompat_Button_Colored = 2131624343;
+			
+			// aapt resource value: 0x7F0E0198
+			public const int Widget_AppCompat_Button_Small = 2131624344;
+			
+			// aapt resource value: 0x7F0E019B
+			public const int Widget_AppCompat_CompoundButton_CheckBox = 2131624347;
+			
+			// aapt resource value: 0x7F0E019C
+			public const int Widget_AppCompat_CompoundButton_RadioButton = 2131624348;
+			
+			// aapt resource value: 0x7F0E019D
+			public const int Widget_AppCompat_CompoundButton_Switch = 2131624349;
+			
+			// aapt resource value: 0x7F0E019E
+			public const int Widget_AppCompat_DrawerArrowToggle = 2131624350;
+			
+			// aapt resource value: 0x7F0E019F
+			public const int Widget_AppCompat_DropDownItem_Spinner = 2131624351;
+			
+			// aapt resource value: 0x7F0E01A0
+			public const int Widget_AppCompat_EditText = 2131624352;
+			
+			// aapt resource value: 0x7F0E01A1
+			public const int Widget_AppCompat_ImageButton = 2131624353;
+			
+			// aapt resource value: 0x7F0E01A2
+			public const int Widget_AppCompat_Light_ActionBar = 2131624354;
+			
+			// aapt resource value: 0x7F0E01A3
+			public const int Widget_AppCompat_Light_ActionBar_Solid = 2131624355;
+			
+			// aapt resource value: 0x7F0E01A4
+			public const int Widget_AppCompat_Light_ActionBar_Solid_Inverse = 2131624356;
+			
+			// aapt resource value: 0x7F0E01A5
+			public const int Widget_AppCompat_Light_ActionBar_TabBar = 2131624357;
+			
+			// aapt resource value: 0x7F0E01A6
+			public const int Widget_AppCompat_Light_ActionBar_TabBar_Inverse = 2131624358;
+			
+			// aapt resource value: 0x7F0E01A7
+			public const int Widget_AppCompat_Light_ActionBar_TabText = 2131624359;
+			
+			// aapt resource value: 0x7F0E01A8
+			public const int Widget_AppCompat_Light_ActionBar_TabText_Inverse = 2131624360;
+			
+			// aapt resource value: 0x7F0E01A9
+			public const int Widget_AppCompat_Light_ActionBar_TabView = 2131624361;
+			
+			// aapt resource value: 0x7F0E01AA
+			public const int Widget_AppCompat_Light_ActionBar_TabView_Inverse = 2131624362;
+			
+			// aapt resource value: 0x7F0E01AB
+			public const int Widget_AppCompat_Light_ActionButton = 2131624363;
+			
+			// aapt resource value: 0x7F0E01AC
+			public const int Widget_AppCompat_Light_ActionButton_CloseMode = 2131624364;
+			
+			// aapt resource value: 0x7F0E01AD
+			public const int Widget_AppCompat_Light_ActionButton_Overflow = 2131624365;
+			
+			// aapt resource value: 0x7F0E01AE
+			public const int Widget_AppCompat_Light_ActionMode_Inverse = 2131624366;
+			
+			// aapt resource value: 0x7F0E01AF
+			public const int Widget_AppCompat_Light_ActivityChooserView = 2131624367;
+			
+			// aapt resource value: 0x7F0E01B0
+			public const int Widget_AppCompat_Light_AutoCompleteTextView = 2131624368;
+			
+			// aapt resource value: 0x7F0E01B1
+			public const int Widget_AppCompat_Light_DropDownItem_Spinner = 2131624369;
+			
+			// aapt resource value: 0x7F0E01B2
+			public const int Widget_AppCompat_Light_ListPopupWindow = 2131624370;
+			
+			// aapt resource value: 0x7F0E01B3
+			public const int Widget_AppCompat_Light_ListView_DropDown = 2131624371;
+			
+			// aapt resource value: 0x7F0E01B4
+			public const int Widget_AppCompat_Light_PopupMenu = 2131624372;
+			
+			// aapt resource value: 0x7F0E01B5
+			public const int Widget_AppCompat_Light_PopupMenu_Overflow = 2131624373;
+			
+			// aapt resource value: 0x7F0E01B6
+			public const int Widget_AppCompat_Light_SearchView = 2131624374;
+			
+			// aapt resource value: 0x7F0E01B7
+			public const int Widget_AppCompat_Light_Spinner_DropDown_ActionBar = 2131624375;
+			
+			// aapt resource value: 0x7F0E01B8
+			public const int Widget_AppCompat_ListMenuView = 2131624376;
+			
+			// aapt resource value: 0x7F0E01B9
+			public const int Widget_AppCompat_ListPopupWindow = 2131624377;
+			
+			// aapt resource value: 0x7F0E01BA
+			public const int Widget_AppCompat_ListView = 2131624378;
+			
+			// aapt resource value: 0x7F0E01BB
+			public const int Widget_AppCompat_ListView_DropDown = 2131624379;
+			
+			// aapt resource value: 0x7F0E01BC
+			public const int Widget_AppCompat_ListView_Menu = 2131624380;
+			
+			// aapt resource value: 0x7F0E01BD
+			public const int Widget_AppCompat_PopupMenu = 2131624381;
+			
+			// aapt resource value: 0x7F0E01BE
+			public const int Widget_AppCompat_PopupMenu_Overflow = 2131624382;
+			
+			// aapt resource value: 0x7F0E01BF
+			public const int Widget_AppCompat_PopupWindow = 2131624383;
+			
+			// aapt resource value: 0x7F0E01C0
+			public const int Widget_AppCompat_ProgressBar = 2131624384;
+			
+			// aapt resource value: 0x7F0E01C1
+			public const int Widget_AppCompat_ProgressBar_Horizontal = 2131624385;
+			
+			// aapt resource value: 0x7F0E01C2
+			public const int Widget_AppCompat_RatingBar = 2131624386;
+			
+			// aapt resource value: 0x7F0E01C3
+			public const int Widget_AppCompat_RatingBar_Indicator = 2131624387;
+			
+			// aapt resource value: 0x7F0E01C4
+			public const int Widget_AppCompat_RatingBar_Small = 2131624388;
+			
+			// aapt resource value: 0x7F0E01C5
+			public const int Widget_AppCompat_SearchView = 2131624389;
+			
+			// aapt resource value: 0x7F0E01C6
+			public const int Widget_AppCompat_SearchView_ActionBar = 2131624390;
+			
+			// aapt resource value: 0x7F0E01C7
+			public const int Widget_AppCompat_SeekBar = 2131624391;
+			
+			// aapt resource value: 0x7F0E01C8
+			public const int Widget_AppCompat_SeekBar_Discrete = 2131624392;
+			
+			// aapt resource value: 0x7F0E01C9
+			public const int Widget_AppCompat_Spinner = 2131624393;
+			
+			// aapt resource value: 0x7F0E01CA
+			public const int Widget_AppCompat_Spinner_DropDown = 2131624394;
+			
+			// aapt resource value: 0x7F0E01CB
+			public const int Widget_AppCompat_Spinner_DropDown_ActionBar = 2131624395;
+			
+			// aapt resource value: 0x7F0E01CC
+			public const int Widget_AppCompat_Spinner_Underlined = 2131624396;
+			
+			// aapt resource value: 0x7F0E01CD
+			public const int Widget_AppCompat_TextView_SpinnerItem = 2131624397;
+			
+			// aapt resource value: 0x7F0E01CE
+			public const int Widget_AppCompat_Toolbar = 2131624398;
+			
+			// aapt resource value: 0x7F0E01CF
+			public const int Widget_AppCompat_Toolbar_Button_Navigation = 2131624399;
+			
+			// aapt resource value: 0x7F0E01D0
+			public const int Widget_Compat_NotificationActionContainer = 2131624400;
+			
+			// aapt resource value: 0x7F0E01D1
+			public const int Widget_Compat_NotificationActionText = 2131624401;
+			
+			// aapt resource value: 0x7F0E01D2
+			public const int Widget_Design_AppBarLayout = 2131624402;
+			
+			// aapt resource value: 0x7F0E01D3
+			public const int Widget_Design_BottomNavigationView = 2131624403;
+			
+			// aapt resource value: 0x7F0E01D4
+			public const int Widget_Design_BottomSheet_Modal = 2131624404;
+			
+			// aapt resource value: 0x7F0E01D5
+			public const int Widget_Design_CollapsingToolbar = 2131624405;
+			
+			// aapt resource value: 0x7F0E01D6
+			public const int Widget_Design_FloatingActionButton = 2131624406;
+			
+			// aapt resource value: 0x7F0E01D7
+			public const int Widget_Design_NavigationView = 2131624407;
+			
+			// aapt resource value: 0x7F0E01D8
+			public const int Widget_Design_ScrimInsetsFrameLayout = 2131624408;
+			
+			// aapt resource value: 0x7F0E01D9
+			public const int Widget_Design_Snackbar = 2131624409;
+			
+			// aapt resource value: 0x7F0E01DA
+			public const int Widget_Design_TabLayout = 2131624410;
+			
+			// aapt resource value: 0x7F0E01DB
+			public const int Widget_Design_TextInputLayout = 2131624411;
+			
+			// aapt resource value: 0x7F0E01DC
+			public const int Widget_MaterialComponents_BottomAppBar = 2131624412;
+			
+			// aapt resource value: 0x7F0E01DD
+			public const int Widget_MaterialComponents_BottomAppBar_Colored = 2131624413;
+			
+			// aapt resource value: 0x7F0E01DE
+			public const int Widget_MaterialComponents_BottomNavigationView = 2131624414;
+			
+			// aapt resource value: 0x7F0E01DF
+			public const int Widget_MaterialComponents_BottomNavigationView_Colored = 2131624415;
+			
+			// aapt resource value: 0x7F0E01E0
+			public const int Widget_MaterialComponents_BottomSheet_Modal = 2131624416;
+			
+			// aapt resource value: 0x7F0E01E1
+			public const int Widget_MaterialComponents_Button = 2131624417;
+			
+			// aapt resource value: 0x7F0E01E2
+			public const int Widget_MaterialComponents_Button_Icon = 2131624418;
+			
+			// aapt resource value: 0x7F0E01E3
+			public const int Widget_MaterialComponents_Button_OutlinedButton = 2131624419;
+			
+			// aapt resource value: 0x7F0E01E4
+			public const int Widget_MaterialComponents_Button_OutlinedButton_Icon = 2131624420;
+			
+			// aapt resource value: 0x7F0E01E5
+			public const int Widget_MaterialComponents_Button_TextButton = 2131624421;
+			
+			// aapt resource value: 0x7F0E01E6
+			public const int Widget_MaterialComponents_Button_TextButton_Dialog = 2131624422;
+			
+			// aapt resource value: 0x7F0E01E7
+			public const int Widget_MaterialComponents_Button_TextButton_Dialog_Icon = 2131624423;
+			
+			// aapt resource value: 0x7F0E01E8
+			public const int Widget_MaterialComponents_Button_TextButton_Icon = 2131624424;
+			
+			// aapt resource value: 0x7F0E01E9
+			public const int Widget_MaterialComponents_Button_UnelevatedButton = 2131624425;
+			
+			// aapt resource value: 0x7F0E01EA
+			public const int Widget_MaterialComponents_Button_UnelevatedButton_Icon = 2131624426;
+			
+			// aapt resource value: 0x7F0E01EB
+			public const int Widget_MaterialComponents_CardView = 2131624427;
+			
+			// aapt resource value: 0x7F0E01F0
+			public const int Widget_MaterialComponents_ChipGroup = 2131624432;
+			
+			// aapt resource value: 0x7F0E01EC
+			public const int Widget_MaterialComponents_Chip_Action = 2131624428;
+			
+			// aapt resource value: 0x7F0E01ED
+			public const int Widget_MaterialComponents_Chip_Choice = 2131624429;
+			
+			// aapt resource value: 0x7F0E01EE
+			public const int Widget_MaterialComponents_Chip_Entry = 2131624430;
+			
+			// aapt resource value: 0x7F0E01EF
+			public const int Widget_MaterialComponents_Chip_Filter = 2131624431;
+			
+			// aapt resource value: 0x7F0E01F1
+			public const int Widget_MaterialComponents_FloatingActionButton = 2131624433;
+			
+			// aapt resource value: 0x7F0E01F2
+			public const int Widget_MaterialComponents_NavigationView = 2131624434;
+			
+			// aapt resource value: 0x7F0E01F3
+			public const int Widget_MaterialComponents_Snackbar = 2131624435;
+			
+			// aapt resource value: 0x7F0E01F4
+			public const int Widget_MaterialComponents_Snackbar_FullWidth = 2131624436;
+			
+			// aapt resource value: 0x7F0E01F5
+			public const int Widget_MaterialComponents_TabLayout = 2131624437;
+			
+			// aapt resource value: 0x7F0E01F6
+			public const int Widget_MaterialComponents_TabLayout_Colored = 2131624438;
+			
+			// aapt resource value: 0x7F0E01F7
+			public const int Widget_MaterialComponents_TextInputEditText_FilledBox = 2131624439;
+			
+			// aapt resource value: 0x7F0E01F8
+			public const int Widget_MaterialComponents_TextInputEditText_FilledBox_Dense = 2131624440;
+			
+			// aapt resource value: 0x7F0E01F9
+			public const int Widget_MaterialComponents_TextInputEditText_OutlinedBox = 2131624441;
+			
+			// aapt resource value: 0x7F0E01FA
+			public const int Widget_MaterialComponents_TextInputEditText_OutlinedBox_Dense = 2131624442;
+			
+			// aapt resource value: 0x7F0E01FB
+			public const int Widget_MaterialComponents_TextInputLayout_FilledBox = 2131624443;
+			
+			// aapt resource value: 0x7F0E01FC
+			public const int Widget_MaterialComponents_TextInputLayout_FilledBox_Dense = 2131624444;
+			
+			// aapt resource value: 0x7F0E01FD
+			public const int Widget_MaterialComponents_TextInputLayout_OutlinedBox = 2131624445;
+			
+			// aapt resource value: 0x7F0E01FE
+			public const int Widget_MaterialComponents_TextInputLayout_OutlinedBox_Dense = 2131624446;
+			
+			// aapt resource value: 0x7F0E01FF
+			public const int Widget_MaterialComponents_Toolbar = 2131624447;
+			
+			// aapt resource value: 0x7F0E0200
+			public const int Widget_MediaRouter_Light_MediaRouteButton = 2131624448;
+			
+			// aapt resource value: 0x7F0E0201
+			public const int Widget_MediaRouter_MediaRouteButton = 2131624449;
+			
+			// aapt resource value: 0x7F0E0202
+			public const int Widget_Support_CoordinatorLayout = 2131624450;
 			
 			static Style()
 			{
@@ -7401,37 +9249,37 @@ namespace NFCSample.Droid
 		public partial class Styleable
 		{
 			
-			// aapt resource value: { 0x7F030031,0x7F030032,0x7F030033,0x7F030066,0x7F030067,0x7F030068,0x7F030069,0x7F03006A,0x7F03006B,0x7F030077,0x7F03007B,0x7F03007C,0x7F030087,0x7F0300A8,0x7F0300A9,0x7F0300AD,0x7F0300AE,0x7F0300AF,0x7F0300B4,0x7F0300BA,0x7F0300D5,0x7F0300EB,0x7F0300FB,0x7F0300FF,0x7F030100,0x7F030124,0x7F030127,0x7F030153,0x7F03015D }
+			// aapt resource value: { 0x7F030031,0x7F030032,0x7F030033,0x7F030091,0x7F030092,0x7F030093,0x7F030094,0x7F030095,0x7F030096,0x7F0300A4,0x7F0300A9,0x7F0300AA,0x7F0300B5,0x7F0300E0,0x7F0300E5,0x7F0300EA,0x7F0300EB,0x7F0300ED,0x7F0300F7,0x7F030101,0x7F030124,0x7F03013D,0x7F03014E,0x7F030152,0x7F030153,0x7F030181,0x7F030184,0x7F0301C9,0x7F0301D3 }
 			public static int[] ActionBar = new int[] {
 					2130903089,
 					2130903090,
 					2130903091,
-					2130903142,
-					2130903143,
-					2130903144,
-					2130903145,
-					2130903146,
-					2130903147,
-					2130903159,
-					2130903163,
-					2130903164,
-					2130903175,
-					2130903208,
+					2130903185,
+					2130903186,
+					2130903187,
+					2130903188,
+					2130903189,
+					2130903190,
+					2130903204,
 					2130903209,
-					2130903213,
-					2130903214,
-					2130903215,
-					2130903220,
-					2130903226,
-					2130903253,
+					2130903210,
+					2130903221,
+					2130903264,
+					2130903269,
+					2130903274,
 					2130903275,
-					2130903291,
-					2130903295,
-					2130903296,
+					2130903277,
+					2130903287,
+					2130903297,
 					2130903332,
-					2130903335,
+					2130903357,
+					2130903374,
+					2130903378,
 					2130903379,
-					2130903389};
+					2130903425,
+					2130903428,
+					2130903497,
+					2130903507};
 			
 			// aapt resource value: { 0x10100B3 }
 			public static int[] ActionBarLayout = new int[] {
@@ -7538,14 +9386,14 @@ namespace NFCSample.Droid
 			public static int[] ActionMenuView = new int[] {
 					-1};
 			
-			// aapt resource value: { 0x7F030031,0x7F030032,0x7F030054,0x7F0300A8,0x7F030127,0x7F03015D }
+			// aapt resource value: { 0x7F030031,0x7F030032,0x7F03007E,0x7F0300E0,0x7F030184,0x7F0301D3 }
 			public static int[] ActionMode = new int[] {
 					2130903089,
 					2130903090,
-					2130903124,
-					2130903208,
-					2130903335,
-					2130903389};
+					2130903166,
+					2130903264,
+					2130903428,
+					2130903507};
 			
 			// aapt resource value: 0
 			public const int ActionMode_background = 0;
@@ -7565,10 +9413,10 @@ namespace NFCSample.Droid
 			// aapt resource value: 5
 			public const int ActionMode_titleTextStyle = 5;
 			
-			// aapt resource value: { 0x7F03008A,0x7F0300B5 }
+			// aapt resource value: { 0x7F0300BA,0x7F0300F8 }
 			public static int[] ActivityChooserView = new int[] {
-					2130903178,
-					2130903221};
+					2130903226,
+					2130903288};
 			
 			// aapt resource value: 0
 			public const int ActivityChooserView_expandActivityOverflowButtonDrawable = 0;
@@ -7576,55 +9424,125 @@ namespace NFCSample.Droid
 			// aapt resource value: 1
 			public const int ActivityChooserView_initialActivityCount = 1;
 			
-			// aapt resource value: { 0x10100F2,0x7F030046,0x7F0300CC,0x7F0300CD,0x7F0300E8,0x7F030114,0x7F030115 }
+			// aapt resource value: { 0x10100F2,0x7F030052,0x7F030053,0x7F03011B,0x7F03011C,0x7F03013A,0x7F030169,0x7F03016A }
 			public static int[] AlertDialog = new int[] {
 					16842994,
-					2130903110,
-					2130903244,
-					2130903245,
-					2130903272,
-					2130903316,
-					2130903317};
+					2130903122,
+					2130903123,
+					2130903323,
+					2130903324,
+					2130903354,
+					2130903401,
+					2130903402};
 			
 			// aapt resource value: 0
 			public const int AlertDialog_android_layout = 0;
 			
 			// aapt resource value: 1
-			public const int AlertDialog_buttonPanelSideLayout = 1;
+			public const int AlertDialog_buttonIconDimen = 1;
 			
 			// aapt resource value: 2
-			public const int AlertDialog_listItemLayout = 2;
+			public const int AlertDialog_buttonPanelSideLayout = 2;
 			
 			// aapt resource value: 3
-			public const int AlertDialog_listLayout = 3;
+			public const int AlertDialog_listItemLayout = 3;
 			
 			// aapt resource value: 4
-			public const int AlertDialog_multiChoiceItemLayout = 4;
+			public const int AlertDialog_listLayout = 4;
 			
 			// aapt resource value: 5
-			public const int AlertDialog_showTitle = 5;
+			public const int AlertDialog_multiChoiceItemLayout = 5;
 			
 			// aapt resource value: 6
-			public const int AlertDialog_singleChoiceItemLayout = 6;
+			public const int AlertDialog_showTitle = 6;
 			
-			// aapt resource value: { 0x10100D4,0x101048F,0x1010540,0x7F030087,0x7F03008B }
+			// aapt resource value: 7
+			public const int AlertDialog_singleChoiceItemLayout = 7;
+			
+			// aapt resource value: { 0x101011C,0x1010194,0x1010195,0x1010196,0x101030C,0x101030D }
+			public static int[] AnimatedStateListDrawableCompat = new int[] {
+					16843036,
+					16843156,
+					16843157,
+					16843158,
+					16843532,
+					16843533};
+			
+			// aapt resource value: 3
+			public const int AnimatedStateListDrawableCompat_android_constantSize = 3;
+			
+			// aapt resource value: 0
+			public const int AnimatedStateListDrawableCompat_android_dither = 0;
+			
+			// aapt resource value: 4
+			public const int AnimatedStateListDrawableCompat_android_enterFadeDuration = 4;
+			
+			// aapt resource value: 5
+			public const int AnimatedStateListDrawableCompat_android_exitFadeDuration = 5;
+			
+			// aapt resource value: 2
+			public const int AnimatedStateListDrawableCompat_android_variablePadding = 2;
+			
+			// aapt resource value: 1
+			public const int AnimatedStateListDrawableCompat_android_visible = 1;
+			
+			// aapt resource value: { 0x10100D0,0x1010199 }
+			public static int[] AnimatedStateListDrawableItem = new int[] {
+					16842960,
+					16843161};
+			
+			// aapt resource value: 1
+			public const int AnimatedStateListDrawableItem_android_drawable = 1;
+			
+			// aapt resource value: 0
+			public const int AnimatedStateListDrawableItem_android_id = 0;
+			
+			// aapt resource value: { 0x1010199,0x1010449,0x101044A,0x101044B }
+			public static int[] AnimatedStateListDrawableTransition = new int[] {
+					16843161,
+					16843849,
+					16843850,
+					16843851};
+			
+			// aapt resource value: 0
+			public const int AnimatedStateListDrawableTransition_android_drawable = 0;
+			
+			// aapt resource value: 2
+			public const int AnimatedStateListDrawableTransition_android_fromId = 2;
+			
+			// aapt resource value: 3
+			public const int AnimatedStateListDrawableTransition_android_reversible = 3;
+			
+			// aapt resource value: 1
+			public const int AnimatedStateListDrawableTransition_android_toId = 1;
+			
+			// aapt resource value: { 0x10100D4,0x101048F,0x1010540,0x7F0300B5,0x7F0300BB,0x7F030116 }
 			public static int[] AppBarLayout = new int[] {
 					16842964,
 					16843919,
 					16844096,
-					2130903175,
-					2130903179};
+					2130903221,
+					2130903227,
+					2130903318};
 			
-			// aapt resource value: { 0x7F03011E,0x7F03011F }
+			// aapt resource value: { 0x7F030177,0x7F030178,0x7F030179,0x7F03017A }
 			public static int[] AppBarLayoutStates = new int[] {
-					2130903326,
-					2130903327};
+					2130903415,
+					2130903416,
+					2130903417,
+					2130903418};
 			
 			// aapt resource value: 0
 			public const int AppBarLayoutStates_state_collapsed = 0;
 			
 			// aapt resource value: 1
 			public const int AppBarLayoutStates_state_collapsible = 1;
+			
+			// aapt resource value: 2
+			public const int AppBarLayoutStates_state_liftable = 2;
+			
+			// aapt resource value: 3
+			public const int AppBarLayoutStates_state_lifted = 3;
 			
 			// aapt resource value: 0
 			public const int AppBarLayout_android_background = 0;
@@ -7641,10 +9559,10 @@ namespace NFCSample.Droid
 			// aapt resource value: 4
 			public const int AppBarLayout_expanded = 4;
 			
-			// aapt resource value: { 0x7F0300C8,0x7F0300C9 }
+			// aapt resource value: { 0x7F030114,0x7F030115 }
 			public static int[] AppBarLayout_Layout = new int[] {
-					2130903240,
-					2130903241};
+					2130903316,
+					2130903317};
 			
 			// aapt resource value: 0
 			public const int AppBarLayout_Layout_layout_scrollFlags = 0;
@@ -7652,12 +9570,15 @@ namespace NFCSample.Droid
 			// aapt resource value: 1
 			public const int AppBarLayout_Layout_layout_scrollInterpolator = 1;
 			
-			// aapt resource value: { 0x1010119,0x7F03011B,0x7F030151,0x7F030152 }
+			// aapt resource value: 5
+			public const int AppBarLayout_liftOnScroll = 5;
+			
+			// aapt resource value: { 0x1010119,0x7F030174,0x7F0301C7,0x7F0301C8 }
 			public static int[] AppCompatImageView = new int[] {
 					16843033,
-					2130903323,
-					2130903377,
-					2130903378};
+					2130903412,
+					2130903495,
+					2130903496};
 			
 			// aapt resource value: 0
 			public const int AppCompatImageView_android_src = 0;
@@ -7671,12 +9592,12 @@ namespace NFCSample.Droid
 			// aapt resource value: 3
 			public const int AppCompatImageView_tintMode = 3;
 			
-			// aapt resource value: { 0x1010142,0x7F03014E,0x7F03014F,0x7F030150 }
+			// aapt resource value: { 0x1010142,0x7F0301C4,0x7F0301C5,0x7F0301C6 }
 			public static int[] AppCompatSeekBar = new int[] {
 					16843074,
-					2130903374,
-					2130903375,
-					2130903376};
+					2130903492,
+					2130903493,
+					2130903494};
 			
 			// aapt resource value: 0
 			public const int AppCompatSeekBar_android_thumb = 0;
@@ -7721,7 +9642,7 @@ namespace NFCSample.Droid
 			// aapt resource value: 0
 			public const int AppCompatTextHelper_android_textAppearance = 0;
 			
-			// aapt resource value: { 0x1010034,0x7F03002C,0x7F03002D,0x7F03002E,0x7F03002F,0x7F030030,0x7F03009B,0x7F03013D }
+			// aapt resource value: { 0x1010034,0x7F03002C,0x7F03002D,0x7F03002E,0x7F03002F,0x7F030030,0x7F0300CF,0x7F0300D2,0x7F030109,0x7F030117,0x7F0301A4 }
 			public static int[] AppCompatTextView = new int[] {
 					16842804,
 					2130903084,
@@ -7729,8 +9650,11 @@ namespace NFCSample.Droid
 					2130903086,
 					2130903087,
 					2130903088,
-					2130903195,
-					2130903357};
+					2130903247,
+					2130903250,
+					2130903305,
+					2130903319,
+					2130903460};
 			
 			// aapt resource value: 0
 			public const int AppCompatTextView_android_textAppearance = 0;
@@ -7751,12 +9675,21 @@ namespace NFCSample.Droid
 			public const int AppCompatTextView_autoSizeTextType = 5;
 			
 			// aapt resource value: 6
-			public const int AppCompatTextView_fontFamily = 6;
+			public const int AppCompatTextView_firstBaselineToTopHeight = 6;
 			
 			// aapt resource value: 7
-			public const int AppCompatTextView_textAllCaps = 7;
+			public const int AppCompatTextView_fontFamily = 7;
 			
-			// aapt resource value: { 0x1010057,0x10100AE,0x7F030000,0x7F030001,0x7F030002,0x7F030003,0x7F030004,0x7F030005,0x7F030006,0x7F030007,0x7F030008,0x7F030009,0x7F03000A,0x7F03000B,0x7F03000C,0x7F03000E,0x7F03000F,0x7F030010,0x7F030011,0x7F030012,0x7F030013,0x7F030014,0x7F030015,0x7F030016,0x7F030017,0x7F030018,0x7F030019,0x7F03001A,0x7F03001B,0x7F03001C,0x7F03001D,0x7F03001E,0x7F030021,0x7F030022,0x7F030023,0x7F030024,0x7F030025,0x7F03002B,0x7F03003D,0x7F030040,0x7F030041,0x7F030042,0x7F030043,0x7F030044,0x7F030047,0x7F030048,0x7F030051,0x7F030052,0x7F03005A,0x7F03005B,0x7F03005C,0x7F03005D,0x7F03005E,0x7F03005F,0x7F030060,0x7F030061,0x7F030062,0x7F030063,0x7F030072,0x7F030079,0x7F03007A,0x7F03007D,0x7F03007F,0x7F030082,0x7F030083,0x7F030084,0x7F030085,0x7F030086,0x7F0300AD,0x7F0300B3,0x7F0300CA,0x7F0300CB,0x7F0300CE,0x7F0300CF,0x7F0300D0,0x7F0300D1,0x7F0300D2,0x7F0300D3,0x7F0300D4,0x7F0300F2,0x7F0300F3,0x7F0300F4,0x7F0300FA,0x7F0300FC,0x7F030103,0x7F030104,0x7F030105,0x7F030106,0x7F03010D,0x7F03010E,0x7F03010F,0x7F030110,0x7F030118,0x7F030119,0x7F03012B,0x7F03013E,0x7F03013F,0x7F030140,0x7F030141,0x7F030142,0x7F030143,0x7F030144,0x7F030145,0x7F030146,0x7F030148,0x7F03015F,0x7F030160,0x7F030161,0x7F030162,0x7F030169,0x7F03016A,0x7F03016B,0x7F03016C,0x7F03016D,0x7F03016E,0x7F03016F,0x7F030170,0x7F030171,0x7F030172 }
+			// aapt resource value: 8
+			public const int AppCompatTextView_lastBaselineToBottomHeight = 8;
+			
+			// aapt resource value: 9
+			public const int AppCompatTextView_lineHeight = 9;
+			
+			// aapt resource value: 10
+			public const int AppCompatTextView_textAllCaps = 10;
+			
+			// aapt resource value: { 0x1010057,0x10100AE,0x7F030000,0x7F030001,0x7F030002,0x7F030003,0x7F030004,0x7F030005,0x7F030006,0x7F030007,0x7F030008,0x7F030009,0x7F03000A,0x7F03000B,0x7F03000C,0x7F03000E,0x7F03000F,0x7F030010,0x7F030011,0x7F030012,0x7F030013,0x7F030014,0x7F030015,0x7F030016,0x7F030017,0x7F030018,0x7F030019,0x7F03001A,0x7F03001B,0x7F03001C,0x7F03001D,0x7F03001E,0x7F030021,0x7F030022,0x7F030023,0x7F030024,0x7F030025,0x7F03002B,0x7F03003E,0x7F03004C,0x7F03004D,0x7F03004E,0x7F03004F,0x7F030050,0x7F030054,0x7F030055,0x7F03005F,0x7F030064,0x7F030084,0x7F030085,0x7F030086,0x7F030087,0x7F030088,0x7F030089,0x7F03008A,0x7F03008B,0x7F03008C,0x7F03008E,0x7F03009D,0x7F0300A6,0x7F0300A7,0x7F0300A8,0x7F0300AB,0x7F0300AD,0x7F0300B0,0x7F0300B1,0x7F0300B2,0x7F0300B3,0x7F0300B4,0x7F0300EA,0x7F0300F6,0x7F030119,0x7F03011A,0x7F03011D,0x7F03011E,0x7F03011F,0x7F030120,0x7F030121,0x7F030122,0x7F030123,0x7F030145,0x7F030146,0x7F030147,0x7F03014D,0x7F03014F,0x7F030156,0x7F030157,0x7F030158,0x7F030159,0x7F030161,0x7F030162,0x7F030163,0x7F030164,0x7F030171,0x7F030172,0x7F030188,0x7F0301AF,0x7F0301B0,0x7F0301B1,0x7F0301B2,0x7F0301B4,0x7F0301B5,0x7F0301B6,0x7F0301B7,0x7F0301BA,0x7F0301BB,0x7F0301D5,0x7F0301D6,0x7F0301D7,0x7F0301D8,0x7F0301DF,0x7F0301E1,0x7F0301E2,0x7F0301E3,0x7F0301E4,0x7F0301E5,0x7F0301E6,0x7F0301E7,0x7F0301E8,0x7F0301E9,0x7F0301EA }
 			public static int[] AppCompatTheme = new int[] {
 					16842839,
 					16842926,
@@ -7796,87 +9729,89 @@ namespace NFCSample.Droid
 					2130903076,
 					2130903077,
 					2130903083,
-					2130903101,
-					2130903104,
-					2130903105,
-					2130903106,
-					2130903107,
-					2130903108,
-					2130903111,
-					2130903112,
-					2130903121,
-					2130903122,
-					2130903130,
-					2130903131,
-					2130903132,
-					2130903133,
-					2130903134,
+					2130903102,
+					2130903116,
+					2130903117,
+					2130903118,
+					2130903119,
+					2130903120,
+					2130903124,
+					2130903125,
 					2130903135,
-					2130903136,
-					2130903137,
-					2130903138,
-					2130903139,
-					2130903154,
-					2130903161,
-					2130903162,
-					2130903165,
-					2130903167,
-					2130903170,
-					2130903171,
+					2130903140,
 					2130903172,
 					2130903173,
 					2130903174,
+					2130903175,
+					2130903176,
+					2130903177,
+					2130903178,
+					2130903179,
+					2130903180,
+					2130903182,
+					2130903197,
+					2130903206,
+					2130903207,
+					2130903208,
+					2130903211,
 					2130903213,
+					2130903216,
+					2130903217,
+					2130903218,
 					2130903219,
-					2130903242,
-					2130903243,
-					2130903246,
-					2130903247,
-					2130903248,
-					2130903249,
-					2130903250,
-					2130903251,
-					2130903252,
-					2130903282,
-					2130903283,
-					2130903284,
-					2130903290,
-					2130903292,
-					2130903299,
-					2130903300,
-					2130903301,
-					2130903302,
-					2130903309,
-					2130903310,
-					2130903311,
-					2130903312,
-					2130903320,
+					2130903220,
+					2130903274,
+					2130903286,
 					2130903321,
-					2130903339,
-					2130903358,
-					2130903359,
-					2130903360,
-					2130903361,
-					2130903362,
-					2130903363,
-					2130903364,
+					2130903322,
+					2130903325,
+					2130903326,
+					2130903327,
+					2130903328,
+					2130903329,
+					2130903330,
+					2130903331,
 					2130903365,
 					2130903366,
-					2130903368,
-					2130903391,
-					2130903392,
+					2130903367,
+					2130903373,
+					2130903375,
+					2130903382,
+					2130903383,
+					2130903384,
+					2130903385,
 					2130903393,
 					2130903394,
-					2130903401,
-					2130903402,
-					2130903403,
-					2130903404,
-					2130903405,
-					2130903406,
-					2130903407,
-					2130903408,
+					2130903395,
+					2130903396,
 					2130903409,
-					2130903410};
+					2130903410,
+					2130903432,
+					2130903471,
+					2130903472,
+					2130903473,
+					2130903474,
+					2130903476,
+					2130903477,
+					2130903478,
+					2130903479,
+					2130903482,
+					2130903483,
+					2130903509,
+					2130903510,
+					2130903511,
+					2130903512,
+					2130903519,
+					2130903521,
+					2130903522,
+					2130903523,
+					2130903524,
+					2130903525,
+					2130903526,
+					2130903527,
+					2130903528,
+					2130903529,
+					2130903530};
 			
 			// aapt resource value: 2
 			public const int AppCompatTheme_actionBarDivider = 2;
@@ -8056,192 +9991,230 @@ namespace NFCSample.Droid
 			public const int AppCompatTheme_controlBackground = 58;
 			
 			// aapt resource value: 59
-			public const int AppCompatTheme_dialogPreferredPadding = 59;
+			public const int AppCompatTheme_dialogCornerRadius = 59;
 			
 			// aapt resource value: 60
-			public const int AppCompatTheme_dialogTheme = 60;
+			public const int AppCompatTheme_dialogPreferredPadding = 60;
 			
 			// aapt resource value: 61
-			public const int AppCompatTheme_dividerHorizontal = 61;
+			public const int AppCompatTheme_dialogTheme = 61;
 			
 			// aapt resource value: 62
-			public const int AppCompatTheme_dividerVertical = 62;
-			
-			// aapt resource value: 64
-			public const int AppCompatTheme_dropdownListPreferredItemHeight = 64;
+			public const int AppCompatTheme_dividerHorizontal = 62;
 			
 			// aapt resource value: 63
-			public const int AppCompatTheme_dropDownListViewStyle = 63;
+			public const int AppCompatTheme_dividerVertical = 63;
 			
 			// aapt resource value: 65
-			public const int AppCompatTheme_editTextBackground = 65;
+			public const int AppCompatTheme_dropdownListPreferredItemHeight = 65;
+			
+			// aapt resource value: 64
+			public const int AppCompatTheme_dropDownListViewStyle = 64;
 			
 			// aapt resource value: 66
-			public const int AppCompatTheme_editTextColor = 66;
+			public const int AppCompatTheme_editTextBackground = 66;
 			
 			// aapt resource value: 67
-			public const int AppCompatTheme_editTextStyle = 67;
+			public const int AppCompatTheme_editTextColor = 67;
 			
 			// aapt resource value: 68
-			public const int AppCompatTheme_homeAsUpIndicator = 68;
+			public const int AppCompatTheme_editTextStyle = 68;
 			
 			// aapt resource value: 69
-			public const int AppCompatTheme_imageButtonStyle = 69;
+			public const int AppCompatTheme_homeAsUpIndicator = 69;
 			
 			// aapt resource value: 70
-			public const int AppCompatTheme_listChoiceBackgroundIndicator = 70;
+			public const int AppCompatTheme_imageButtonStyle = 70;
 			
 			// aapt resource value: 71
-			public const int AppCompatTheme_listDividerAlertDialog = 71;
+			public const int AppCompatTheme_listChoiceBackgroundIndicator = 71;
 			
 			// aapt resource value: 72
-			public const int AppCompatTheme_listMenuViewStyle = 72;
+			public const int AppCompatTheme_listDividerAlertDialog = 72;
 			
 			// aapt resource value: 73
-			public const int AppCompatTheme_listPopupWindowStyle = 73;
+			public const int AppCompatTheme_listMenuViewStyle = 73;
 			
 			// aapt resource value: 74
-			public const int AppCompatTheme_listPreferredItemHeight = 74;
+			public const int AppCompatTheme_listPopupWindowStyle = 74;
 			
 			// aapt resource value: 75
-			public const int AppCompatTheme_listPreferredItemHeightLarge = 75;
+			public const int AppCompatTheme_listPreferredItemHeight = 75;
 			
 			// aapt resource value: 76
-			public const int AppCompatTheme_listPreferredItemHeightSmall = 76;
+			public const int AppCompatTheme_listPreferredItemHeightLarge = 76;
 			
 			// aapt resource value: 77
-			public const int AppCompatTheme_listPreferredItemPaddingLeft = 77;
+			public const int AppCompatTheme_listPreferredItemHeightSmall = 77;
 			
 			// aapt resource value: 78
-			public const int AppCompatTheme_listPreferredItemPaddingRight = 78;
+			public const int AppCompatTheme_listPreferredItemPaddingLeft = 78;
 			
 			// aapt resource value: 79
-			public const int AppCompatTheme_panelBackground = 79;
+			public const int AppCompatTheme_listPreferredItemPaddingRight = 79;
 			
 			// aapt resource value: 80
-			public const int AppCompatTheme_panelMenuListTheme = 80;
+			public const int AppCompatTheme_panelBackground = 80;
 			
 			// aapt resource value: 81
-			public const int AppCompatTheme_panelMenuListWidth = 81;
+			public const int AppCompatTheme_panelMenuListTheme = 81;
 			
 			// aapt resource value: 82
-			public const int AppCompatTheme_popupMenuStyle = 82;
+			public const int AppCompatTheme_panelMenuListWidth = 82;
 			
 			// aapt resource value: 83
-			public const int AppCompatTheme_popupWindowStyle = 83;
+			public const int AppCompatTheme_popupMenuStyle = 83;
 			
 			// aapt resource value: 84
-			public const int AppCompatTheme_radioButtonStyle = 84;
+			public const int AppCompatTheme_popupWindowStyle = 84;
 			
 			// aapt resource value: 85
-			public const int AppCompatTheme_ratingBarStyle = 85;
+			public const int AppCompatTheme_radioButtonStyle = 85;
 			
 			// aapt resource value: 86
-			public const int AppCompatTheme_ratingBarStyleIndicator = 86;
+			public const int AppCompatTheme_ratingBarStyle = 86;
 			
 			// aapt resource value: 87
-			public const int AppCompatTheme_ratingBarStyleSmall = 87;
+			public const int AppCompatTheme_ratingBarStyleIndicator = 87;
 			
 			// aapt resource value: 88
-			public const int AppCompatTheme_searchViewStyle = 88;
+			public const int AppCompatTheme_ratingBarStyleSmall = 88;
 			
 			// aapt resource value: 89
-			public const int AppCompatTheme_seekBarStyle = 89;
+			public const int AppCompatTheme_searchViewStyle = 89;
 			
 			// aapt resource value: 90
-			public const int AppCompatTheme_selectableItemBackground = 90;
+			public const int AppCompatTheme_seekBarStyle = 90;
 			
 			// aapt resource value: 91
-			public const int AppCompatTheme_selectableItemBackgroundBorderless = 91;
+			public const int AppCompatTheme_selectableItemBackground = 91;
 			
 			// aapt resource value: 92
-			public const int AppCompatTheme_spinnerDropDownItemStyle = 92;
+			public const int AppCompatTheme_selectableItemBackgroundBorderless = 92;
 			
 			// aapt resource value: 93
-			public const int AppCompatTheme_spinnerStyle = 93;
+			public const int AppCompatTheme_spinnerDropDownItemStyle = 93;
 			
 			// aapt resource value: 94
-			public const int AppCompatTheme_switchStyle = 94;
+			public const int AppCompatTheme_spinnerStyle = 94;
 			
 			// aapt resource value: 95
-			public const int AppCompatTheme_textAppearanceLargePopupMenu = 95;
+			public const int AppCompatTheme_switchStyle = 95;
 			
 			// aapt resource value: 96
-			public const int AppCompatTheme_textAppearanceListItem = 96;
+			public const int AppCompatTheme_textAppearanceLargePopupMenu = 96;
 			
 			// aapt resource value: 97
-			public const int AppCompatTheme_textAppearanceListItemSecondary = 97;
+			public const int AppCompatTheme_textAppearanceListItem = 97;
 			
 			// aapt resource value: 98
-			public const int AppCompatTheme_textAppearanceListItemSmall = 98;
+			public const int AppCompatTheme_textAppearanceListItemSecondary = 98;
 			
 			// aapt resource value: 99
-			public const int AppCompatTheme_textAppearancePopupMenuHeader = 99;
+			public const int AppCompatTheme_textAppearanceListItemSmall = 99;
 			
 			// aapt resource value: 100
-			public const int AppCompatTheme_textAppearanceSearchResultSubtitle = 100;
+			public const int AppCompatTheme_textAppearancePopupMenuHeader = 100;
 			
 			// aapt resource value: 101
-			public const int AppCompatTheme_textAppearanceSearchResultTitle = 101;
+			public const int AppCompatTheme_textAppearanceSearchResultSubtitle = 101;
 			
 			// aapt resource value: 102
-			public const int AppCompatTheme_textAppearanceSmallPopupMenu = 102;
+			public const int AppCompatTheme_textAppearanceSearchResultTitle = 102;
 			
 			// aapt resource value: 103
-			public const int AppCompatTheme_textColorAlertDialogListItem = 103;
+			public const int AppCompatTheme_textAppearanceSmallPopupMenu = 103;
 			
 			// aapt resource value: 104
-			public const int AppCompatTheme_textColorSearchUrl = 104;
+			public const int AppCompatTheme_textColorAlertDialogListItem = 104;
 			
 			// aapt resource value: 105
-			public const int AppCompatTheme_toolbarNavigationButtonStyle = 105;
+			public const int AppCompatTheme_textColorSearchUrl = 105;
 			
 			// aapt resource value: 106
-			public const int AppCompatTheme_toolbarStyle = 106;
+			public const int AppCompatTheme_toolbarNavigationButtonStyle = 106;
 			
 			// aapt resource value: 107
-			public const int AppCompatTheme_tooltipForegroundColor = 107;
+			public const int AppCompatTheme_toolbarStyle = 107;
 			
 			// aapt resource value: 108
-			public const int AppCompatTheme_tooltipFrameBackground = 108;
+			public const int AppCompatTheme_tooltipForegroundColor = 108;
 			
 			// aapt resource value: 109
-			public const int AppCompatTheme_windowActionBar = 109;
+			public const int AppCompatTheme_tooltipFrameBackground = 109;
 			
 			// aapt resource value: 110
-			public const int AppCompatTheme_windowActionBarOverlay = 110;
+			public const int AppCompatTheme_viewInflaterClass = 110;
 			
 			// aapt resource value: 111
-			public const int AppCompatTheme_windowActionModeOverlay = 111;
+			public const int AppCompatTheme_windowActionBar = 111;
 			
 			// aapt resource value: 112
-			public const int AppCompatTheme_windowFixedHeightMajor = 112;
+			public const int AppCompatTheme_windowActionBarOverlay = 112;
 			
 			// aapt resource value: 113
-			public const int AppCompatTheme_windowFixedHeightMinor = 113;
+			public const int AppCompatTheme_windowActionModeOverlay = 113;
 			
 			// aapt resource value: 114
-			public const int AppCompatTheme_windowFixedWidthMajor = 114;
+			public const int AppCompatTheme_windowFixedHeightMajor = 114;
 			
 			// aapt resource value: 115
-			public const int AppCompatTheme_windowFixedWidthMinor = 115;
+			public const int AppCompatTheme_windowFixedHeightMinor = 115;
 			
 			// aapt resource value: 116
-			public const int AppCompatTheme_windowMinWidthMajor = 116;
+			public const int AppCompatTheme_windowFixedWidthMajor = 116;
 			
 			// aapt resource value: 117
-			public const int AppCompatTheme_windowMinWidthMinor = 117;
+			public const int AppCompatTheme_windowFixedWidthMinor = 117;
 			
 			// aapt resource value: 118
-			public const int AppCompatTheme_windowNoTitle = 118;
+			public const int AppCompatTheme_windowMinWidthMajor = 118;
 			
-			// aapt resource value: { 0x7F030087,0x7F0300B8,0x7F0300B9,0x7F0300BC,0x7F0300E7 }
+			// aapt resource value: 119
+			public const int AppCompatTheme_windowMinWidthMinor = 119;
+			
+			// aapt resource value: 120
+			public const int AppCompatTheme_windowNoTitle = 120;
+			
+			// aapt resource value: { 0x7F030034,0x7F0300C4,0x7F0300C5,0x7F0300C6,0x7F0300C7,0x7F0300E6 }
+			public static int[] BottomAppBar = new int[] {
+					2130903092,
+					2130903236,
+					2130903237,
+					2130903238,
+					2130903239,
+					2130903270};
+			
+			// aapt resource value: 0
+			public const int BottomAppBar_backgroundTint = 0;
+			
+			// aapt resource value: 1
+			public const int BottomAppBar_fabAlignmentMode = 1;
+			
+			// aapt resource value: 2
+			public const int BottomAppBar_fabCradleMargin = 2;
+			
+			// aapt resource value: 3
+			public const int BottomAppBar_fabCradleRoundedCornerRadius = 3;
+			
+			// aapt resource value: 4
+			public const int BottomAppBar_fabCradleVerticalOffset = 4;
+			
+			// aapt resource value: 5
+			public const int BottomAppBar_hideOnScroll = 5;
+			
+			// aapt resource value: { 0x7F0300B5,0x7F0300FB,0x7F0300FD,0x7F0300FF,0x7F030100,0x7F030104,0x7F030105,0x7F030106,0x7F030108,0x7F030139 }
 			public static int[] BottomNavigationView = new int[] {
-					2130903175,
-					2130903224,
-					2130903225,
-					2130903228,
-					2130903271};
+					2130903221,
+					2130903291,
+					2130903293,
+					2130903295,
+					2130903296,
+					2130903300,
+					2130903301,
+					2130903302,
+					2130903304,
+					2130903353};
 			
 			// aapt resource value: 0
 			public const int BottomNavigationView_elevation = 0;
@@ -8250,28 +10223,47 @@ namespace NFCSample.Droid
 			public const int BottomNavigationView_itemBackground = 1;
 			
 			// aapt resource value: 2
-			public const int BottomNavigationView_itemIconTint = 2;
+			public const int BottomNavigationView_itemHorizontalTranslationEnabled = 2;
 			
 			// aapt resource value: 3
-			public const int BottomNavigationView_itemTextColor = 3;
+			public const int BottomNavigationView_itemIconSize = 3;
 			
 			// aapt resource value: 4
-			public const int BottomNavigationView_menu = 4;
+			public const int BottomNavigationView_itemIconTint = 4;
 			
-			// aapt resource value: { 0x7F030038,0x7F03003A,0x7F03003B }
+			// aapt resource value: 5
+			public const int BottomNavigationView_itemTextAppearanceActive = 5;
+			
+			// aapt resource value: 6
+			public const int BottomNavigationView_itemTextAppearanceInactive = 6;
+			
+			// aapt resource value: 7
+			public const int BottomNavigationView_itemTextColor = 7;
+			
+			// aapt resource value: 8
+			public const int BottomNavigationView_labelVisibilityMode = 8;
+			
+			// aapt resource value: 9
+			public const int BottomNavigationView_menu = 9;
+			
+			// aapt resource value: { 0x7F030038,0x7F030039,0x7F03003B,0x7F03003C }
 			public static int[] BottomSheetBehavior_Layout = new int[] {
 					2130903096,
-					2130903098,
-					2130903099};
+					2130903097,
+					2130903099,
+					2130903100};
 			
 			// aapt resource value: 0
-			public const int BottomSheetBehavior_Layout_behavior_hideable = 0;
+			public const int BottomSheetBehavior_Layout_behavior_fitToContents = 0;
 			
 			// aapt resource value: 1
-			public const int BottomSheetBehavior_Layout_behavior_peekHeight = 1;
+			public const int BottomSheetBehavior_Layout_behavior_hideable = 1;
 			
 			// aapt resource value: 2
-			public const int BottomSheetBehavior_Layout_behavior_skipCollapsed = 2;
+			public const int BottomSheetBehavior_Layout_behavior_peekHeight = 2;
+			
+			// aapt resource value: 3
+			public const int BottomSheetBehavior_Layout_behavior_skipCollapsed = 3;
 			
 			// aapt resource value: { 0x7F030026 }
 			public static int[] ButtonBarLayout = new int[] {
@@ -8280,21 +10272,21 @@ namespace NFCSample.Droid
 			// aapt resource value: 0
 			public const int ButtonBarLayout_allowStacking = 0;
 			
-			// aapt resource value: { 0x101013F,0x1010140,0x7F03004B,0x7F03004C,0x7F03004D,0x7F03004E,0x7F03004F,0x7F030050,0x7F03006C,0x7F03006D,0x7F03006E,0x7F03006F,0x7F030070 }
+			// aapt resource value: { 0x101013F,0x1010140,0x7F030058,0x7F030059,0x7F03005A,0x7F03005B,0x7F03005C,0x7F03005D,0x7F030097,0x7F030098,0x7F030099,0x7F03009A,0x7F03009B }
 			public static int[] CardView = new int[] {
 					16843071,
 					16843072,
-					2130903115,
-					2130903116,
-					2130903117,
-					2130903118,
-					2130903119,
-					2130903120,
-					2130903148,
-					2130903149,
-					2130903150,
-					2130903151,
-					2130903152};
+					2130903128,
+					2130903129,
+					2130903130,
+					2130903131,
+					2130903132,
+					2130903133,
+					2130903191,
+					2130903192,
+					2130903193,
+					2130903194,
+					2130903195};
 			
 			// aapt resource value: 1
 			public const int CardView_android_minHeight = 1;
@@ -8335,24 +10327,190 @@ namespace NFCSample.Droid
 			// aapt resource value: 12
 			public const int CardView_contentPaddingTop = 12;
 			
-			// aapt resource value: { 0x7F030057,0x7F030058,0x7F030071,0x7F03008C,0x7F03008D,0x7F03008E,0x7F03008F,0x7F030090,0x7F030091,0x7F030092,0x7F030109,0x7F03010A,0x7F030121,0x7F030153,0x7F030154,0x7F03015E }
-			public static int[] CollapsingToolbarLayout = new int[] {
-					2130903127,
-					2130903128,
+			// aapt resource value: { 0x1010034,0x10100AB,0x101011F,0x101014F,0x10101E5,0x7F030061,0x7F030062,0x7F030063,0x7F030065,0x7F030066,0x7F030067,0x7F030069,0x7F03006A,0x7F03006B,0x7F03006C,0x7F03006D,0x7F03006E,0x7F030073,0x7F030074,0x7F030075,0x7F030077,0x7F030078,0x7F030079,0x7F03007A,0x7F03007B,0x7F03007C,0x7F03007D,0x7F0300E4,0x7F0300EE,0x7F0300F2,0x7F03015B,0x7F030167,0x7F0301BC,0x7F0301BE }
+			public static int[] Chip = new int[] {
+					16842804,
+					16842923,
+					16843039,
+					16843087,
+					16843237,
+					2130903137,
+					2130903138,
+					2130903139,
+					2130903141,
+					2130903142,
+					2130903143,
+					2130903145,
+					2130903146,
+					2130903147,
+					2130903148,
+					2130903149,
+					2130903150,
+					2130903155,
+					2130903156,
+					2130903157,
+					2130903159,
+					2130903160,
+					2130903161,
+					2130903162,
+					2130903163,
+					2130903164,
+					2130903165,
+					2130903268,
+					2130903278,
+					2130903282,
+					2130903387,
+					2130903399,
+					2130903484,
+					2130903486};
+			
+			// aapt resource value: { 0x7F030060,0x7F03006F,0x7F030070,0x7F030071,0x7F03016B,0x7F03016C }
+			public static int[] ChipGroup = new int[] {
+					2130903136,
+					2130903151,
+					2130903152,
 					2130903153,
-					2130903180,
-					2130903181,
-					2130903182,
-					2130903183,
-					2130903184,
-					2130903185,
-					2130903186,
-					2130903305,
-					2130903306,
-					2130903329,
-					2130903379,
-					2130903380,
-					2130903390};
+					2130903403,
+					2130903404};
+			
+			// aapt resource value: 0
+			public const int ChipGroup_checkedChip = 0;
+			
+			// aapt resource value: 1
+			public const int ChipGroup_chipSpacing = 1;
+			
+			// aapt resource value: 2
+			public const int ChipGroup_chipSpacingHorizontal = 2;
+			
+			// aapt resource value: 3
+			public const int ChipGroup_chipSpacingVertical = 3;
+			
+			// aapt resource value: 4
+			public const int ChipGroup_singleLine = 4;
+			
+			// aapt resource value: 5
+			public const int ChipGroup_singleSelection = 5;
+			
+			// aapt resource value: 4
+			public const int Chip_android_checkable = 4;
+			
+			// aapt resource value: 1
+			public const int Chip_android_ellipsize = 1;
+			
+			// aapt resource value: 2
+			public const int Chip_android_maxWidth = 2;
+			
+			// aapt resource value: 3
+			public const int Chip_android_text = 3;
+			
+			// aapt resource value: 0
+			public const int Chip_android_textAppearance = 0;
+			
+			// aapt resource value: 5
+			public const int Chip_checkedIcon = 5;
+			
+			// aapt resource value: 6
+			public const int Chip_checkedIconEnabled = 6;
+			
+			// aapt resource value: 7
+			public const int Chip_checkedIconVisible = 7;
+			
+			// aapt resource value: 8
+			public const int Chip_chipBackgroundColor = 8;
+			
+			// aapt resource value: 9
+			public const int Chip_chipCornerRadius = 9;
+			
+			// aapt resource value: 10
+			public const int Chip_chipEndPadding = 10;
+			
+			// aapt resource value: 11
+			public const int Chip_chipIcon = 11;
+			
+			// aapt resource value: 12
+			public const int Chip_chipIconEnabled = 12;
+			
+			// aapt resource value: 13
+			public const int Chip_chipIconSize = 13;
+			
+			// aapt resource value: 14
+			public const int Chip_chipIconTint = 14;
+			
+			// aapt resource value: 15
+			public const int Chip_chipIconVisible = 15;
+			
+			// aapt resource value: 16
+			public const int Chip_chipMinHeight = 16;
+			
+			// aapt resource value: 17
+			public const int Chip_chipStartPadding = 17;
+			
+			// aapt resource value: 18
+			public const int Chip_chipStrokeColor = 18;
+			
+			// aapt resource value: 19
+			public const int Chip_chipStrokeWidth = 19;
+			
+			// aapt resource value: 20
+			public const int Chip_closeIcon = 20;
+			
+			// aapt resource value: 21
+			public const int Chip_closeIconEnabled = 21;
+			
+			// aapt resource value: 22
+			public const int Chip_closeIconEndPadding = 22;
+			
+			// aapt resource value: 23
+			public const int Chip_closeIconSize = 23;
+			
+			// aapt resource value: 24
+			public const int Chip_closeIconStartPadding = 24;
+			
+			// aapt resource value: 25
+			public const int Chip_closeIconTint = 25;
+			
+			// aapt resource value: 26
+			public const int Chip_closeIconVisible = 26;
+			
+			// aapt resource value: 27
+			public const int Chip_hideMotionSpec = 27;
+			
+			// aapt resource value: 28
+			public const int Chip_iconEndPadding = 28;
+			
+			// aapt resource value: 29
+			public const int Chip_iconStartPadding = 29;
+			
+			// aapt resource value: 30
+			public const int Chip_rippleColor = 30;
+			
+			// aapt resource value: 31
+			public const int Chip_showMotionSpec = 31;
+			
+			// aapt resource value: 32
+			public const int Chip_textEndPadding = 32;
+			
+			// aapt resource value: 33
+			public const int Chip_textStartPadding = 33;
+			
+			// aapt resource value: { 0x7F030081,0x7F030082,0x7F03009C,0x7F0300BC,0x7F0300BD,0x7F0300BE,0x7F0300BF,0x7F0300C0,0x7F0300C1,0x7F0300C2,0x7F03015C,0x7F03015E,0x7F03017C,0x7F0301C9,0x7F0301CA,0x7F0301D4 }
+			public static int[] CollapsingToolbarLayout = new int[] {
+					2130903169,
+					2130903170,
+					2130903196,
+					2130903228,
+					2130903229,
+					2130903230,
+					2130903231,
+					2130903232,
+					2130903233,
+					2130903234,
+					2130903388,
+					2130903390,
+					2130903420,
+					2130903497,
+					2130903498,
+					2130903508};
 			
 			// aapt resource value: 0
 			public const int CollapsingToolbarLayout_collapsedTitleGravity = 0;
@@ -8384,10 +10542,10 @@ namespace NFCSample.Droid
 			// aapt resource value: 9
 			public const int CollapsingToolbarLayout_expandedTitleTextAppearance = 9;
 			
-			// aapt resource value: { 0x7F0300C3,0x7F0300C4 }
+			// aapt resource value: { 0x7F03010F,0x7F030110 }
 			public static int[] CollapsingToolbarLayout_Layout = new int[] {
-					2130903235,
-					2130903236};
+					2130903311,
+					2130903312};
 			
 			// aapt resource value: 0
 			public const int CollapsingToolbarLayout_Layout_layout_collapseMode = 0;
@@ -8428,11 +10586,11 @@ namespace NFCSample.Droid
 			// aapt resource value: 0
 			public const int ColorStateListItem_android_color = 0;
 			
-			// aapt resource value: { 0x1010107,0x7F030049,0x7F03004A }
+			// aapt resource value: { 0x1010107,0x7F030056,0x7F030057 }
 			public static int[] CompoundButton = new int[] {
 					16843015,
-					2130903113,
-					2130903114};
+					2130903126,
+					2130903127};
 			
 			// aapt resource value: 0
 			public const int CompoundButton_android_button = 0;
@@ -8443,23 +10601,23 @@ namespace NFCSample.Droid
 			// aapt resource value: 2
 			public const int CompoundButton_buttonTintMode = 2;
 			
-			// aapt resource value: { 0x7F0300BD,0x7F030120 }
+			// aapt resource value: { 0x7F030107,0x7F03017B }
 			public static int[] CoordinatorLayout = new int[] {
-					2130903229,
-					2130903328};
+					2130903303,
+					2130903419};
 			
 			// aapt resource value: 0
 			public const int CoordinatorLayout_keylines = 0;
 			
-			// aapt resource value: { 0x10100B3,0x7F0300C0,0x7F0300C1,0x7F0300C2,0x7F0300C5,0x7F0300C6,0x7F0300C7 }
+			// aapt resource value: { 0x10100B3,0x7F03010C,0x7F03010D,0x7F03010E,0x7F030111,0x7F030112,0x7F030113 }
 			public static int[] CoordinatorLayout_Layout = new int[] {
 					16842931,
-					2130903232,
-					2130903233,
-					2130903234,
-					2130903237,
-					2130903238,
-					2130903239};
+					2130903308,
+					2130903309,
+					2130903310,
+					2130903313,
+					2130903314,
+					2130903315};
 			
 			// aapt resource value: 0
 			public const int CoordinatorLayout_Layout_android_layout_gravity = 0;
@@ -8485,11 +10643,10 @@ namespace NFCSample.Droid
 			// aapt resource value: 1
 			public const int CoordinatorLayout_statusBarBackground = 1;
 			
-			// aapt resource value: { 0x7F03003E,0x7F03003F,0x7F030147 }
+			// aapt resource value: { 0x7F030041,0x7F030042 }
 			public static int[] DesignTheme = new int[] {
-					2130903102,
-					2130903103,
-					2130903367};
+					2130903105,
+					2130903106};
 			
 			// aapt resource value: 0
 			public const int DesignTheme_bottomSheetDialogTheme = 0;
@@ -8497,19 +10654,16 @@ namespace NFCSample.Droid
 			// aapt resource value: 1
 			public const int DesignTheme_bottomSheetStyle = 1;
 			
-			// aapt resource value: 2
-			public const int DesignTheme_textColorError = 2;
-			
-			// aapt resource value: { 0x7F030029,0x7F03002A,0x7F030036,0x7F030059,0x7F030080,0x7F0300A5,0x7F030117,0x7F03014A }
+			// aapt resource value: { 0x7F030029,0x7F03002A,0x7F030036,0x7F030083,0x7F0300AE,0x7F0300DD,0x7F030170,0x7F0301C0 }
 			public static int[] DrawerArrowToggle = new int[] {
 					2130903081,
 					2130903082,
 					2130903094,
-					2130903129,
-					2130903168,
-					2130903205,
-					2130903319,
-					2130903370};
+					2130903171,
+					2130903214,
+					2130903261,
+					2130903408,
+					2130903488};
 			
 			// aapt resource value: 0
 			public const int DrawerArrowToggle_arrowHeadLength = 0;
@@ -8535,16 +10689,21 @@ namespace NFCSample.Droid
 			// aapt resource value: 7
 			public const int DrawerArrowToggle_thickness = 7;
 			
-			// aapt resource value: { 0x7F030034,0x7F030035,0x7F03003C,0x7F030087,0x7F030094,0x7F0300FE,0x7F030108,0x7F030167 }
+			// aapt resource value: { 0x7F030034,0x7F030035,0x7F03003D,0x7F0300B5,0x7F0300C8,0x7F0300C9,0x7F0300E4,0x7F0300EC,0x7F03012A,0x7F030151,0x7F03015B,0x7F030167,0x7F0301DE }
 			public static int[] FloatingActionButton = new int[] {
 					2130903092,
 					2130903093,
-					2130903100,
-					2130903175,
-					2130903188,
-					2130903294,
-					2130903304,
-					2130903399};
+					2130903101,
+					2130903221,
+					2130903240,
+					2130903241,
+					2130903268,
+					2130903276,
+					2130903338,
+					2130903377,
+					2130903387,
+					2130903399,
+					2130903518};
 			
 			// aapt resource value: 0
 			public const int FloatingActionButton_backgroundTint = 0;
@@ -8566,34 +10725,64 @@ namespace NFCSample.Droid
 			public const int FloatingActionButton_elevation = 3;
 			
 			// aapt resource value: 4
-			public const int FloatingActionButton_fabSize = 4;
+			public const int FloatingActionButton_fabCustomSize = 4;
 			
 			// aapt resource value: 5
-			public const int FloatingActionButton_pressedTranslationZ = 5;
+			public const int FloatingActionButton_fabSize = 5;
 			
 			// aapt resource value: 6
-			public const int FloatingActionButton_rippleColor = 6;
+			public const int FloatingActionButton_hideMotionSpec = 6;
 			
 			// aapt resource value: 7
-			public const int FloatingActionButton_useCompatPadding = 7;
+			public const int FloatingActionButton_hoveredFocusedTranslationZ = 7;
 			
-			// aapt resource value: { 0x7F03009C,0x7F03009D,0x7F03009E,0x7F03009F,0x7F0300A0,0x7F0300A1 }
+			// aapt resource value: 8
+			public const int FloatingActionButton_maxImageSize = 8;
+			
+			// aapt resource value: 9
+			public const int FloatingActionButton_pressedTranslationZ = 9;
+			
+			// aapt resource value: 10
+			public const int FloatingActionButton_rippleColor = 10;
+			
+			// aapt resource value: 11
+			public const int FloatingActionButton_showMotionSpec = 11;
+			
+			// aapt resource value: 12
+			public const int FloatingActionButton_useCompatPadding = 12;
+			
+			// aapt resource value: { 0x7F030102,0x7F030118 }
+			public static int[] FlowLayout = new int[] {
+					2130903298,
+					2130903320};
+			
+			// aapt resource value: 0
+			public const int FlowLayout_itemSpacing = 0;
+			
+			// aapt resource value: 1
+			public const int FlowLayout_lineSpacing = 1;
+			
+			// aapt resource value: { 0x7F0300D3,0x7F0300D4,0x7F0300D5,0x7F0300D6,0x7F0300D7,0x7F0300D8 }
 			public static int[] FontFamily = new int[] {
-					2130903196,
-					2130903197,
-					2130903198,
-					2130903199,
-					2130903200,
-					2130903201};
+					2130903251,
+					2130903252,
+					2130903253,
+					2130903254,
+					2130903255,
+					2130903256};
 			
-			// aapt resource value: { 0x1010532,0x1010533,0x101053F,0x7F03009A,0x7F0300A2,0x7F0300A3 }
+			// aapt resource value: { 0x1010532,0x1010533,0x101053F,0x101056F,0x1010570,0x7F0300D1,0x7F0300D9,0x7F0300DA,0x7F0300DB,0x7F0301DD }
 			public static int[] FontFamilyFont = new int[] {
 					16844082,
 					16844083,
 					16844095,
-					2130903194,
-					2130903202,
-					2130903203};
+					16844143,
+					16844144,
+					2130903249,
+					2130903257,
+					2130903258,
+					2130903259,
+					2130903517};
 			
 			// aapt resource value: 0
 			public const int FontFamilyFont_android_font = 0;
@@ -8601,17 +10790,29 @@ namespace NFCSample.Droid
 			// aapt resource value: 2
 			public const int FontFamilyFont_android_fontStyle = 2;
 			
+			// aapt resource value: 4
+			public const int FontFamilyFont_android_fontVariationSettings = 4;
+			
 			// aapt resource value: 1
 			public const int FontFamilyFont_android_fontWeight = 1;
 			
 			// aapt resource value: 3
-			public const int FontFamilyFont_font = 3;
-			
-			// aapt resource value: 4
-			public const int FontFamilyFont_fontStyle = 4;
+			public const int FontFamilyFont_android_ttcIndex = 3;
 			
 			// aapt resource value: 5
-			public const int FontFamilyFont_fontWeight = 5;
+			public const int FontFamilyFont_font = 5;
+			
+			// aapt resource value: 6
+			public const int FontFamilyFont_fontStyle = 6;
+			
+			// aapt resource value: 7
+			public const int FontFamilyFont_fontVariationSettings = 7;
+			
+			// aapt resource value: 8
+			public const int FontFamilyFont_fontWeight = 8;
+			
+			// aapt resource value: 9
+			public const int FontFamilyFont_ttcIndex = 9;
 			
 			// aapt resource value: 0
 			public const int FontFamily_fontProviderAuthority = 0;
@@ -8631,11 +10832,11 @@ namespace NFCSample.Droid
 			// aapt resource value: 5
 			public const int FontFamily_fontProviderQuery = 5;
 			
-			// aapt resource value: { 0x1010109,0x1010200,0x7F0300A4 }
+			// aapt resource value: { 0x1010109,0x1010200,0x7F0300DC }
 			public static int[] ForegroundLinearLayout = new int[] {
 					16843017,
 					16843264,
-					2130903204};
+					2130903260};
 			
 			// aapt resource value: 0
 			public const int ForegroundLinearLayout_android_foreground = 0;
@@ -8646,17 +10847,79 @@ namespace NFCSample.Droid
 			// aapt resource value: 2
 			public const int ForegroundLinearLayout_foregroundInsidePadding = 2;
 			
-			// aapt resource value: { 0x10100AF,0x10100C4,0x1010126,0x1010127,0x1010128,0x7F03007C,0x7F03007E,0x7F0300D9,0x7F030112 }
+			// aapt resource value: { 0x101019D,0x101019E,0x10101A1,0x10101A2,0x10101A3,0x10101A4,0x1010201,0x101020B,0x1010510,0x1010511,0x1010512,0x1010513 }
+			public static int[] GradientColor = new int[] {
+					16843165,
+					16843166,
+					16843169,
+					16843170,
+					16843171,
+					16843172,
+					16843265,
+					16843275,
+					16844048,
+					16844049,
+					16844050,
+					16844051};
+			
+			// aapt resource value: { 0x10101A5,0x1010514 }
+			public static int[] GradientColorItem = new int[] {
+					16843173,
+					16844052};
+			
+			// aapt resource value: 0
+			public const int GradientColorItem_android_color = 0;
+			
+			// aapt resource value: 1
+			public const int GradientColorItem_android_offset = 1;
+			
+			// aapt resource value: 7
+			public const int GradientColor_android_centerColor = 7;
+			
+			// aapt resource value: 3
+			public const int GradientColor_android_centerX = 3;
+			
+			// aapt resource value: 4
+			public const int GradientColor_android_centerY = 4;
+			
+			// aapt resource value: 1
+			public const int GradientColor_android_endColor = 1;
+			
+			// aapt resource value: 10
+			public const int GradientColor_android_endX = 10;
+			
+			// aapt resource value: 11
+			public const int GradientColor_android_endY = 11;
+			
+			// aapt resource value: 5
+			public const int GradientColor_android_gradientRadius = 5;
+			
+			// aapt resource value: 0
+			public const int GradientColor_android_startColor = 0;
+			
+			// aapt resource value: 8
+			public const int GradientColor_android_startX = 8;
+			
+			// aapt resource value: 9
+			public const int GradientColor_android_startY = 9;
+			
+			// aapt resource value: 6
+			public const int GradientColor_android_tileMode = 6;
+			
+			// aapt resource value: 2
+			public const int GradientColor_android_type = 2;
+			
+			// aapt resource value: { 0x10100AF,0x10100C4,0x1010126,0x1010127,0x1010128,0x7F0300AA,0x7F0300AC,0x7F03012B,0x7F030166 }
 			public static int[] LinearLayoutCompat = new int[] {
 					16842927,
 					16842948,
 					16843046,
 					16843047,
 					16843048,
-					2130903164,
-					2130903166,
-					2130903257,
-					2130903314};
+					2130903210,
+					2130903212,
+					2130903339,
+					2130903398};
 			
 			// aapt resource value: 2
 			public const int LinearLayoutCompat_android_baselineAligned = 2;
@@ -8715,12 +10978,221 @@ namespace NFCSample.Droid
 			// aapt resource value: 1
 			public const int ListPopupWindow_android_dropDownVerticalOffset = 1;
 			
-			// aapt resource value: { 0x101013F,0x1010140,0x7F030093,0x7F0300DC }
+			// aapt resource value: { 0x10101B7,0x10101B8,0x10101B9,0x10101BA,0x7F030034,0x7F030035,0x7F03009F,0x7F0300ED,0x7F0300EF,0x7F0300F0,0x7F0300F1,0x7F0300F3,0x7F0300F4,0x7F03015B,0x7F03017D,0x7F03017E }
+			public static int[] MaterialButton = new int[] {
+					16843191,
+					16843192,
+					16843193,
+					16843194,
+					2130903092,
+					2130903093,
+					2130903199,
+					2130903277,
+					2130903279,
+					2130903280,
+					2130903281,
+					2130903283,
+					2130903284,
+					2130903387,
+					2130903421,
+					2130903422};
+			
+			// aapt resource value: 3
+			public const int MaterialButton_android_insetBottom = 3;
+			
+			// aapt resource value: 0
+			public const int MaterialButton_android_insetLeft = 0;
+			
+			// aapt resource value: 1
+			public const int MaterialButton_android_insetRight = 1;
+			
+			// aapt resource value: 2
+			public const int MaterialButton_android_insetTop = 2;
+			
+			// aapt resource value: 4
+			public const int MaterialButton_backgroundTint = 4;
+			
+			// aapt resource value: 5
+			public const int MaterialButton_backgroundTintMode = 5;
+			
+			// aapt resource value: 6
+			public const int MaterialButton_cornerRadius = 6;
+			
+			// aapt resource value: 7
+			public const int MaterialButton_icon = 7;
+			
+			// aapt resource value: 8
+			public const int MaterialButton_iconGravity = 8;
+			
+			// aapt resource value: 9
+			public const int MaterialButton_iconPadding = 9;
+			
+			// aapt resource value: 10
+			public const int MaterialButton_iconSize = 10;
+			
+			// aapt resource value: 11
+			public const int MaterialButton_iconTint = 11;
+			
+			// aapt resource value: 12
+			public const int MaterialButton_iconTintMode = 12;
+			
+			// aapt resource value: 13
+			public const int MaterialButton_rippleColor = 13;
+			
+			// aapt resource value: 14
+			public const int MaterialButton_strokeColor = 14;
+			
+			// aapt resource value: 15
+			public const int MaterialButton_strokeWidth = 15;
+			
+			// aapt resource value: { 0x7F03017D,0x7F03017E }
+			public static int[] MaterialCardView = new int[] {
+					2130903421,
+					2130903422};
+			
+			// aapt resource value: 0
+			public const int MaterialCardView_strokeColor = 0;
+			
+			// aapt resource value: 1
+			public const int MaterialCardView_strokeWidth = 1;
+			
+			// aapt resource value: { 0x7F030041,0x7F030042,0x7F030068,0x7F030072,0x7F030076,0x7F030084,0x7F030085,0x7F03008B,0x7F03008C,0x7F03008D,0x7F0300B4,0x7F0300D0,0x7F030126,0x7F030127,0x7F03013E,0x7F03015D,0x7F03016D,0x7F0301A0,0x7F0301A5,0x7F0301A6,0x7F0301A7,0x7F0301A8,0x7F0301A9,0x7F0301AA,0x7F0301AB,0x7F0301AC,0x7F0301AD,0x7F0301AE,0x7F0301B3,0x7F0301B8,0x7F0301B9,0x7F0301BD }
+			public static int[] MaterialComponentsTheme = new int[] {
+					2130903105,
+					2130903106,
+					2130903144,
+					2130903154,
+					2130903158,
+					2130903172,
+					2130903173,
+					2130903179,
+					2130903180,
+					2130903181,
+					2130903220,
+					2130903248,
+					2130903334,
+					2130903335,
+					2130903358,
+					2130903389,
+					2130903405,
+					2130903456,
+					2130903461,
+					2130903462,
+					2130903463,
+					2130903464,
+					2130903465,
+					2130903466,
+					2130903467,
+					2130903468,
+					2130903469,
+					2130903470,
+					2130903475,
+					2130903480,
+					2130903481,
+					2130903485};
+			
+			// aapt resource value: 0
+			public const int MaterialComponentsTheme_bottomSheetDialogTheme = 0;
+			
+			// aapt resource value: 1
+			public const int MaterialComponentsTheme_bottomSheetStyle = 1;
+			
+			// aapt resource value: 2
+			public const int MaterialComponentsTheme_chipGroupStyle = 2;
+			
+			// aapt resource value: 3
+			public const int MaterialComponentsTheme_chipStandaloneStyle = 3;
+			
+			// aapt resource value: 4
+			public const int MaterialComponentsTheme_chipStyle = 4;
+			
+			// aapt resource value: 5
+			public const int MaterialComponentsTheme_colorAccent = 5;
+			
+			// aapt resource value: 6
+			public const int MaterialComponentsTheme_colorBackgroundFloating = 6;
+			
+			// aapt resource value: 7
+			public const int MaterialComponentsTheme_colorPrimary = 7;
+			
+			// aapt resource value: 8
+			public const int MaterialComponentsTheme_colorPrimaryDark = 8;
+			
+			// aapt resource value: 9
+			public const int MaterialComponentsTheme_colorSecondary = 9;
+			
+			// aapt resource value: 10
+			public const int MaterialComponentsTheme_editTextStyle = 10;
+			
+			// aapt resource value: 11
+			public const int MaterialComponentsTheme_floatingActionButtonStyle = 11;
+			
+			// aapt resource value: 12
+			public const int MaterialComponentsTheme_materialButtonStyle = 12;
+			
+			// aapt resource value: 13
+			public const int MaterialComponentsTheme_materialCardViewStyle = 13;
+			
+			// aapt resource value: 14
+			public const int MaterialComponentsTheme_navigationViewStyle = 14;
+			
+			// aapt resource value: 15
+			public const int MaterialComponentsTheme_scrimBackground = 15;
+			
+			// aapt resource value: 16
+			public const int MaterialComponentsTheme_snackbarButtonStyle = 16;
+			
+			// aapt resource value: 17
+			public const int MaterialComponentsTheme_tabStyle = 17;
+			
+			// aapt resource value: 18
+			public const int MaterialComponentsTheme_textAppearanceBody1 = 18;
+			
+			// aapt resource value: 19
+			public const int MaterialComponentsTheme_textAppearanceBody2 = 19;
+			
+			// aapt resource value: 20
+			public const int MaterialComponentsTheme_textAppearanceButton = 20;
+			
+			// aapt resource value: 21
+			public const int MaterialComponentsTheme_textAppearanceCaption = 21;
+			
+			// aapt resource value: 22
+			public const int MaterialComponentsTheme_textAppearanceHeadline1 = 22;
+			
+			// aapt resource value: 23
+			public const int MaterialComponentsTheme_textAppearanceHeadline2 = 23;
+			
+			// aapt resource value: 24
+			public const int MaterialComponentsTheme_textAppearanceHeadline3 = 24;
+			
+			// aapt resource value: 25
+			public const int MaterialComponentsTheme_textAppearanceHeadline4 = 25;
+			
+			// aapt resource value: 26
+			public const int MaterialComponentsTheme_textAppearanceHeadline5 = 26;
+			
+			// aapt resource value: 27
+			public const int MaterialComponentsTheme_textAppearanceHeadline6 = 27;
+			
+			// aapt resource value: 28
+			public const int MaterialComponentsTheme_textAppearanceOverline = 28;
+			
+			// aapt resource value: 29
+			public const int MaterialComponentsTheme_textAppearanceSubtitle1 = 29;
+			
+			// aapt resource value: 30
+			public const int MaterialComponentsTheme_textAppearanceSubtitle2 = 30;
+			
+			// aapt resource value: 31
+			public const int MaterialComponentsTheme_textInputStyle = 31;
+			
+			// aapt resource value: { 0x101013F,0x1010140,0x7F0300C3,0x7F03012E }
 			public static int[] MediaRouteButton = new int[] {
 					16843071,
 					16843072,
-					2130903187,
-					2130903260};
+					2130903235,
+					2130903342};
 			
 			// aapt resource value: 1
 			public const int MediaRouteButton_android_minHeight = 1;
@@ -8761,7 +11233,7 @@ namespace NFCSample.Droid
 			// aapt resource value: 2
 			public const int MenuGroup_android_visible = 2;
 			
-			// aapt resource value: { 0x1010002,0x101000E,0x10100D0,0x1010106,0x1010194,0x10101DE,0x10101DF,0x10101E1,0x10101E2,0x10101E3,0x10101E4,0x10101E5,0x101026F,0x7F03000D,0x7F03001F,0x7F030020,0x7F030028,0x7F030065,0x7F0300B0,0x7F0300B1,0x7F0300EC,0x7F030111,0x7F030163 }
+			// aapt resource value: { 0x1010002,0x101000E,0x10100D0,0x1010106,0x1010194,0x10101DE,0x10101DF,0x10101E1,0x10101E2,0x10101E3,0x10101E4,0x10101E5,0x101026F,0x7F03000D,0x7F03001F,0x7F030020,0x7F030028,0x7F030090,0x7F0300F3,0x7F0300F4,0x7F03013F,0x7F030165,0x7F0301D9 }
 			public static int[] MenuItem = new int[] {
 					16842754,
 					16842766,
@@ -8780,12 +11252,12 @@ namespace NFCSample.Droid
 					2130903071,
 					2130903072,
 					2130903080,
-					2130903141,
-					2130903216,
-					2130903217,
-					2130903276,
-					2130903313,
-					2130903395};
+					2130903184,
+					2130903283,
+					2130903284,
+					2130903359,
+					2130903397,
+					2130903513};
 			
 			// aapt resource value: 13
 			public const int MenuItem_actionLayout = 13;
@@ -8856,7 +11328,7 @@ namespace NFCSample.Droid
 			// aapt resource value: 22
 			public const int MenuItem_tooltipText = 22;
 			
-			// aapt resource value: { 0x10100AE,0x101012C,0x101012D,0x101012E,0x101012F,0x1010130,0x1010131,0x7F0300FD,0x7F030122 }
+			// aapt resource value: { 0x10100AE,0x101012C,0x101012D,0x101012E,0x101012F,0x1010130,0x1010131,0x7F030150,0x7F03017F }
 			public static int[] MenuView = new int[] {
 					16842926,
 					16843052,
@@ -8865,8 +11337,8 @@ namespace NFCSample.Droid
 					16843055,
 					16843056,
 					16843057,
-					2130903293,
-					2130903330};
+					2130903376,
+					2130903423};
 			
 			// aapt resource value: 4
 			public const int MenuView_android_headerBackground = 4;
@@ -8895,18 +11367,20 @@ namespace NFCSample.Droid
 			// aapt resource value: 8
 			public const int MenuView_subMenuArrow = 8;
 			
-			// aapt resource value: { 0x10100D4,0x10100DD,0x101011F,0x7F030087,0x7F0300A7,0x7F0300B8,0x7F0300B9,0x7F0300BB,0x7F0300BC,0x7F0300E7 }
+			// aapt resource value: { 0x10100D4,0x10100DD,0x101011F,0x7F0300B5,0x7F0300DF,0x7F0300FB,0x7F0300FC,0x7F0300FE,0x7F030100,0x7F030103,0x7F030106,0x7F030139 }
 			public static int[] NavigationView = new int[] {
 					16842964,
 					16842973,
 					16843039,
-					2130903175,
-					2130903207,
-					2130903224,
-					2130903225,
-					2130903227,
-					2130903228,
-					2130903271};
+					2130903221,
+					2130903263,
+					2130903291,
+					2130903292,
+					2130903294,
+					2130903296,
+					2130903299,
+					2130903302,
+					2130903353};
 			
 			// aapt resource value: 0
 			public const int NavigationView_android_background = 0;
@@ -8927,26 +11401,32 @@ namespace NFCSample.Droid
 			public const int NavigationView_itemBackground = 5;
 			
 			// aapt resource value: 6
-			public const int NavigationView_itemIconTint = 6;
+			public const int NavigationView_itemHorizontalPadding = 6;
 			
 			// aapt resource value: 7
-			public const int NavigationView_itemTextAppearance = 7;
+			public const int NavigationView_itemIconPadding = 7;
 			
 			// aapt resource value: 8
-			public const int NavigationView_itemTextColor = 8;
+			public const int NavigationView_itemIconTint = 8;
 			
 			// aapt resource value: 9
-			public const int NavigationView_menu = 9;
+			public const int NavigationView_itemTextAppearance = 9;
 			
-			// aapt resource value: { 0x1010176,0x10102C9,0x7F0300ED }
+			// aapt resource value: 10
+			public const int NavigationView_itemTextColor = 10;
+			
+			// aapt resource value: 11
+			public const int NavigationView_menu = 11;
+			
+			// aapt resource value: { 0x1010176,0x10102C9,0x7F030140 }
 			public static int[] PopupWindow = new int[] {
 					16843126,
 					16843465,
-					2130903277};
+					2130903360};
 			
-			// aapt resource value: { 0x7F03011D }
+			// aapt resource value: { 0x7F030176 }
 			public static int[] PopupWindowBackgroundState = new int[] {
-					2130903325};
+					2130903414};
 			
 			// aapt resource value: 0
 			public const int PopupWindowBackgroundState_state_above_anchor = 0;
@@ -8960,10 +11440,10 @@ namespace NFCSample.Droid
 			// aapt resource value: 2
 			public const int PopupWindow_overlapAnchor = 2;
 			
-			// aapt resource value: { 0x7F0300EE,0x7F0300F1 }
+			// aapt resource value: { 0x7F030141,0x7F030144 }
 			public static int[] RecycleListView = new int[] {
-					2130903278,
-					2130903281};
+					2130903361,
+					2130903364};
 			
 			// aapt resource value: 0
 			public const int RecycleListView_paddingBottomNoButtons = 0;
@@ -8971,19 +11451,19 @@ namespace NFCSample.Droid
 			// aapt resource value: 1
 			public const int RecycleListView_paddingTopNoTitle = 1;
 			
-			// aapt resource value: { 0x10100C4,0x10100F1,0x7F030095,0x7F030096,0x7F030097,0x7F030098,0x7F030099,0x7F0300BF,0x7F030107,0x7F030116,0x7F03011C }
+			// aapt resource value: { 0x10100C4,0x10100F1,0x7F0300CA,0x7F0300CB,0x7F0300CC,0x7F0300CD,0x7F0300CE,0x7F03010B,0x7F03015A,0x7F03016F,0x7F030175 }
 			public static int[] RecyclerView = new int[] {
 					16842948,
 					16842993,
-					2130903189,
-					2130903190,
-					2130903191,
-					2130903192,
-					2130903193,
-					2130903231,
-					2130903303,
-					2130903318,
-					2130903324};
+					2130903242,
+					2130903243,
+					2130903244,
+					2130903245,
+					2130903246,
+					2130903307,
+					2130903386,
+					2130903407,
+					2130903413};
 			
 			// aapt resource value: 1
 			public const int RecyclerView_android_descendantFocusability = 1;
@@ -9018,39 +11498,39 @@ namespace NFCSample.Droid
 			// aapt resource value: 10
 			public const int RecyclerView_stackFromEnd = 10;
 			
-			// aapt resource value: { 0x7F0300B6 }
+			// aapt resource value: { 0x7F0300F9 }
 			public static int[] ScrimInsetsFrameLayout = new int[] {
-					2130903222};
+					2130903289};
 			
 			// aapt resource value: 0
 			public const int ScrimInsetsFrameLayout_insetForeground = 0;
 			
-			// aapt resource value: { 0x7F030039 }
+			// aapt resource value: { 0x7F03003A }
 			public static int[] ScrollingViewBehavior_Layout = new int[] {
-					2130903097};
+					2130903098};
 			
 			// aapt resource value: 0
 			public const int ScrollingViewBehavior_Layout_behavior_overlapTop = 0;
 			
-			// aapt resource value: { 0x10100DA,0x101011F,0x1010220,0x1010264,0x7F030053,0x7F030064,0x7F030078,0x7F0300A6,0x7F0300B2,0x7F0300BE,0x7F030101,0x7F030102,0x7F03010B,0x7F03010C,0x7F030123,0x7F030128,0x7F030168 }
+			// aapt resource value: { 0x10100DA,0x101011F,0x1010220,0x1010264,0x7F030077,0x7F03008F,0x7F0300A5,0x7F0300DE,0x7F0300F5,0x7F03010A,0x7F030154,0x7F030155,0x7F03015F,0x7F030160,0x7F030180,0x7F030185,0x7F0301E0 }
 			public static int[] SearchView = new int[] {
 					16842970,
 					16843039,
 					16843296,
 					16843364,
-					2130903123,
-					2130903140,
-					2130903160,
-					2130903206,
-					2130903218,
-					2130903230,
-					2130903297,
-					2130903298,
-					2130903307,
-					2130903308,
-					2130903331,
-					2130903336,
-					2130903400};
+					2130903159,
+					2130903183,
+					2130903205,
+					2130903262,
+					2130903285,
+					2130903306,
+					2130903380,
+					2130903381,
+					2130903391,
+					2130903392,
+					2130903424,
+					2130903429,
+					2130903520};
 			
 			// aapt resource value: 0
 			public const int SearchView_android_focusable = 0;
@@ -9103,11 +11583,16 @@ namespace NFCSample.Droid
 			// aapt resource value: 16
 			public const int SearchView_voiceIcon = 16;
 			
-			// aapt resource value: { 0x101011F,0x7F030087,0x7F0300D7 }
+			// aapt resource value: { 0x7F03016D,0x7F03016E }
+			public static int[] Snackbar = new int[] {
+					2130903405,
+					2130903406};
+			
+			// aapt resource value: { 0x101011F,0x7F0300B5,0x7F030128 }
 			public static int[] SnackbarLayout = new int[] {
 					16843039,
-					2130903175,
-					2130903255};
+					2130903221,
+					2130903336};
 			
 			// aapt resource value: 0
 			public const int SnackbarLayout_android_maxWidth = 0;
@@ -9118,13 +11603,19 @@ namespace NFCSample.Droid
 			// aapt resource value: 2
 			public const int SnackbarLayout_maxActionInlineWidth = 2;
 			
-			// aapt resource value: { 0x10100B2,0x1010176,0x101017B,0x1010262,0x7F0300FB }
+			// aapt resource value: 0
+			public const int Snackbar_snackbarButtonStyle = 0;
+			
+			// aapt resource value: 1
+			public const int Snackbar_snackbarStyle = 1;
+			
+			// aapt resource value: { 0x10100B2,0x1010176,0x101017B,0x1010262,0x7F03014E }
 			public static int[] Spinner = new int[] {
 					16842930,
 					16843126,
 					16843131,
 					16843362,
-					2130903291};
+					2130903374};
 			
 			// aapt resource value: 3
 			public const int Spinner_android_dropDownWidth = 3;
@@ -9141,22 +11632,56 @@ namespace NFCSample.Droid
 			// aapt resource value: 4
 			public const int Spinner_popupTheme = 4;
 			
-			// aapt resource value: { 0x1010124,0x1010125,0x1010142,0x7F030113,0x7F03011A,0x7F030129,0x7F03012A,0x7F03012C,0x7F03014B,0x7F03014C,0x7F03014D,0x7F030164,0x7F030165,0x7F030166 }
+			// aapt resource value: { 0x101011C,0x1010194,0x1010195,0x1010196,0x101030C,0x101030D }
+			public static int[] StateListDrawable = new int[] {
+					16843036,
+					16843156,
+					16843157,
+					16843158,
+					16843532,
+					16843533};
+			
+			// aapt resource value: { 0x1010199 }
+			public static int[] StateListDrawableItem = new int[] {
+					16843161};
+			
+			// aapt resource value: 0
+			public const int StateListDrawableItem_android_drawable = 0;
+			
+			// aapt resource value: 3
+			public const int StateListDrawable_android_constantSize = 3;
+			
+			// aapt resource value: 0
+			public const int StateListDrawable_android_dither = 0;
+			
+			// aapt resource value: 4
+			public const int StateListDrawable_android_enterFadeDuration = 4;
+			
+			// aapt resource value: 5
+			public const int StateListDrawable_android_exitFadeDuration = 5;
+			
+			// aapt resource value: 2
+			public const int StateListDrawable_android_variablePadding = 2;
+			
+			// aapt resource value: 1
+			public const int StateListDrawable_android_visible = 1;
+			
+			// aapt resource value: { 0x1010124,0x1010125,0x1010142,0x7F030168,0x7F030173,0x7F030186,0x7F030187,0x7F030189,0x7F0301C1,0x7F0301C2,0x7F0301C3,0x7F0301DA,0x7F0301DB,0x7F0301DC }
 			public static int[] SwitchCompat = new int[] {
 					16843044,
 					16843045,
 					16843074,
-					2130903315,
-					2130903322,
-					2130903337,
-					2130903338,
-					2130903340,
-					2130903371,
-					2130903372,
-					2130903373,
-					2130903396,
-					2130903397,
-					2130903398};
+					2130903400,
+					2130903411,
+					2130903430,
+					2130903431,
+					2130903433,
+					2130903489,
+					2130903490,
+					2130903491,
+					2130903514,
+					2130903515,
+					2130903516};
 			
 			// aapt resource value: 1
 			public const int SwitchCompat_android_textOff = 1;
@@ -9215,24 +11740,33 @@ namespace NFCSample.Droid
 			// aapt resource value: 2
 			public const int TabItem_android_text = 2;
 			
-			// aapt resource value: { 0x7F03012D,0x7F03012E,0x7F03012F,0x7F030130,0x7F030131,0x7F030132,0x7F030133,0x7F030134,0x7F030135,0x7F030136,0x7F030137,0x7F030138,0x7F030139,0x7F03013A,0x7F03013B,0x7F03013C }
+			// aapt resource value: { 0x7F03018A,0x7F03018B,0x7F03018C,0x7F03018D,0x7F03018E,0x7F03018F,0x7F030190,0x7F030191,0x7F030192,0x7F030193,0x7F030194,0x7F030195,0x7F030196,0x7F030197,0x7F030198,0x7F030199,0x7F03019A,0x7F03019B,0x7F03019C,0x7F03019D,0x7F03019E,0x7F03019F,0x7F0301A1,0x7F0301A2,0x7F0301A3 }
 			public static int[] TabLayout = new int[] {
-					2130903341,
-					2130903342,
-					2130903343,
-					2130903344,
-					2130903345,
-					2130903346,
-					2130903347,
-					2130903348,
-					2130903349,
-					2130903350,
-					2130903351,
-					2130903352,
-					2130903353,
-					2130903354,
-					2130903355,
-					2130903356};
+					2130903434,
+					2130903435,
+					2130903436,
+					2130903437,
+					2130903438,
+					2130903439,
+					2130903440,
+					2130903441,
+					2130903442,
+					2130903443,
+					2130903444,
+					2130903445,
+					2130903446,
+					2130903447,
+					2130903448,
+					2130903449,
+					2130903450,
+					2130903451,
+					2130903452,
+					2130903453,
+					2130903454,
+					2130903455,
+					2130903457,
+					2130903458,
+					2130903459};
 			
 			// aapt resource value: 0
 			public const int TabLayout_tabBackground = 0;
@@ -9244,45 +11778,72 @@ namespace NFCSample.Droid
 			public const int TabLayout_tabGravity = 2;
 			
 			// aapt resource value: 3
-			public const int TabLayout_tabIndicatorColor = 3;
+			public const int TabLayout_tabIconTint = 3;
 			
 			// aapt resource value: 4
-			public const int TabLayout_tabIndicatorHeight = 4;
+			public const int TabLayout_tabIconTintMode = 4;
 			
 			// aapt resource value: 5
-			public const int TabLayout_tabMaxWidth = 5;
+			public const int TabLayout_tabIndicator = 5;
 			
 			// aapt resource value: 6
-			public const int TabLayout_tabMinWidth = 6;
+			public const int TabLayout_tabIndicatorAnimationDuration = 6;
 			
 			// aapt resource value: 7
-			public const int TabLayout_tabMode = 7;
+			public const int TabLayout_tabIndicatorColor = 7;
 			
 			// aapt resource value: 8
-			public const int TabLayout_tabPadding = 8;
+			public const int TabLayout_tabIndicatorFullWidth = 8;
 			
 			// aapt resource value: 9
-			public const int TabLayout_tabPaddingBottom = 9;
+			public const int TabLayout_tabIndicatorGravity = 9;
 			
 			// aapt resource value: 10
-			public const int TabLayout_tabPaddingEnd = 10;
+			public const int TabLayout_tabIndicatorHeight = 10;
 			
 			// aapt resource value: 11
-			public const int TabLayout_tabPaddingStart = 11;
+			public const int TabLayout_tabInlineLabel = 11;
 			
 			// aapt resource value: 12
-			public const int TabLayout_tabPaddingTop = 12;
+			public const int TabLayout_tabMaxWidth = 12;
 			
 			// aapt resource value: 13
-			public const int TabLayout_tabSelectedTextColor = 13;
+			public const int TabLayout_tabMinWidth = 13;
 			
 			// aapt resource value: 14
-			public const int TabLayout_tabTextAppearance = 14;
+			public const int TabLayout_tabMode = 14;
 			
 			// aapt resource value: 15
-			public const int TabLayout_tabTextColor = 15;
+			public const int TabLayout_tabPadding = 15;
 			
-			// aapt resource value: { 0x1010095,0x1010096,0x1010097,0x1010098,0x101009A,0x101009B,0x1010161,0x1010162,0x1010163,0x1010164,0x10103AC,0x7F03009B,0x7F03013D }
+			// aapt resource value: 16
+			public const int TabLayout_tabPaddingBottom = 16;
+			
+			// aapt resource value: 17
+			public const int TabLayout_tabPaddingEnd = 17;
+			
+			// aapt resource value: 18
+			public const int TabLayout_tabPaddingStart = 18;
+			
+			// aapt resource value: 19
+			public const int TabLayout_tabPaddingTop = 19;
+			
+			// aapt resource value: 20
+			public const int TabLayout_tabRippleColor = 20;
+			
+			// aapt resource value: 21
+			public const int TabLayout_tabSelectedTextColor = 21;
+			
+			// aapt resource value: 22
+			public const int TabLayout_tabTextAppearance = 22;
+			
+			// aapt resource value: 23
+			public const int TabLayout_tabTextColor = 23;
+			
+			// aapt resource value: 24
+			public const int TabLayout_tabUnboundedRipple = 24;
+			
+			// aapt resource value: { 0x1010095,0x1010096,0x1010097,0x1010098,0x101009A,0x101009B,0x1010161,0x1010162,0x1010163,0x1010164,0x10103AC,0x7F0300D2,0x7F0301A4 }
 			public static int[] TextAppearance = new int[] {
 					16842901,
 					16842902,
@@ -9295,8 +11856,8 @@ namespace NFCSample.Droid
 					16843107,
 					16843108,
 					16843692,
-					2130903195,
-					2130903357};
+					2130903250,
+					2130903460};
 			
 			// aapt resource value: 10
 			public const int TextAppearance_android_fontFamily = 10;
@@ -9337,24 +11898,36 @@ namespace NFCSample.Droid
 			// aapt resource value: 12
 			public const int TextAppearance_textAllCaps = 12;
 			
-			// aapt resource value: { 0x101009A,0x1010150,0x7F030073,0x7F030074,0x7F030075,0x7F030076,0x7F030088,0x7F030089,0x7F0300AA,0x7F0300AB,0x7F0300AC,0x7F0300F5,0x7F0300F6,0x7F0300F7,0x7F0300F8,0x7F0300F9 }
+			// aapt resource value: { 0x101009A,0x1010150,0x7F030043,0x7F030044,0x7F030045,0x7F030046,0x7F030047,0x7F030048,0x7F030049,0x7F03004A,0x7F03004B,0x7F0300A0,0x7F0300A1,0x7F0300A2,0x7F0300A3,0x7F0300B8,0x7F0300B9,0x7F0300E1,0x7F0300E2,0x7F0300E3,0x7F0300E7,0x7F0300E8,0x7F0300E9,0x7F030148,0x7F030149,0x7F03014A,0x7F03014B,0x7F03014C }
 			public static int[] TextInputLayout = new int[] {
 					16842906,
 					16843088,
-					2130903155,
-					2130903156,
-					2130903157,
-					2130903158,
-					2130903176,
-					2130903177,
-					2130903210,
-					2130903211,
-					2130903212,
-					2130903285,
-					2130903286,
-					2130903287,
-					2130903288,
-					2130903289};
+					2130903107,
+					2130903108,
+					2130903109,
+					2130903110,
+					2130903111,
+					2130903112,
+					2130903113,
+					2130903114,
+					2130903115,
+					2130903200,
+					2130903201,
+					2130903202,
+					2130903203,
+					2130903224,
+					2130903225,
+					2130903265,
+					2130903266,
+					2130903267,
+					2130903271,
+					2130903272,
+					2130903273,
+					2130903368,
+					2130903369,
+					2130903370,
+					2130903371,
+					2130903372};
 			
 			// aapt resource value: 1
 			public const int TextInputLayout_android_hint = 1;
@@ -9363,78 +11936,129 @@ namespace NFCSample.Droid
 			public const int TextInputLayout_android_textColorHint = 0;
 			
 			// aapt resource value: 2
-			public const int TextInputLayout_counterEnabled = 2;
+			public const int TextInputLayout_boxBackgroundColor = 2;
 			
 			// aapt resource value: 3
-			public const int TextInputLayout_counterMaxLength = 3;
+			public const int TextInputLayout_boxBackgroundMode = 3;
 			
 			// aapt resource value: 4
-			public const int TextInputLayout_counterOverflowTextAppearance = 4;
+			public const int TextInputLayout_boxCollapsedPaddingTop = 4;
 			
 			// aapt resource value: 5
-			public const int TextInputLayout_counterTextAppearance = 5;
+			public const int TextInputLayout_boxCornerRadiusBottomEnd = 5;
 			
 			// aapt resource value: 6
-			public const int TextInputLayout_errorEnabled = 6;
+			public const int TextInputLayout_boxCornerRadiusBottomStart = 6;
 			
 			// aapt resource value: 7
-			public const int TextInputLayout_errorTextAppearance = 7;
+			public const int TextInputLayout_boxCornerRadiusTopEnd = 7;
 			
 			// aapt resource value: 8
-			public const int TextInputLayout_hintAnimationEnabled = 8;
+			public const int TextInputLayout_boxCornerRadiusTopStart = 8;
 			
 			// aapt resource value: 9
-			public const int TextInputLayout_hintEnabled = 9;
+			public const int TextInputLayout_boxStrokeColor = 9;
 			
 			// aapt resource value: 10
-			public const int TextInputLayout_hintTextAppearance = 10;
+			public const int TextInputLayout_boxStrokeWidth = 10;
 			
 			// aapt resource value: 11
-			public const int TextInputLayout_passwordToggleContentDescription = 11;
+			public const int TextInputLayout_counterEnabled = 11;
 			
 			// aapt resource value: 12
-			public const int TextInputLayout_passwordToggleDrawable = 12;
+			public const int TextInputLayout_counterMaxLength = 12;
 			
 			// aapt resource value: 13
-			public const int TextInputLayout_passwordToggleEnabled = 13;
+			public const int TextInputLayout_counterOverflowTextAppearance = 13;
 			
 			// aapt resource value: 14
-			public const int TextInputLayout_passwordToggleTint = 14;
+			public const int TextInputLayout_counterTextAppearance = 14;
 			
 			// aapt resource value: 15
-			public const int TextInputLayout_passwordToggleTintMode = 15;
+			public const int TextInputLayout_errorEnabled = 15;
 			
-			// aapt resource value: { 0x10100AF,0x1010140,0x7F030045,0x7F030055,0x7F030056,0x7F030066,0x7F030067,0x7F030068,0x7F030069,0x7F03006A,0x7F03006B,0x7F0300D5,0x7F0300D6,0x7F0300D8,0x7F0300E9,0x7F0300EA,0x7F0300FB,0x7F030124,0x7F030125,0x7F030126,0x7F030153,0x7F030155,0x7F030156,0x7F030157,0x7F030158,0x7F030159,0x7F03015A,0x7F03015B,0x7F03015C }
+			// aapt resource value: 16
+			public const int TextInputLayout_errorTextAppearance = 16;
+			
+			// aapt resource value: 17
+			public const int TextInputLayout_helperText = 17;
+			
+			// aapt resource value: 18
+			public const int TextInputLayout_helperTextEnabled = 18;
+			
+			// aapt resource value: 19
+			public const int TextInputLayout_helperTextTextAppearance = 19;
+			
+			// aapt resource value: 20
+			public const int TextInputLayout_hintAnimationEnabled = 20;
+			
+			// aapt resource value: 21
+			public const int TextInputLayout_hintEnabled = 21;
+			
+			// aapt resource value: 22
+			public const int TextInputLayout_hintTextAppearance = 22;
+			
+			// aapt resource value: 23
+			public const int TextInputLayout_passwordToggleContentDescription = 23;
+			
+			// aapt resource value: 24
+			public const int TextInputLayout_passwordToggleDrawable = 24;
+			
+			// aapt resource value: 25
+			public const int TextInputLayout_passwordToggleEnabled = 25;
+			
+			// aapt resource value: 26
+			public const int TextInputLayout_passwordToggleTint = 26;
+			
+			// aapt resource value: 27
+			public const int TextInputLayout_passwordToggleTintMode = 27;
+			
+			// aapt resource value: { 0x1010034,0x7F0300B6,0x7F0300B7 }
+			public static int[] ThemeEnforcement = new int[] {
+					16842804,
+					2130903222,
+					2130903223};
+			
+			// aapt resource value: 0
+			public const int ThemeEnforcement_android_textAppearance = 0;
+			
+			// aapt resource value: 1
+			public const int ThemeEnforcement_enforceMaterialTheme = 1;
+			
+			// aapt resource value: 2
+			public const int ThemeEnforcement_enforceTextAppearance = 2;
+			
+			// aapt resource value: { 0x10100AF,0x1010140,0x7F030051,0x7F03007F,0x7F030080,0x7F030091,0x7F030092,0x7F030093,0x7F030094,0x7F030095,0x7F030096,0x7F030124,0x7F030125,0x7F030129,0x7F03013B,0x7F03013C,0x7F03014E,0x7F030181,0x7F030182,0x7F030183,0x7F0301C9,0x7F0301CB,0x7F0301CC,0x7F0301CD,0x7F0301CE,0x7F0301CF,0x7F0301D0,0x7F0301D1,0x7F0301D2 }
 			public static int[] Toolbar = new int[] {
 					16842927,
 					16843072,
-					2130903109,
-					2130903125,
-					2130903126,
-					2130903142,
-					2130903143,
-					2130903144,
-					2130903145,
-					2130903146,
-					2130903147,
-					2130903253,
-					2130903254,
-					2130903256,
-					2130903273,
-					2130903274,
-					2130903291,
+					2130903121,
+					2130903167,
+					2130903168,
+					2130903185,
+					2130903186,
+					2130903187,
+					2130903188,
+					2130903189,
+					2130903190,
 					2130903332,
 					2130903333,
-					2130903334,
-					2130903379,
-					2130903381,
-					2130903382,
-					2130903383,
-					2130903384,
-					2130903385,
-					2130903386,
-					2130903387,
-					2130903388};
+					2130903337,
+					2130903355,
+					2130903356,
+					2130903374,
+					2130903425,
+					2130903426,
+					2130903427,
+					2130903497,
+					2130903499,
+					2130903500,
+					2130903501,
+					2130903502,
+					2130903503,
+					2130903504,
+					2130903505,
+					2130903506};
 			
 			// aapt resource value: 0
 			public const int Toolbar_android_gravity = 0;
@@ -9523,13 +12147,13 @@ namespace NFCSample.Droid
 			// aapt resource value: 28
 			public const int Toolbar_titleTextColor = 28;
 			
-			// aapt resource value: { 0x1010000,0x10100DA,0x7F0300EF,0x7F0300F0,0x7F030149 }
+			// aapt resource value: { 0x1010000,0x10100DA,0x7F030142,0x7F030143,0x7F0301BF }
 			public static int[] View = new int[] {
 					16842752,
 					16842970,
-					2130903279,
-					2130903280,
-					2130903369};
+					2130903362,
+					2130903363,
+					2130903487};
 			
 			// aapt resource value: { 0x10100D4,0x7F030034,0x7F030035 }
 			public static int[] ViewBackgroundHelper = new int[] {

--- a/src/Plugin.NFC.Sample/Plugin.NFC.Sample/MainPage.xaml
+++ b/src/Plugin.NFC.Sample/Plugin.NFC.Sample/MainPage.xaml
@@ -27,6 +27,10 @@
                     IsEnabled="{Binding NfcIsEnabled}"
                     Text="Read Tag" />
 
+            <Button Clicked="Button_Clicked_StopListening"
+                    IsEnabled="{Binding NfcIsEnabled}"
+                    Text="Stop Listener" />
+
             <Frame BorderColor="Gray" HasShadow="False">
                 <StackLayout>
 
@@ -68,16 +72,15 @@
 
             <Label Margin="0,6,0,0"
                    Padding="12,6"
-                   BackgroundColor="Red"
-                   FontAttributes="Bold"
+                   BackgroundColor="Blue"
                    HorizontalOptions="CenterAndExpand"
                    IsVisible="{Binding DeviceIsListening}"
                    Text="Listening for NFC Tag..."
-				   FontAttributes="Bold"
-                   TextColor="Blue"/>
+                   TextColor="White" />
 
-			<Label Margin="0,6,0,0"
-				   Padding="12,6"
+            <Label Margin="0,6,0,0"
+                   Padding="12,6"
+                   BackgroundColor="Red"
                    HorizontalOptions="CenterAndExpand"
                    IsVisible="{Binding NfcIsDisabled}"
                    Text="NFC IS DISABLED"

--- a/src/Plugin.NFC.Sample/Plugin.NFC.Sample/MainPage.xaml
+++ b/src/Plugin.NFC.Sample/Plugin.NFC.Sample/MainPage.xaml
@@ -71,6 +71,14 @@
                    BackgroundColor="Red"
                    FontAttributes="Bold"
                    HorizontalOptions="CenterAndExpand"
+                   IsVisible="{Binding DeviceIsListening}"
+                   Text="Listening for NFC Tag..."
+				   FontAttributes="Bold"
+                   TextColor="Blue"/>
+
+			<Label Margin="0,6,0,0"
+				   Padding="12,6"
+                   HorizontalOptions="CenterAndExpand"
                    IsVisible="{Binding NfcIsDisabled}"
                    Text="NFC IS DISABLED"
                    TextColor="White" />

--- a/src/Plugin.NFC.Sample/Plugin.NFC.Sample/MainPage.xaml.cs
+++ b/src/Plugin.NFC.Sample/Plugin.NFC.Sample/MainPage.xaml.cs
@@ -23,7 +23,7 @@ namespace NFCSample
 		/// </summary>
 		public bool DeviceIsListening
 		{
-			get => _deviceIsListening && NfcIsEnabled;
+			get => _deviceIsListening;
 			set
 			{
 				_deviceIsListening = value;
@@ -115,6 +115,7 @@ namespace NFCSample
 			CrossNFC.Current.OnMessagePublished += Current_OnMessagePublished;
 			CrossNFC.Current.OnTagDiscovered += Current_OnTagDiscovered;
 			CrossNFC.Current.OnNfcStatusChanged += Current_OnNfcStatusChanged;
+			CrossNFC.Current.OnTagListeningStatusChanged += Current_OnTagListeningStatusChanged;
 
 			if (_isDeviceiOS)
 				CrossNFC.Current.OniOSReadingSessionCancelled += Current_OniOSReadingSessionCancelled;
@@ -129,10 +130,17 @@ namespace NFCSample
 			CrossNFC.Current.OnMessagePublished -= Current_OnMessagePublished;
 			CrossNFC.Current.OnTagDiscovered -= Current_OnTagDiscovered;
 			CrossNFC.Current.OnNfcStatusChanged -= Current_OnNfcStatusChanged;
+			CrossNFC.Current.OnTagListeningStatusChanged += Current_OnTagListeningStatusChanged;
 
 			if (_isDeviceiOS)
 				CrossNFC.Current.OniOSReadingSessionCancelled -= Current_OniOSReadingSessionCancelled;
 		}
+
+		/// <summary>
+		/// Event raised when Listener Status has changed
+		/// </summary>
+		/// <param name="isListening"></param>
+		void Current_OnTagListeningStatusChanged(bool isListening) => DeviceIsListening = isListening;
 
 		/// <summary>
 		/// Event raised when NFC Status has changed
@@ -174,7 +182,6 @@ namespace NFCSample
 				var first = tagInfo.Records[0];
 				await ShowAlert(GetMessage(first), title);
 			}
-			DeviceIsListening = false;
 		}
 
 		/// <summary>
@@ -266,7 +273,6 @@ namespace NFCSample
 			{
 				await ShowAlert(ex.Message);
 			}
-			DeviceIsListening = false;
 		}
 
 		/// <summary>
@@ -275,6 +281,13 @@ namespace NFCSample
 		/// <param name="sender"></param>
 		/// <param name="e"></param>
 		async void Button_Clicked_StartListening(object sender, System.EventArgs e) => await BeginListening();
+
+		/// <summary>
+		/// Stop listening for NFC tags
+		/// </summary>
+		/// <param name="sender"></param>
+		/// <param name="e"></param>
+		async void Button_Clicked_StopListening(object sender, System.EventArgs e) => await StopListening();
 
 		/// <summary>
 		/// Start publish operation to write the tag (TEXT) when <see cref="Current_OnTagDiscovered(ITagInfo, bool)"/> event will be raised
@@ -388,10 +401,25 @@ namespace NFCSample
 		/// <returns>The task to be performed</returns>
 		async Task BeginListening()
 		{
-			DeviceIsListening = true;
 			try
 			{
 				CrossNFC.Current.StartListening();
+			}
+			catch (Exception ex)
+			{
+				await ShowAlert(ex.Message);
+			}
+		}
+
+		/// <summary>
+		/// Task to safely stop listening for NFC tags
+		/// </summary>
+		/// <returns>The task to be performed</returns>
+		async Task StopListening()
+		{
+			try
+			{
+				CrossNFC.Current.StopListening();
 			}
 			catch (Exception ex)
 			{

--- a/src/Plugin.NFC/Android/CrossNFC.android.cs
+++ b/src/Plugin.NFC/Android/CrossNFC.android.cs
@@ -39,6 +39,11 @@ namespace Plugin.NFC
 		public static void OnNewIntent(Intent intent) => ((NFCImplementation)Current).HandleNewIntent(intent);
 
 		/// <summary>
+		/// Overrides Activity.OnResume()
+		/// </summary>
+		public static void OnResume() => ((NFCImplementation)Current).HandleOnResume();
+
+		/// <summary>
 		/// Returns the current Android <see cref="Context"/>
 		/// </summary>
 		internal static Context AppContext => Application.Context;

--- a/src/Plugin.NFC/Android/NFC.android.cs
+++ b/src/Plugin.NFC/Android/NFC.android.cs
@@ -350,13 +350,11 @@ namespace Plugin.NFC
 				return null;
 
 			var ndef = Ndef.Get(tag);
-			var nTag = new TagInfo(tag.GetId(), ndef != null)
-			{
-				Capacity = ndef.MaxSize
-			};
+			var nTag = new TagInfo(tag.GetId(), ndef != null);
 
 			if (ndef != null)
 			{
+				nTag.Capacity = ndef.MaxSize;
 				nTag.IsWritable = ndef.IsWritable;
 
 				if (ndefMessage == null)

--- a/src/Plugin.NFC/Plugin.NFC.csproj
+++ b/src/Plugin.NFC/Plugin.NFC.csproj
@@ -2,9 +2,8 @@
 
   <PropertyGroup>
     <!--Work around so the conditions work below-->
-    <TargetFrameworks></TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">netstandard1.0;netstandard2.0;Xamarin.iOS10;MonoAndroid81;MonoAndroid90;uap10.0.16299</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.0;netstandard2.0;Xamarin.iOS10;MonoAndroid81;MonoAndroid90</TargetFrameworks>
+    <TargetFrameworks>netstandard1.0;netstandard2.0;Xamarin.iOS10;MonoAndroid81;MonoAndroid90;MonoAndroid10.0;</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);uap10.0.16299</TargetFrameworks>
     <!--Feel free to add as many targets as you need below
     netstandard1.0;netstandard2.0;MonoAndroid81;Xamarin.iOS10;uap10.0.16299;Xamarin.TVOS10;Xamarin.WatchOS10;Xamarin.Mac20;Tizen40
     For UWP update the version number with a version number you have installed.

--- a/src/Plugin.NFC/Shared/INFC.shared.cs
+++ b/src/Plugin.NFC/Shared/INFC.shared.cs
@@ -7,6 +7,7 @@ namespace Plugin.NFC
 	public delegate void NdefMessagePublishedEventHandler(ITagInfo tagInfo);
 	public delegate void TagDiscoveredEventHandler(ITagInfo tagInfo, bool format);
 	public delegate void OnNfcStatusChangedEventHandler(bool isEnabled);
+	public delegate void TagListeningStatusChangedEventHandler(bool isListening);
 	#endregion
 
 	/// <summary>
@@ -108,5 +109,10 @@ namespace Plugin.NFC
 		/// Event raised when NFC status changes
 		/// </summary>
 		event OnNfcStatusChangedEventHandler OnNfcStatusChanged;
+
+		/// <summary>
+		/// Event raised when NFC listener status changes
+		/// </summary>
+		event TagListeningStatusChangedEventHandler OnTagListeningStatusChanged;
 	}
 }

--- a/src/Plugin.NFC/Shared/NfcConfiguration.shared.cs
+++ b/src/Plugin.NFC/Shared/NfcConfiguration.shared.cs
@@ -45,9 +45,9 @@
 		string _nfcErrorNotSupportedTag = "Tag is not supported";
 		string _nfcErrorNotCompliantTag = "Tag is not NDEF compliant";
 		string _nfcErrorWrite = "Nothing to write";
-		string _nfcSuccessRead = "Tag Read Success";
-		string _nfcSuccessWrite = "Tag Write Success";
-		string _nfcSuccessClear = "Tag Clear Success";
+		string _nfcSuccessRead = "Read Operation Successful";
+		string _nfcSuccessWrite = "Write Operation Successful";
+		string _nfcSuccessClear = "Clear Operation Successful";
 
 		/// <summary>
 		/// Writing feature not supported

--- a/src/Plugin.NFC/UWP/NFC.uwp.cs
+++ b/src/Plugin.NFC/UWP/NFC.uwp.cs
@@ -16,6 +16,7 @@ namespace Plugin.NFC
 		public event TagDiscoveredEventHandler OnTagDiscovered;
 		public event EventHandler OniOSReadingSessionCancelled;
 		public event OnNfcStatusChangedEventHandler OnNfcStatusChanged;
+		public event TagListeningStatusChangedEventHandler OnTagListeningStatusChanged;
 
 		readonly ProximityDevice _defaultDevice;
 		long _ndefSubscriptionId = -1;
@@ -80,6 +81,7 @@ namespace Plugin.NFC
 			_defaultDevice.DeviceArrived += OnDeviceArrived;
 			_defaultDevice.DeviceDeparted += OnDeviceDeparted;
 			_ndefSubscriptionId = _defaultDevice.SubscribeForMessage("NDEF", OnNdefMessageReceived);
+			OnTagListeningStatusChanged?.Invoke(true);
 		}
 
 		/// <summary>
@@ -95,6 +97,8 @@ namespace Plugin.NFC
 				_defaultDevice.StopSubscribingForMessage(_ndefSubscriptionId);
 				_ndefSubscriptionId = -1;
 			}
+
+			OnTagListeningStatusChanged?.Invoke(false);
 		}
 
 		/// <summary>

--- a/src/Plugin.NFC/iOS/NFC.iOS.cs
+++ b/src/Plugin.NFC/iOS/NFC.iOS.cs
@@ -22,6 +22,7 @@ namespace Plugin.NFC
 		public event TagDiscoveredEventHandler OnTagDiscovered;
 		public event EventHandler OniOSReadingSessionCancelled;
 		public event OnNfcStatusChangedEventHandler OnNfcStatusChanged;
+		public event TagListeningStatusChangedEventHandler OnTagListeningStatusChanged;
 
 		bool _isWriting;
 		bool _isFormatting;
@@ -79,12 +80,17 @@ namespace Plugin.NFC
 				AlertMessage = Configuration.Messages.NFCDialogAlertMessage
 			};
 			NfcSession?.BeginSession();
+			OnTagListeningStatusChanged?.Invoke(true);
 		}
 
 		/// <summary>
 		/// Stops tags detection
 		/// </summary>
-		public void StopListening() => NfcSession?.InvalidateSession();
+		public void StopListening()
+		{
+			NfcSession?.InvalidateSession();
+			OnTagListeningStatusChanged?.Invoke(false);
+		}
 
 		/// <summary>
 		/// Starts tag publishing (writing or formatting)
@@ -104,6 +110,7 @@ namespace Plugin.NFC
 				AlertMessage = Configuration.Messages.NFCDialogAlertMessage
 			};
 			NfcSession?.BeginSession();
+			OnTagListeningStatusChanged?.Invoke(true);
 		}
 
 		/// <summary>
@@ -114,6 +121,7 @@ namespace Plugin.NFC
 			_isWriting = _isFormatting = _customInvalidation = false;
 			_tag = null;
 			NfcSession?.InvalidateSession();
+			OnTagListeningStatusChanged?.Invoke(false);
 		}
 
 		/// <summary>
@@ -348,6 +356,7 @@ namespace Plugin.NFC
 				session.InvalidateSession();
 			else
 				session.InvalidateSession(message);
+			OnTagListeningStatusChanged?.Invoke(false);
 		}
 
 		/// <summary>
@@ -570,6 +579,7 @@ namespace Plugin.NFC
 		public event TagDiscoveredEventHandler OnTagDiscovered;
 		public event EventHandler OniOSReadingSessionCancelled;
 		public event OnNfcStatusChangedEventHandler OnNfcStatusChanged;
+		public event TagListeningStatusChangedEventHandler OnTagListeningStatusChanged;
 
 		NFCNdefReaderSession NfcSession { get; set; }
 
@@ -617,12 +627,17 @@ namespace Plugin.NFC
 				AlertMessage = Configuration.Messages.NFCDialogAlertMessage
 			};
 			NfcSession?.BeginSession();
+			OnTagListeningStatusChanged?.Invoke(true);
 		}
 
 		/// <summary>
 		/// Stops tags detection
 		/// </summary>
-		public void StopListening() => NfcSession?.InvalidateSession();
+		public void StopListening()
+		{
+			NfcSession?.InvalidateSession();
+			OnTagListeningStatusChanged?.Invoke(false);
+		}
 
 		/// <summary>
 		/// Starts tag publishing (writing or formatting)


### PR DESCRIPTION

### Initial Pull-Request  ###

- Related to PR #31 by @saamerm  

### Description of Change ###

* Added a "Listening for NFC tag..." label at the bottom of the Clear button to display when the device is listening for an NFC Tag
* On iOS, if the device is listening, there's a popup box indicating the listening action. However on Android there was no indication before
* Created a Property DeviceIsListening that determines visibility of the "Listening.." label for Android and appropriately set it to true or false depending on each situation
* DeviceIsListening is not needed for iOS since the user sees the prompt anyway, and cannot be used for iOS because of the DidInvalidate() in Plugin.NFC/iOS/NFC.iOS.cs not being accessible from the Xaml.cs file

**Testing**
----------
* Tested on iOS & Android and it worked fine.
* Tested the different possible failure cases:
  * When the user presses cancel or the NFC prompt times out, the Listening text goes away
  * It indicated how Android keeps listening without a timeout, unlike iOS that times out
  * Tested on iOS & Android devices with and without NFC technology to make sure it works

### Behavioral Changes ###
Earlier on android, in the sample there was no indication that the app was listening for an nfc tag when a button is pressed, now the sample shows a “Listening for NFC Tag...” label when the app is looking for a tag. iOS is unchanged since it already showed a dialog when listening for device.  

- [ ] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation