### PR TITLE
Fix: null reference issue with null payload

### DIFF
--- a/src/Plugin.NFC/iOS/NFC.iOS.cs
+++ b/src/Plugin.NFC/iOS/NFC.iOS.cs
@@ -262,7 +262,7 @@ namespace Plugin.NFC
 				return;
 			}
 
-			if (tagInfo == null)
+			if (tagInfo == null || tagInfo.Records.Any(record => record.Payload == null))
 			{
 				Invalidate(NfcSession, Configuration.Messages.NFCErrorMissingTagInfo);
 				return;


### PR DESCRIPTION
### Description of Change ###

Fix the issue regarding null payload cause unhandled exception during NFC writing on iOS.
Documentation changes and samples are not needed.

### Bugs Fixed ###

- Related to issue #84 

### API Changes ###

None

### Behavioral Changes ###

Null payload will display the NFCErrorMissingTagInfo error message for the user instead of causing a null reference exception and a potential app crash.

### PR Checklist ###

- [x] Has tests
- [ ] ~~Has samples~~
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [ ] ~~Updated documentation~~