### PR TITLE
Exemplary support for locale setting in NDEF records (Android only)

### DIFF
--- a/src/Plugin.NFC.Sample/Plugin.NFC.Sample.Android/MainActivity.cs
+++ b/src/Plugin.NFC.Sample/Plugin.NFC.Sample.Android/MainActivity.cs
@@ -19,8 +19,6 @@ namespace NFCSample.Droid
 			base.OnCreate(savedInstanceState);
 			CrossNFC.Init(this);
 			global::Xamarin.Forms.Forms.Init(this, savedInstanceState);
-			//ManniAT: set locale globally
-			NFCImplementation.GlobalStaticLocale = "en";
 
 			LoadApplication(new App());
 		}

--- a/src/Plugin.NFC.Sample/Plugin.NFC.Sample.Android/MainActivity.cs
+++ b/src/Plugin.NFC.Sample/Plugin.NFC.Sample.Android/MainActivity.cs
@@ -19,6 +19,8 @@ namespace NFCSample.Droid
 			base.OnCreate(savedInstanceState);
 			CrossNFC.Init(this);
 			global::Xamarin.Forms.Forms.Init(this, savedInstanceState);
+			//ManniAT: set locale globally
+			NFCImplementation.GlobalStaticLocale = "en";
 
 			LoadApplication(new App());
 		}

--- a/src/Plugin.NFC.Sample/Plugin.NFC.Sample/MainPage.xaml.cs
+++ b/src/Plugin.NFC.Sample/Plugin.NFC.Sample/MainPage.xaml.cs
@@ -231,8 +231,10 @@ namespace NFCSample
 				switch(_type)
 				{
 					case NFCNdefTypeFormat.WellKnown:
-						record = new NFCNdefRecord
+						//ManniAT - use locale enabled record (different than global setting)
+						record = new NFCNdefRecordWithLocale
 						{
+							LanguageCode="de-AT",
 							TypeFormat = NFCNdefTypeFormat.WellKnown,
 							MimeType = MIME_TYPE,
 							Payload = NFCUtils.EncodeToByteArray("Plugin.NFC is awesome!")

--- a/src/Plugin.NFC.Sample/Plugin.NFC.Sample/MainPage.xaml.cs
+++ b/src/Plugin.NFC.Sample/Plugin.NFC.Sample/MainPage.xaml.cs
@@ -69,6 +69,7 @@ namespace NFCSample
 				//// Custom NFC configuration (ex. UI messages in French)
 				//CrossNFC.Current.SetConfiguration(new NfcConfiguration
 				//{
+				//	DefaultLanguageCode = "fr",
 				//	Messages = new UserDefinedMessages
 				//	{
 				//		NFCWritingNotSupported = "L'écriture des TAGs NFC n'est pas supporté sur cet appareil",
@@ -85,7 +86,7 @@ namespace NFCSample
 				//		NFCSuccessRead = "Lecture réussie",
 				//		NFCSuccessWrite = "Ecriture réussie",
 				//		NFCSuccessClear = "Effaçage réussi"
-				//	}
+				//	},
 				//});
 
 				SubscribeEvents();
@@ -231,13 +232,12 @@ namespace NFCSample
 				switch(_type)
 				{
 					case NFCNdefTypeFormat.WellKnown:
-						//ManniAT - use locale enabled record (different than global setting)
-						record = new NFCNdefRecordWithLocale
+						record = new NFCNdefRecord
 						{
-							LanguageCode="de-AT",
 							TypeFormat = NFCNdefTypeFormat.WellKnown,
 							MimeType = MIME_TYPE,
-							Payload = NFCUtils.EncodeToByteArray("Plugin.NFC is awesome!")
+							Payload = NFCUtils.EncodeToByteArray("Plugin.NFC is awesome!"),
+							LanguageCode = "de-AT"
 						};
 						break;
 					case NFCNdefTypeFormat.Uri:
@@ -361,7 +361,7 @@ namespace NFCSample
 			message += Environment.NewLine;
 			message += $"RawMessage: {Encoding.UTF8.GetString(record.Payload)}";
 			message += Environment.NewLine;
-			message += $"Type: {record.TypeFormat.ToString()}";
+			message += $"Type: {record.TypeFormat}";
 
 			if (!string.IsNullOrWhiteSpace(record.MimeType))
 			{

--- a/src/Plugin.NFC/Android/NFC.android.cs
+++ b/src/Plugin.NFC/Android/NFC.android.cs
@@ -3,6 +3,7 @@ using Android.App;
 using Android.Content;
 using Android.Nfc;
 using Android.Nfc.Tech;
+using Android.OS;
 using Java.Util;
 using System;
 using System.Collections.Generic;
@@ -398,14 +399,9 @@ namespace Plugin.NFC
 			switch (record.TypeFormat)
 			{
 				case NFCNdefTypeFormat.WellKnown:
-					//if enhanced version is used check for locale (could be checked with if(record is NFCNdefRecordWithLocale) {.....} also
-					string strLocale = (record as NFCNdefRecordWithLocale)?.LanguageCode;
-
-					if(string.IsNullOrWhiteSpace(strLocale)){    //not passed in record
-																//use global if set - else obtain from OS
-						strLocale = string.IsNullOrWhiteSpace(_GlobalStaticLocale) ? Locale.Default.ToLanguageTag() : _GlobalStaticLocale;
-					}
-					ndefRecord = NdefRecord.CreateTextRecord(strLocale, Encoding.UTF8.GetString(record.Payload));
+					var languageCode = record.LanguageCode;
+					if (string.IsNullOrWhiteSpace(languageCode)) languageCode = Configuration.DefaultLanguageCode;
+					ndefRecord = NdefRecord.CreateTextRecord(languageCode.Substring(0,2), Encoding.UTF8.GetString(record.Payload));
 					break;
 				case NFCNdefTypeFormat.Mime:        
 					ndefRecord = NdefRecord.CreateMime(record.MimeType, record.Payload);            

--- a/src/Plugin.NFC/Shared/ITagInfo.shared.cs
+++ b/src/Plugin.NFC/Shared/ITagInfo.shared.cs
@@ -81,18 +81,9 @@
 		/// </summary>
 		public string Message => NFCUtils.GetMessage(TypeFormat, Payload, Uri);
 
-	}
-
-	/// <summary>
-	/// instead of adding a property to the original class I placed it in an extra class (be as compatible as possible)
-	/// </summary>
-	/// <remarks>Added by ManniAT as possible solution</remarks>
-	public class NFCNdefRecordWithLocale : NFCNdefRecord
-	{
 		/// <summary>
-		/// Enhancement to pass language codes (locale) like "en" "de-At" for publication
+		/// Two letters ISO 639-1 Language Code (ex: en, fr, de...)
 		/// </summary>
-		/// <remarks>Added by ManniAT as possible solution</remarks>
 		public string LanguageCode { get; set; }
 	}
 

--- a/src/Plugin.NFC/Shared/ITagInfo.shared.cs
+++ b/src/Plugin.NFC/Shared/ITagInfo.shared.cs
@@ -80,6 +80,20 @@
 		/// String formatted payload
 		/// </summary>
 		public string Message => NFCUtils.GetMessage(TypeFormat, Payload, Uri);
+
+	}
+
+	/// <summary>
+	/// instead of adding a property to the original class I placed it in an extra class (be as compatible as possible)
+	/// </summary>
+	/// <remarks>Added by ManniAT as possible solution</remarks>
+	public class NFCNdefRecordWithLocale : NFCNdefRecord
+	{
+		/// <summary>
+		/// Enhancement to pass language codes (locale) like "en" "de-At" for publication
+		/// </summary>
+		/// <remarks>Added by ManniAT as possible solution</remarks>
+		public string LanguageCode { get; set; }
 	}
 
 	/// <summary>

--- a/src/Plugin.NFC/Shared/NfcConfiguration.shared.cs
+++ b/src/Plugin.NFC/Shared/NfcConfiguration.shared.cs
@@ -11,6 +11,11 @@
 		public UserDefinedMessages Messages { get; set; }
 
 		/// <summary>
+		/// Sets ISO 639-1 Language Code for all ndef records (default is "en")
+		/// </summary>
+		public string DefaultLanguageCode { get; set; }
+
+		/// <summary>
 		/// Update Nfc Configuration with a new configuration object
 		/// </summary>
 		/// <param name="newCfg"><see cref="NfcConfiguration"/></param>
@@ -19,6 +24,7 @@
 			if (newCfg == null || newCfg.Messages == null)
 				return;
 			Messages = newCfg.Messages;
+			DefaultLanguageCode = newCfg.DefaultLanguageCode;
 		}
 
 		/// <summary>
@@ -26,7 +32,7 @@
 		/// </summary>
 		/// <returns>Default <see cref="NfcConfiguration"/></returns>
 		public static NfcConfiguration GetDefaultConfiguration()
-			=> new NfcConfiguration { Messages = new UserDefinedMessages() };
+			=> new NfcConfiguration { Messages = new UserDefinedMessages(), DefaultLanguageCode = "en" };
 	}
 
 	/// <summary>

--- a/src/Plugin.NFC/iOS/NFC.iOS.cs
+++ b/src/Plugin.NFC/iOS/NFC.iOS.cs
@@ -423,7 +423,11 @@ namespace Plugin.NFC
 			switch (record.TypeFormat)
 			{
 				case NFCNdefTypeFormat.WellKnown:
-					payload = NFCNdefPayload.CreateWellKnownTypePayload(Encoding.UTF8.GetString(record.Payload), NSLocale.CurrentLocale);
+					var lang = record.LanguageCode;
+					if (string.IsNullOrWhiteSpace(lang)) lang = Configuration.DefaultLanguageCode;
+					var langData = Encoding.ASCII.GetBytes(lang.Substring(0,2));
+					var payloadData = new byte[] { 0x02 }.Concat(langData).Concat(record.Payload).ToArray();
+					payload = new NFCNdefPayload(NFCTypeNameFormat.NFCWellKnown, NSData.FromString("T"), new NSData(), NSData.FromString(Encoding.UTF8.GetString(payloadData), NSStringEncoding.UTF8));
 					break;
 				case NFCNdefTypeFormat.Mime:
 					payload = new NFCNdefPayload(NFCTypeNameFormat.Media, record.MimeType, new NSData(), NSData.FromArray(record.Payload));


### PR DESCRIPTION
### Description of Change ###

I added two variants of "locale setting" - one global (using a static property) and the other an extra property  to NFCNdefRecord.

### Feature request ###

https://github.com/franckbour/Plugin.NFC/issues/52