### PR TITLE
Android: Use newer API to read tags

### DIFF
--- a/src/Plugin.NFC.Forms.Sample/Plugin.NFC.Forms.Sample.Android/MainActivity.cs
+++ b/src/Plugin.NFC.Forms.Sample/Plugin.NFC.Forms.Sample.Android/MainActivity.cs
@@ -9,7 +9,8 @@ namespace NFCSample.Droid
 {
 	[Activity(Label = "NFCSample", Icon = "@mipmap/icon", Theme = "@style/MainTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation, LaunchMode = LaunchMode.SingleTask)]
 	[IntentFilter(new[] { NfcAdapter.ActionNdefDiscovered }, Categories = new[] { Intent.CategoryDefault }, DataMimeType = MainPage.MIME_TYPE)]
-	public class MainActivity : global::Xamarin.Forms.Platform.Android.FormsAppCompatActivity
+    [MetaData(NfcAdapter.ActionTechDiscovered, Resource = "@xml/nfc_tech_filters")]
+    public class MainActivity : global::Xamarin.Forms.Platform.Android.FormsAppCompatActivity
 	{
 		protected override void OnCreate(Bundle savedInstanceState)
 		{

--- a/src/Plugin.NFC.Forms.Sample/Plugin.NFC.Forms.Sample.Android/Plugin.NFC.Forms.Sample.Android.csproj
+++ b/src/Plugin.NFC.Forms.Sample/Plugin.NFC.Forms.Sample.Android/Plugin.NFC.Forms.Sample.Android.csproj
@@ -92,6 +92,10 @@
     <AndroidResource Include="Resources\mipmap-xxhdpi\launcher_foreground.png" />
     <AndroidResource Include="Resources\mipmap-xxxhdpi\icon.png" />
     <AndroidResource Include="Resources\mipmap-xxxhdpi\launcher_foreground.png" />
+    <AndroidResource Include="Resources\xml\nfc_tech_filters.xml">
+      <SubType></SubType>
+      <Generator></Generator>
+    </AndroidResource>
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Resources\drawable-hdpi\" />
@@ -99,6 +103,7 @@
     <Folder Include="Resources\drawable-xxhdpi\" />
     <Folder Include="Resources\drawable-xxxhdpi\" />
     <Folder Include="Resources\drawable\" />
+    <Folder Include="Resources\xml\" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Plugin.NFC\Plugin.NFC.csproj">

--- a/src/Plugin.NFC.Forms.Sample/Plugin.NFC.Forms.Sample.Android/Resources/xml/nfc_tech_filters.xml
+++ b/src/Plugin.NFC.Forms.Sample/Plugin.NFC.Forms.Sample.Android/Resources/xml/nfc_tech_filters.xml
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android">
+    <tech-list>
+        <tech>android.nfc.tech.NfcA</tech>
+        <!-- Support old tags -->
+        <tech>android.nfc.tech.MifareClassic</tech>
+    </tech-list>
+</resources>

--- a/src/Plugin.NFC.Maui.Sample/Platforms/Android/MainActivity.cs
+++ b/src/Plugin.NFC.Maui.Sample/Platforms/Android/MainActivity.cs
@@ -8,6 +8,7 @@ namespace Plugin.NFC.Maui.Sample
 {
     [Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
     [IntentFilter(new[] { NfcAdapter.ActionNdefDiscovered }, Categories = new[] { Intent.CategoryDefault }, DataMimeType = MainPage.MIME_TYPE)]
+    [MetaData(NfcAdapter.ActionTechDiscovered, Resource = "@xml/nfc_tech_filters")]
     public class MainActivity : MauiAppCompatActivity
     {
         protected override void OnCreate(Bundle savedInstanceState)

--- a/src/Plugin.NFC.Maui.Sample/Platforms/Android/Resources/xml/nfc_tech_filters.xml
+++ b/src/Plugin.NFC.Maui.Sample/Platforms/Android/Resources/xml/nfc_tech_filters.xml
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android">
+    <tech-list>
+        <tech>android.nfc.tech.NfcA</tech>
+        <!-- Support old tags -->
+        <tech>android.nfc.tech.MifareClassic</tech>
+    </tech-list>
+</resources>

--- a/src/Plugin.NFC.Maui.Sample/Plugin.NFC.Maui.Sample.csproj
+++ b/src/Plugin.NFC.Maui.Sample/Plugin.NFC.Maui.Sample.csproj
@@ -47,4 +47,7 @@
 	  <ProjectReference Include="..\Plugin.NFC\Plugin.NFC.csproj" />
 	</ItemGroup>
 
+	<ItemGroup>
+	  <Folder Include="Platforms\Android\Resources\xml\" />
+	</ItemGroup>
 </Project>


### PR DESCRIPTION
On some android devices after scanning the tag, the `intent.Action` is getting null which doesn't call the `OnTagDiscovered` or `OnMessageReceived` events.

This also fixes issue #111.