### PR TITLE
Null Reference Exception checks for iOS

### DIFF
--- a/src/Plugin.NFC/iOS/NFC.iOS.cs
+++ b/src/Plugin.NFC/iOS/NFC.iOS.cs
@@ -1056,13 +1056,13 @@ namespace Plugin.NFC
 				case NFCTypeNameFormat.NFCWellKnown:
 					if (payload.Type.ToString() == "U")
 					{
-						var uri = payload.Payload.ParseWktUri();
+						var uri = payload.Payload?.ParseWktUri();
 						return uri;
 					}
 					break;
 				case NFCTypeNameFormat.AbsoluteUri:
 				case NFCTypeNameFormat.Media:
-					var content = Encoding.UTF8.GetString(payload.Payload.ToByteArray());
+					var content = Encoding.UTF8.GetString(payload.Payload?.ToByteArray());
 					if (Uri.TryCreate(content, UriKind.RelativeOrAbsolute, out var result))
 						return result;
 
@@ -1177,7 +1177,7 @@ namespace Plugin.NFC
 					TypeFormat = (NFCNdefTypeFormat)record.TypeNameFormat,
 					Uri = records[i].ToUri()?.ToString(),
 					MimeType = records[i].ToMimeType(),
-					Payload = record.Payload.ToByteArray()
+					Payload = record.Payload?.ToByteArray()
 				};
 				results.SetValue(ndefRecord, i);
 			}


### PR DESCRIPTION
* Added null reference exception checks to the app
* Line 1180 was causing a crash while reading empty NFC tags since the payload was null

### Description of Change ###

Added a null reference check

### Bugs Fixed ###

- Related to issue #107 


### API Changes ###

None


### Behavioral Changes ###

Fixed the bug