### PR TITLE
Fix #90: Added support for Android 12

### DIFF
--- a/src/Plugin.NFC.Sample/Plugin.NFC.Sample.Android/Plugin.NFC.Sample.Android.csproj
+++ b/src/Plugin.NFC.Sample/Plugin.NFC.Sample.Android/Plugin.NFC.Sample.Android.csproj
@@ -30,6 +30,11 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AndroidLinkMode>None</AndroidLinkMode>
+    <AotAssemblies>false</AotAssemblies>
+    <EnableLLVM>false</EnableLLVM>
+    <AndroidEnableProfiledAot>false</AndroidEnableProfiledAot>
+    <BundleAssemblies>false</BundleAssemblies>
+    <EmbedAssembliesIntoApk>true</EmbedAssembliesIntoApk>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/Plugin.NFC.Sample/Plugin.NFC.Sample/Plugin.NFC.Sample.csproj
+++ b/src/Plugin.NFC.Sample/Plugin.NFC.Sample/Plugin.NFC.Sample.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DebugType>pdbonly</DebugType>
+    <DebugType>portable</DebugType>
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 

--- a/src/Plugin.NFC/Android/NFC.android.cs
+++ b/src/Plugin.NFC/Android/NFC.android.cs
@@ -93,7 +93,14 @@ namespace Plugin.NFC
 				return;
 
 			var intent = new Intent(CurrentActivity, CurrentActivity.GetType()).AddFlags(ActivityFlags.SingleTop);
-			var pendingIntent = PendingIntent.GetActivity(CurrentActivity, 0, intent, 0);
+
+			// We don't use MonoAndroid12.0 as targetframework for easier backward compatibility:
+			// MonoAndroid12.0 needs JDK 11.
+			PendingIntentFlags pendingIntentFlags = 0;
+			if ((int)Android.OS.Build.VERSION.SdkInt >= 31) //Android.OS.BuildVersionCodes.S
+				pendingIntentFlags = (PendingIntentFlags)33554432; //PendingIntentFlags.Mutable
+
+			var pendingIntent = PendingIntent.GetActivity(CurrentActivity, 0, intent, pendingIntentFlags);
 
 			var ndefFilter = new IntentFilter(NfcAdapter.ActionNdefDiscovered);
 			ndefFilter.AddDataType("*/*");

--- a/src/Plugin.NFC/Plugin.NFC.csproj
+++ b/src/Plugin.NFC/Plugin.NFC.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="MSBuild.Sdk.Extras/3.0.23">
+﻿<Project Sdk="MSBuild.Sdk.Extras/3.0.44">
 
   <PropertyGroup>
     <!--Work around so the conditions work below-->
-    <TargetFrameworks>netstandard1.0;netstandard2.0;Xamarin.iOS10;MonoAndroid81;MonoAndroid90;MonoAndroid10.0;</TargetFrameworks>
+    <TargetFrameworks>netstandard1.0;netstandard2.0;Xamarin.iOS10;MonoAndroid10.0;</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);uap10.0.16299</TargetFrameworks>
     <!--Feel free to add as many targets as you need below
     netstandard1.0;netstandard2.0;MonoAndroid81;Xamarin.iOS10;uap10.0.16299;Xamarin.TVOS10;Xamarin.WatchOS10;Xamarin.Mac20;Tizen40

--- a/src/Plugin.NFC/Shared/CrossNFC.shared.cs
+++ b/src/Plugin.NFC/Shared/CrossNFC.shared.cs
@@ -7,12 +7,12 @@ namespace Plugin.NFC
     /// </summary>
     public static partial class CrossNFC
     {
-        static Lazy<INFC> implementation = new Lazy<INFC>(() => CreateNFC(), System.Threading.LazyThreadSafetyMode.PublicationOnly);
+        static Lazy<INFC> _implementation = new Lazy<INFC>(() => CreateNFC(), System.Threading.LazyThreadSafetyMode.PublicationOnly);
 
         /// <summary>
         /// Gets if the plugin is supported on the current platform.
         /// </summary>
-        public static bool IsSupported => implementation.Value == null ? false : true;
+        public static bool IsSupported => _implementation.Value != null;
 
 		/// <summary>
         /// Legacy Mode (Supporting Mifare Classic on iOS)
@@ -30,7 +30,7 @@ namespace Plugin.NFC
 			{
 				_legacy = value;
 
-				implementation = new Lazy<INFC>(() => CreateNFC(), System.Threading.LazyThreadSafetyMode.PublicationOnly);
+				_implementation = new Lazy<INFC>(() => CreateNFC(), System.Threading.LazyThreadSafetyMode.PublicationOnly);
 			}
 		}
 		
@@ -41,7 +41,7 @@ namespace Plugin.NFC
         {
             get
             {
-                INFC ret = implementation.Value;
+                INFC ret = _implementation.Value;
                 if (ret == null)
                 {
                     throw NotImplementedInReferenceAssembly();


### PR DESCRIPTION
### Description of Change ###

Android 12 and above requires FLAG_IMMUTABLE or FLAG_MUTABLE when creating a PendingIntent.
Added `PendingIntentFlags.Mutable` to pending intent flags in `NFC.android.cs`.

### Bugs Fixed ###

- Related to issue #90

### API Changes ###

No changes.


### Behavioral Changes ###

No changes.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [ ] Updated documentation