### PR TITLE
Fix/44 and Managed the missing iOS native NFC pop-up messages. Added the iOS Mifare EV3 notes to enable the scanning of that cards 

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,8 @@ CrossNFC.Current.SetConfiguration(new NfcConfiguration
 {
     Messages = new UserDefinedMessages
     {
+   	NFCSessionInvalidated = "Session invalidée";
+	NFCSessionInvalidatedButton = "OK";
         NFCWritingNotSupported = "L'écriture des TAGs NFC n'est pas supporté sur cet appareil",
         NFCDialogAlertMessage = "Approchez votre appareil du tag NFC",
         NFCErrorRead = "Erreur de lecture. Veuillez rééssayer",

--- a/README.md
+++ b/README.md
@@ -87,10 +87,16 @@ An iPhone 7+ and iOS 11+ are required in order to use NFC with iOS devices.
 * Add these lines in your Info.plist if you want to interact with ISO 7816 compatible tags
 ```xml
 <key>com.apple.developer.nfc.readersession.iso7816.select-identifiers</key>
-	<array>
-		<string>com.apple.developer.nfc.readersession.iso7816.select-identifiers</string>
-		<string>D2760000850100</string>
-	</array>
+<string>com.apple.developer.nfc.readersession.iso7816.select-identifiers</string>
+```
+
+* Add these lines in your Info.plist if you want to interact with Mifare Desfire EV3 compatible tags
+```xml
+<key>com.apple.developer.nfc.readersession.iso7816.select-identifiers</key>
+<array>
+    <string>com.apple.developer.nfc.readersession.iso7816.select-identifiers</string>
+    <string>D2760000850100</string>
+</array>
 ```
 
 #### iOS Considerations

--- a/README.md
+++ b/README.md
@@ -89,7 +89,14 @@ An iPhone 7+ and iOS 11+ are required in order to use NFC with iOS devices.
 <key>com.apple.developer.nfc.readersession.iso7816.select-identifiers</key>
 <string>com.apple.developer.nfc.readersession.iso7816.select-identifiers</string>
 ```
-
+* Add these lines in your Info.plist if you want to interact with Mifare EV3 compatible tags
+```xml
+<key>com.apple.developer.nfc.readersession.iso7816.select-identifiers</key>
+	<array>
+		<string>com.apple.developer.nfc.readersession.iso7816.select-identifiers</string>
+		<string>D2760000850100</string>
+	</array>
+```
 ## API Usage
 
 Before to use the plugin, please check if NFC feature is supported by the platform using `CrossNFC.IsSupported`.

--- a/src/Plugin.NFC.Sample/Plugin.NFC.Sample/MainPage.xaml.cs
+++ b/src/Plugin.NFC.Sample/Plugin.NFC.Sample/MainPage.xaml.cs
@@ -72,6 +72,8 @@ namespace NFCSample
 				//	DefaultLanguageCode = "fr",
 				//	Messages = new UserDefinedMessages
 				//	{
+				//		NFCSessionInvalidated = "Session invalidée",
+				//		NFCSessionInvalidatedButton = "OK",
 				//		NFCWritingNotSupported = "L'écriture des TAGs NFC n'est pas supporté sur cet appareil",
 				//		NFCDialogAlertMessage = "Approchez votre appareil du tag NFC",
 				//		NFCErrorRead = "Erreur de lecture. Veuillez rééssayer",

--- a/src/Plugin.NFC/Shared/NfcConfiguration.shared.cs
+++ b/src/Plugin.NFC/Shared/NfcConfiguration.shared.cs
@@ -40,6 +40,8 @@
 	/// </summary>
 	public class UserDefinedMessages
 	{
+		string _nfcSessionInvalidated = "Session Invalidated";
+		string _nfcSessionInvalidatedButton = "OK";
 		string _nfcWritingNotSupported = "Writing NFC Tag is not supported on this device";
 		string _nfcDialogAlertMessage = "Please hold your phone near a NFC tag";
 		string _nfcErrorRead = "Read error. Please try again";
@@ -54,6 +56,46 @@
 		string _nfcSuccessRead = "Read Operation Successful";
 		string _nfcSuccessWrite = "Write Operation Successful";
 		string _nfcSuccessClear = "Clear Operation Successful";
+		string _nfcSessionTimeout = "session timeout";
+
+		/// <summary>
+		/// Session timeout
+		/// </summary>
+		public string NFCSessionTimeout
+		{
+			get => _nfcSessionTimeout;
+			set
+			{
+				if (!string.IsNullOrWhiteSpace(value))
+					_nfcSessionTimeout = value;
+			}
+		}
+
+		/// <summary>
+		/// Session invalidated
+		/// </summary>
+		public string NFCSessionInvalidatedButton
+		{
+			get => _nfcSessionInvalidatedButton;
+			set
+			{
+				if (!string.IsNullOrWhiteSpace(value))
+					_nfcSessionInvalidatedButton = value;
+			}
+		}
+
+		/// <summary>
+		/// Session invalidated
+		/// </summary>
+		public string NFCSessionInvalidated
+		{
+			get => _nfcSessionInvalidated;
+			set
+			{
+				if (!string.IsNullOrWhiteSpace(value))
+					_nfcSessionInvalidated = value;
+			}
+		}
 
 		/// <summary>
 		/// Writing feature not supported

--- a/src/Plugin.NFC/iOS/NFC.iOS.cs
+++ b/src/Plugin.NFC/iOS/NFC.iOS.cs
@@ -15,6 +15,8 @@ namespace Plugin.NFC
 	/// </summary>
 	public class NFCImplementation : NFCTagReaderSessionDelegate, INFC
 	{
+		public const string SessionTimeoutMessage = "session timeout";
+
 		public event EventHandler OnTagConnected;
 		public event EventHandler OnTagDisconnected;
 		public event NdefMessageReceivedEventHandler OnMessageReceived;
@@ -27,7 +29,7 @@ namespace Plugin.NFC
 		bool _isWriting;
 		bool _isFormatting;
 		bool _customInvalidation = false;
-		
+
 		INFCTag _tag;
 
 		NFCTagReaderSession NfcSession { get; set; }
@@ -55,7 +57,7 @@ namespace Plugin.NFC
 		/// <summary>
 		/// Default constructor
 		/// </summary>
-		public NFCImplementation() 
+		public NFCImplementation()
 		{
 			Configuration = NfcConfiguration.GetDefaultConfiguration();
 		}
@@ -231,8 +233,8 @@ namespace Plugin.NFC
 			var readerError = (NFCReaderError)(long)error.Code;
 			if (readerError != NFCReaderError.ReaderSessionInvalidationErrorFirstNDEFTagRead && readerError != NFCReaderError.ReaderSessionInvalidationErrorUserCanceled)
 			{
-				var alertController = UIAlertController.Create("Session Invalidated", error.LocalizedDescription, UIAlertControllerStyle.Alert);
-				alertController.AddAction(UIAlertAction.Create("Ok", UIAlertActionStyle.Default, null));
+				var alertController = UIAlertController.Create(Configuration.Messages.NFCSessionInvalidated, error.LocalizedDescription.ToLower().Equals(SessionTimeoutMessage) ? Configuration.Messages.NFCSessionTimeout : error.LocalizedDescription, UIAlertControllerStyle.Alert);
+				alertController.AddAction(UIAlertAction.Create(Configuration.Messages.NFCSessionInvalidatedButton, UIAlertActionStyle.Default, null));
 				DispatchQueue.MainQueue.DispatchAsync(() =>
 				{
 					GetCurrentController().PresentViewController(alertController, true, null);
@@ -541,7 +543,7 @@ namespace Plugin.NFC
 						tagInfo.Records = GetRecords(message.Records);
 						OnMessagePublished?.Invoke(tagInfo);
 						Invalidate(NfcSession);
-					});					
+					});
 				}
 				else
 					Invalidate(session, Configuration.Messages.NFCErrorWrite);
@@ -583,6 +585,8 @@ namespace Plugin.NFC
 	/// </summary>
 	public class NFCImplementation_Before_iOS13 : NFCNdefReaderSessionDelegate, INFC
 	{
+		public const string SessionTimeoutMessage = "session timeout";
+
 		public event EventHandler OnTagConnected;
 		public event EventHandler OnTagDisconnected;
 		public event NdefMessageReceivedEventHandler OnMessageReceived;
@@ -617,7 +621,7 @@ namespace Plugin.NFC
 		/// <summary>
 		/// Default constructor
 		/// </summary>
-		public NFCImplementation_Before_iOS13() 
+		public NFCImplementation_Before_iOS13()
 		{
 			Configuration = NfcConfiguration.GetDefaultConfiguration();
 		}
@@ -706,8 +710,8 @@ namespace Plugin.NFC
 			var readerError = (NFCReaderError)(long)error.Code;
 			if (readerError != NFCReaderError.ReaderSessionInvalidationErrorFirstNDEFTagRead && readerError != NFCReaderError.ReaderSessionInvalidationErrorUserCanceled)
 			{
-				var alertController = UIAlertController.Create("Session Invalidated", error.LocalizedDescription, UIAlertControllerStyle.Alert);
-				alertController.AddAction(UIAlertAction.Create("Ok", UIAlertActionStyle.Default, null));
+				var alertController = UIAlertController.Create(Configuration.Messages.NFCSessionInvalidated, error.LocalizedDescription.ToLower().Equals(SessionTimeoutMessage) ? Configuration.Messages.NFCSessionTimeout : error.LocalizedDescription, UIAlertControllerStyle.Alert);
+				alertController.AddAction(UIAlertAction.Create(Configuration.Messages.NFCSessionInvalidatedButton, UIAlertActionStyle.Default, null));
 				DispatchQueue.MainQueue.DispatchAsync(() =>
 				{
 					GetCurrentController().PresentViewController(alertController, true, null);


### PR DESCRIPTION
### Description of Change ###

Is possible to manage the missing translation messages shown in the iOS native pop-up in case of a session time-out error.

The fixing of #44 is described in the following link. The fixing is a change in the info.plist file.
[https://github.com/sborghini/Plugin.NFC](url)

### Bugs Fixed ###

- Related to issue #44

### API Changes ###
Added into UserDefinedMessages: 
 string _nfcSessionInvalidated = "Session Invalidated";
 string _nfcSessionInvalidatedButton = "OK";
 string _nfcSessionTimeout = "session timeout";

### Behavioral Changes ###

Managed the missing iOS NFC messages present in iOS native NFC scan pop-up in order to manage the "Session timeout" error.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [x] Updated documentation