### PR TITLE
Format non dfef tags

### DIFF
--- a/src/Plugin.NFC/Android/NFC.android.cs
+++ b/src/Plugin.NFC/Android/NFC.android.cs
@@ -94,21 +94,12 @@ namespace Plugin.NFC
 
 			var intent = new Intent(CurrentActivity, CurrentActivity.GetType()).AddFlags(ActivityFlags.SingleTop);
 
-			// We don't use MonoAndroid12.0 as targetframework for easier backward compatibility:
-			// MonoAndroid12.0 needs JDK 11.
-			PendingIntentFlags pendingIntentFlags = 0;
-			if ((int)Android.OS.Build.VERSION.SdkInt >= 31) //Android.OS.BuildVersionCodes.S
-				pendingIntentFlags = (PendingIntentFlags)33554432; //PendingIntentFlags.Mutable
+			var tagDetected = new IntentFilter(NfcAdapter.ActionTagDiscovered);
+			var ndefDetected = new IntentFilter(NfcAdapter.ActionNdefDiscovered);
+			var techDetected = new IntentFilter(NfcAdapter.ActionTechDiscovered);
+			var filters = new[] { ndefDetected, tagDetected, techDetected };
 
-			var pendingIntent = PendingIntent.GetActivity(CurrentActivity, 0, intent, pendingIntentFlags);
-
-			var ndefFilter = new IntentFilter(NfcAdapter.ActionNdefDiscovered);
-			ndefFilter.AddDataType("*/*");
-
-			var tagFilter = new IntentFilter(NfcAdapter.ActionTagDiscovered);
-			tagFilter.AddCategory(Intent.CategoryDefault);
-
-			var filters = new IntentFilter[] { ndefFilter, tagFilter };
+			var pendingIntent = PendingIntent.GetActivity(CurrentActivity, 0, intent, 0);
 
 			_nfcAdapter.EnableForegroundDispatch(CurrentActivity, pendingIntent, filters, null);
 

--- a/src/Plugin.NFC/Shared/INFC.shared.cs
+++ b/src/Plugin.NFC/Shared/INFC.shared.cs
@@ -76,6 +76,11 @@ namespace Plugin.NFC
 		void ClearMessage(ITagInfo tagInfo);
 
 		/// <summary>
+		/// Format non NDEF Tags - The tag must be NDEF Formatable
+		/// </summary>
+		void FormatNonNDEFTag();
+
+		/// <summary>
 		/// Event raised when tag is connected
 		/// </summary>
 		event EventHandler OnTagConnected;

--- a/src/Plugin.NFC/Shared/ITagInfo.shared.cs
+++ b/src/Plugin.NFC/Shared/ITagInfo.shared.cs
@@ -11,6 +11,11 @@
 		byte[] Identifier { get; }
 
 		/// <summary>
+		/// Tag Identifier as string
+		/// </summary>
+		string TagId { get; }
+
+		/// <summary>
 		/// Tag Serial Number
 		/// </summary>
 		string SerialNumber { get; }

--- a/src/Plugin.NFC/Shared/NFCUtils.shared.cs
+++ b/src/Plugin.NFC/Shared/NFCUtils.shared.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Text;
 #if XAMARIN_IOS
 using UIKit;
@@ -93,6 +94,13 @@ namespace Plugin.NFC
         {
             return bytes == null ? string.Empty : string.Join(separator ?? string.Empty, bytes.Select(b => b.ToString("X2")));
         }
+
+		public static string LittleEndian(string num)
+		{
+			var number = Convert.ToInt32(num, 16);
+			var bytes = BitConverter.GetBytes(number);
+			return bytes.Aggregate("", (current, b) => current + b.ToString("X2"));
+		}
 
 		/// <summary>
 		/// Checks if writing tags is supported

--- a/src/Plugin.NFC/Shared/TagInfo.shared.cs
+++ b/src/Plugin.NFC/Shared/TagInfo.shared.cs
@@ -1,4 +1,6 @@
-﻿namespace Plugin.NFC
+﻿using System;
+
+namespace Plugin.NFC
 {
 	/// <summary>
 	/// Default implementation of <see cref="ITagInfo"/>
@@ -6,6 +8,21 @@
 	public class TagInfo : ITagInfo
 	{
 		public byte[] Identifier { get; }
+
+		public string TagId
+		{
+			get
+			{
+				if (Identifier != null && Identifier.Length > 0)
+				{
+					var tagIdString = NFCUtils.ByteArrayToHexString(Identifier);
+					var reverseHex = NFCUtils.LittleEndian(tagIdString);
+					return Convert.ToInt64(reverseHex, 16).ToString();
+				}
+				else
+					return string.Empty;
+			}
+		}
 
 		/// <summary>
 		/// Tag Serial Number

--- a/src/Plugin.NFC/iOS/NFC.iOS.cs
+++ b/src/Plugin.NFC/iOS/NFC.iOS.cs
@@ -140,6 +140,11 @@ namespace Plugin.NFC
 		public void ClearMessage(ITagInfo tagInfo) => WriteOrClearMessage(_tag, tagInfo, true);
 
 		/// <summary>
+		/// Format non NDEF Tags - The tag must be NDEF Formatable
+		/// </summary>
+		public void FormatNonNDEFTag() => throw new NotSupportedException(Configuration.Messages.NFCWritingNotSupported);
+
+		/// <summary>
 		/// Event raised when NFC tags are detected
 		/// </summary>
 		/// <param name="session">iOS <see cref="NFCTagReaderSession"/></param>
@@ -676,6 +681,8 @@ namespace Plugin.NFC
 		/// </summary>
 		/// <param name="tagInfo">see <see cref="ITagInfo"/></param>
 		public void ClearMessage(ITagInfo tagInfo) => throw new NotSupportedException(Configuration.Messages.NFCWritingNotSupported);
+
+		public void FormatNonNDEFTag() => throw new NotSupportedException(Configuration.Messages.NFCWritingNotSupported);
 
 		/// <summary>
 		/// Event raised when NDEF messages are detected


### PR DESCRIPTION
Add method to read and format non NDEF tags. The tag must be NDEF formatable.

Add property to get Identifier as string on ITagInfo and TagInfo implementation.

Credits to: https://github.com/tanersahincom -> https://github.com/tanersahincom/NFCAndroidExample